### PR TITLE
Fix bug in audio pump that did not schedule next send if the current …

### DIFF
--- a/src/common.speech/SpeechServiceRecognizer.ts
+++ b/src/common.speech/SpeechServiceRecognizer.ts
@@ -87,7 +87,7 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                 const simple: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(connectionMessage.textBody);
                 const resultReason: ResultReason = EnumTranslation.implTranslateRecognitionResult(simple.RecognitionStatus);
 
-                requestSession.onServiceRecognized(requestSession.currentTurnAudioOffset + simple.Offset);
+                requestSession.onServiceRecognized(requestSession.currentTurnAudioOffset + simple.Offset + simple.Duration);
 
                 if (ResultReason.Canceled === resultReason) {
                     const cancelReason: CancellationReason = EnumTranslation.implTranslateCancelResult(simple.RecognitionStatus);

--- a/src/common.speech/TranslationServiceRecognizer.ts
+++ b/src/common.speech/TranslationServiceRecognizer.ts
@@ -80,6 +80,8 @@ export class TranslationServiceRecognizer extends ServiceRecognizerBase {
                 const translatedPhrase: TranslationPhrase = TranslationPhrase.fromJSON(connectionMessage.textBody);
 
                 if (translatedPhrase.RecognitionStatus === RecognitionStatus.Success) {
+                    requestSession.onServiceRecognized(requestSession.currentTurnAudioOffset + translatedPhrase.Offset + translatedPhrase.Duration);
+
                     // OK, the recognition was successful. How'd the translation do?
                     const result: TranslationRecognitionEventArgs = this.fireEventForResult(translatedPhrase, requestSession);
                     if (!!this.privTranslationRecognizer.recognized) {
@@ -292,18 +294,20 @@ export class TranslationServiceRecognizer extends ServiceRecognizerBase {
             resultReason = ResultReason.TranslatingSpeech;
         }
 
+        const offset: number = serviceResult.Offset + requestSession.currentTurnAudioOffset;
+
         const result = new TranslationRecognitionResult(
             translations,
             requestSession.requestId,
             resultReason,
             serviceResult.Text,
             serviceResult.Duration,
-            serviceResult.Offset,
+            offset,
             serviceResult.Translation.FailureReason,
             JSON.stringify(serviceResult),
             undefined);
 
-        const ev = new TranslationRecognitionEventArgs(result, serviceResult.Offset, requestSession.sessionId);
+        const ev = new TranslationRecognitionEventArgs(result, offset, requestSession.sessionId);
         return ev;
     }
 

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -1614,8 +1614,9 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         // Pump valid speech and then silence until at least one speech end cycle hits.
         const fileBuffer: ArrayBuffer = WaveFileAudioInput.LoadArrayFromFile(Settings.WaveFile);
 
+        const alternatePhraseFileBuffer: ArrayBuffer = WaveFileAudioInput.LoadArrayFromFile(Settings.LuisWaveFile);
+
         let p: sdk.PullAudioInputStream;
-        const bigFileBuffer: Uint8Array = new Uint8Array(32 * 1024 * 30); // ~30 seconds.
         let s: sdk.SpeechConfig;
         if (undefined === Settings.SpeechTimeoutEndpoint || undefined === Settings.SpeechTimeoutKey) {
             // tslint:disable-next-line:no-console
@@ -1627,8 +1628,10 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         objsToClose.push(s);
 
         let pumpSilence: boolean = false;
+        let sendAlternateFile: boolean = false;
+
         let bytesSent: number = 0;
-        const targetLoops: number = 250;
+        const targetLoops: number = 500;
 
         // Pump the audio from the wave file specified with 1 second silence between iterations indefinetly.
         p = sdk.AudioInputStream.createPullStream(
@@ -1637,22 +1640,26 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 read: (buffer: ArrayBuffer): number => {
                     if (pumpSilence) {
                         bytesSent += buffer.byteLength;
-                        if (bytesSent >= 8000) {
+                        if (bytesSent >= 16000) {
                             bytesSent = 0;
                             pumpSilence = false;
                         }
                         return buffer.byteLength;
                     } else {
+                        // Alternate between the two files with different phrases in them.
+                        const sendBuffer: ArrayBuffer = sendAlternateFile ? alternatePhraseFileBuffer : fileBuffer;
+
                         const copyArray: Uint8Array = new Uint8Array(buffer);
                         const start: number = bytesSent;
-                        const end: number = buffer.byteLength > (fileBuffer.byteLength - bytesSent) ? (fileBuffer.byteLength - 1) : (bytesSent + buffer.byteLength - 1);
-                        copyArray.set(new Uint8Array(fileBuffer.slice(start, end)));
+                        const end: number = buffer.byteLength > (sendBuffer.byteLength - bytesSent) ? (sendBuffer.byteLength - 1) : (bytesSent + buffer.byteLength - 1);
+                        copyArray.set(new Uint8Array(sendBuffer.slice(start, end)));
                         const readyToSend: number = (end - start) + 1;
                         bytesSent += readyToSend;
 
                         if (readyToSend < buffer.byteLength) {
                             bytesSent = 0;
                             pumpSilence = true;
+                            sendAlternateFile = !sendAlternateFile;
                         }
 
                         return readyToSend;
@@ -1671,22 +1678,33 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         let recogCount: number = 0;
         let canceled: boolean = false;
         let inTurn: boolean = false;
+        let alternatePhrase: boolean = false;
 
         r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
             try {
-                expect(sdk.ResultReason[e.result.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
-                expect(e.offset).toBeGreaterThanOrEqual(lastOffset);
-                lastOffset = e.offset;
+                // If the target number of loops has been seen already, don't check as the audio being sent could have been clipped randomly during a phrase,
+                // and failing because of that isn't warranted.
+                if (recogCount <= targetLoops) {
 
-                // If there is silence exactly at the moment of disconnect, an extra speech.phrase with text ="" is returned just before the
-                // connection is disconnected.
-                if ("" !== e.result.text) {
-                    expect(e.result.text).toEqual(Settings.WaveFileText);
-                }
-                if (recogCount++ > targetLoops) {
-                    p.close();
-                }
+                    expect(sdk.ResultReason[e.result.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+                    expect(e.offset).toBeGreaterThanOrEqual(lastOffset);
+                    lastOffset = e.offset;
 
+                    // If there is silence exactly at the moment of disconnect, an extra speech.phrase with text ="" is returned just before the
+                    // connection is disconnected.
+                    if ("" !== e.result.text) {
+                        if (alternatePhrase) {
+                            expect(e.result.text).toEqual(Settings.LuisWavFileText);
+                        } else {
+                            expect(e.result.text).toEqual(Settings.WaveFileText);
+                        }
+
+                        alternatePhrase = !alternatePhrase;
+                    }
+                    if (recogCount++ >= targetLoops) {
+                        p.close();
+                    }
+                }
             } catch (error) {
                 done.fail(error);
             }
@@ -1731,7 +1749,7 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
             (err: string) => {
                 done.fail(err);
             });
-    }, 35000);
+    }, 1000 * 60 * 12);
 });
 
 test("Push Stream Async", (done: jest.DoneCallback) => {

--- a/tests/TranslationRecognizerTests.ts
+++ b/tests/TranslationRecognizerTests.ts
@@ -1246,6 +1246,152 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
             });
     }, 35000);
 
+    // Tests client reconnect after speech timeouts.
+    test.skip("Reconnect After timeout", (done: jest.DoneCallback) => {
+        // tslint:disable-next-line:no-console
+        console.info("Name: Reconnect After timeout");
+        // Pump valid speech and then silence until at least one speech end cycle hits.
+        const fileBuffer: ArrayBuffer = WaveFileAudioInput.LoadArrayFromFile(Settings.WaveFile);
+
+        const alternatePhraseFileBuffer: ArrayBuffer = WaveFileAudioInput.LoadArrayFromFile(Settings.LuisWaveFile);
+
+        let p: sdk.PullAudioInputStream;
+        let s: sdk.SpeechTranslationConfig;
+        if (undefined === Settings.SpeechTimeoutEndpoint || undefined === Settings.SpeechTimeoutKey) {
+            // tslint:disable-next-line:no-console
+            console.warn("Running timeout test against production, this will be very slow...");
+            s = BuildSpeechConfig();
+        } else {
+            s = sdk.SpeechTranslationConfig.fromEndpoint(new URL(Settings.SpeechTimeoutEndpoint), Settings.SpeechTimeoutKey);
+        }
+        objsToClose.push(s);
+
+        s.addTargetLanguage(Settings.WaveFileLanguage);
+        s.speechRecognitionLanguage = Settings.WaveFileLanguage;
+
+        let pumpSilence: boolean = false;
+        let sendAlternateFile: boolean = false;
+
+        let bytesSent: number = 0;
+        const targetLoops: number = 250;
+
+        // Pump the audio from the wave file specified with 1 second silence between iterations indefinetly.
+        p = sdk.AudioInputStream.createPullStream(
+            {
+                close: () => { return; },
+                read: (buffer: ArrayBuffer): number => {
+                    if (pumpSilence) {
+                        bytesSent += buffer.byteLength;
+                        if (bytesSent >= 16000) {
+                            bytesSent = 0;
+                            pumpSilence = false;
+                        }
+                        return buffer.byteLength;
+                    } else {
+                        // Alternate between the two files with different phrases in them.
+                        const sendBuffer: ArrayBuffer = sendAlternateFile ? alternatePhraseFileBuffer : fileBuffer;
+
+                        const copyArray: Uint8Array = new Uint8Array(buffer);
+                        const start: number = bytesSent;
+                        const end: number = buffer.byteLength > (sendBuffer.byteLength - bytesSent) ? (sendBuffer.byteLength - 1) : (bytesSent + buffer.byteLength - 1);
+                        copyArray.set(new Uint8Array(sendBuffer.slice(start, end)));
+                        const readyToSend: number = (end - start) + 1;
+                        bytesSent += readyToSend;
+
+                        if (readyToSend < buffer.byteLength) {
+                            bytesSent = 0;
+                            pumpSilence = true;
+                            sendAlternateFile = !sendAlternateFile;
+                        }
+
+                        return readyToSend;
+                    }
+
+                },
+            });
+
+        const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
+
+        const r: sdk.TranslationRecognizer = new sdk.TranslationRecognizer(s, config);
+        objsToClose.push(r);
+
+        let speechEnded: number = 0;
+        let lastOffset: number = 0;
+        let recogCount: number = 0;
+        let canceled: boolean = false;
+        let inTurn: boolean = false;
+        let alternatePhrase: boolean = false;
+
+        r.recognized = (o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs) => {
+            try {
+                // If the target number of loops has been seen already, don't check as the audio being sent could have been clipped randomly during a phrase,
+                // and failing because of that isn't warranted.
+                if (recogCount <= targetLoops) {
+                    expect(sdk.ResultReason[e.result.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
+                    expect(e.offset).toBeGreaterThanOrEqual(lastOffset);
+                    lastOffset = e.offset;
+
+                    // If there is silence exactly at the moment of disconnect, an extra speech.phrase with text ="" is returned just before the
+                    // connection is disconnected.
+                    if ("" !== e.result.text) {
+                        if (alternatePhrase) {
+                            expect(e.result.text).toEqual(Settings.LuisWavFileText);
+                        } else {
+                            expect(e.result.text).toEqual(Settings.WaveFileText);
+                        }
+
+                        alternatePhrase = !alternatePhrase;
+                    }
+                    if (recogCount++ >= targetLoops) {
+                        p.close();
+                    }
+                }
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
+        r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+                expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.EndOfStream]);
+                canceled = true;
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
+        r.sessionStarted = ((s: sdk.Recognizer, e: sdk.SessionEventArgs): void => {
+            inTurn = true;
+        });
+
+        r.sessionStopped = ((s: sdk.Recognizer, e: sdk.SessionEventArgs): void => {
+            inTurn = false;
+        });
+
+        r.speechEndDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
+            speechEnded++;
+        };
+
+        r.startContinuousRecognitionAsync(() => {
+            WaitForCondition(() => (canceled && !inTurn), () => {
+                r.stopContinuousRecognitionAsync(() => {
+                    try {
+                        expect(speechEnded).toEqual(1);
+                        done();
+                    } catch (error) {
+                        done.fail(error);
+                    }
+                }, (error: string) => {
+                    done.fail(error);
+                });
+            });
+        },
+            (err: string) => {
+                done.fail(err);
+            });
+    }, 1000 * 60 * 12);
+
     test("Silence Then Speech", (done: jest.DoneCallback) => {
         // tslint:disable-next-line:no-console
         console.info("Name: Silence Then Speech");


### PR DESCRIPTION
…send failed.

This resulted in no additional audio being sent when the connection was lost mid-send.

Also fixed over transmission of audio data from SpeechRecognizer & TranslationRecognizers when the connection was dropped.

Updated test cases to use multiple alternating phrasesto help detect over transmission of audio data.

Left the reconnect tests disabled as they take ~25 minutes to run total.