### PR TITLE
Add support for Connection object.

### DIFF
--- a/src/common.speech/RecognizerConfig.ts
+++ b/src/common.speech/RecognizerConfig.ts
@@ -16,30 +16,33 @@ export enum SpeechResultFormat {
 
 export class RecognizerConfig {
     private privRecognitionMode: RecognitionMode = RecognitionMode.Interactive;
-    private privPlatformConfig: PlatformConfig;
+    private privSpeechServiceConfig: SpeechServiceConfig;
     private privRecognitionActivityTimeout: number;
-    private privSpeechConfig: PropertyCollection;
+    private privParameters: PropertyCollection;
 
     constructor(
-        platformConfig: PlatformConfig,
-        recognitionMode: RecognitionMode = RecognitionMode.Interactive,
-        speechConfig: PropertyCollection) {
-        this.privPlatformConfig = platformConfig ? platformConfig : new PlatformConfig(new Context(null));
-        this.privRecognitionMode = recognitionMode;
-        this.privRecognitionActivityTimeout = recognitionMode === RecognitionMode.Interactive ? 8000 : 25000;
-        this.privSpeechConfig = speechConfig;
+        speechServiceConfig: SpeechServiceConfig,
+        parameters: PropertyCollection) {
+        this.privSpeechServiceConfig = speechServiceConfig ? speechServiceConfig : new SpeechServiceConfig(new Context(null));
+        this.privParameters = parameters;
     }
 
     public get parameters(): PropertyCollection {
-        return this.privSpeechConfig;
+        return this.privParameters;
     }
 
     public get recognitionMode(): RecognitionMode {
         return this.privRecognitionMode;
     }
 
-    public get platformConfig(): PlatformConfig {
-        return this.privPlatformConfig;
+    public set recognitionMode(value: RecognitionMode) {
+        this.privRecognitionMode = value;
+        this.privRecognitionActivityTimeout = value === RecognitionMode.Interactive ? 8000 : 25000;
+        this.privSpeechServiceConfig.Recognition = RecognitionMode[value];
+    }
+
+    public get SpeechServiceConfig(): SpeechServiceConfig {
+        return this.privSpeechServiceConfig;
     }
 
     public get recognitionActivityTimeout(): number {
@@ -51,9 +54,11 @@ export class RecognizerConfig {
     }
 }
 
+// The config is serialized and sent as the Speech.Config
 // tslint:disable-next-line:max-classes-per-file
-export class PlatformConfig {
+export class SpeechServiceConfig {
     private context: Context;
+    private recognition: string;
 
     constructor(context: Context) {
         this.context = context;
@@ -78,6 +83,13 @@ export class PlatformConfig {
         return this.context;
     }
 
+    public get Recognition(): string {
+        return this.recognition;
+    }
+
+    public set Recognition(value: string) {
+        this.recognition = value.toLowerCase();
+    }
 }
 
 // tslint:disable-next-line:max-classes-per-file

--- a/src/common.speech/RequestSession.ts
+++ b/src/common.speech/RequestSession.ts
@@ -6,7 +6,6 @@ import {
     createNoDashGuid,
     Deferred,
     Events,
-    IAudioStreamNode,
     IDetachable,
     IEventSource,
     PlatformEvent,
@@ -31,25 +30,20 @@ export class RequestSession {
     private privAudioNode: ReplayableAudioNode;
     private privAuthFetchEventId: string;
     private privIsAudioNodeDetached: boolean = false;
-    private privIsCompleted: boolean = false;
+    private privIsRecognizing: boolean = false;
     private privRequestCompletionDeferral: Deferred<boolean>;
     private privIsSpeechEnded: boolean = false;
-    private privIsCanceled: boolean = false;
     private privContextJson: string;
     private privTurnStartAudioOffset: number = 0;
     private privLastRecoOffset: number = 0;
 
     protected privSessionId: string;
 
-    constructor(audioSourceId: string, contextJson: string) {
+    constructor(audioSourceId: string) {
         this.privAudioSourceId = audioSourceId;
         this.privRequestId = createNoDashGuid();
         this.privAudioNodeId = createNoDashGuid();
         this.privRequestCompletionDeferral = new Deferred<boolean>();
-        this.privContextJson = contextJson;
-        this.privServiceTelemetryListener = new ServiceTelemetryListener(this.privRequestId, this.privAudioSourceId, this.privAudioNodeId);
-
-        this.onEvent(new RecognitionTriggeredEvent(this.requestId, this.privSessionId, this.privAudioSourceId, this.privAudioNodeId));
     }
 
     public get contextJson(): string {
@@ -76,12 +70,8 @@ export class RequestSession {
         return this.privIsSpeechEnded;
     }
 
-    public get isCompleted(): boolean {
-        return this.privIsCompleted;
-    }
-
-    public get isCanceled(): boolean {
-        return this.privIsCanceled;
+    public get isRecognizing(): boolean {
+        return this.privIsRecognizing;
     }
 
     public get currentTurnAudioOffset(): number {
@@ -89,7 +79,19 @@ export class RequestSession {
     }
 
     public listenForServiceTelemetry(eventSource: IEventSource<PlatformEvent>): void {
-        this.privDetachables.push(eventSource.attachListener(this.privServiceTelemetryListener));
+        if (!!this.privServiceTelemetryListener) {
+            this.privDetachables.push(eventSource.attachListener(this.privServiceTelemetryListener));
+        }
+    }
+
+    public startNewRecognition(contextJson: string): void {
+        this.privIsRecognizing = true;
+        this.privTurnStartAudioOffset = 0;
+        this.privLastRecoOffset = 0;
+        this.privRequestId = createNoDashGuid();
+        this.privContextJson = contextJson;
+        this.privServiceTelemetryListener = new ServiceTelemetryListener(this.privRequestId, this.privAudioSourceId, this.privAudioNodeId);
+        this.onEvent(new RecognitionTriggeredEvent(this.requestId, this.privSessionId, this.privAudioSourceId, this.privAudioNodeId));
     }
 
     public onAudioSourceAttachCompleted = (audioNode: ReplayableAudioNode, isError: boolean, error?: string): void => {
@@ -117,12 +119,12 @@ export class RequestSession {
     public onConnectionEstablishCompleted = (statusCode: number, reason?: string): void => {
         if (statusCode === 200) {
             this.onEvent(new RecognitionStartedEvent(this.requestId, this.privAudioSourceId, this.privAudioNodeId, this.privAuthFetchEventId, this.privSessionId));
-            this.privAudioNode.replay();
+            if (!!this.privAudioNode) {
+                this.privAudioNode.replay();
+            }
             this.privTurnStartAudioOffset = this.privLastRecoOffset;
             return;
         } else if (statusCode === 403) {
-            this.onComplete();
-        } else {
             this.onComplete();
         }
     }
@@ -159,8 +161,8 @@ export class RequestSession {
         return this.privServiceTelemetryListener.getTelemetry();
     }
 
-    public onCancelled(): void {
-        this.privIsCanceled = true;
+    public onStopRecognizing(): void {
+        this.privIsRecognizing = false;
     }
 
     // Should be called with the audioNode for this session has indicated that it is out of speech.
@@ -169,13 +171,15 @@ export class RequestSession {
     }
 
     protected onEvent = (event: SpeechRecognitionEvent): void => {
-        this.privServiceTelemetryListener.onEvent(event);
+        if (!!this.privServiceTelemetryListener) {
+            this.privServiceTelemetryListener.onEvent(event);
+        }
         Events.instance.onEvent(event);
     }
 
     private onComplete = (): void => {
-        if (!this.privIsCompleted) {
-            this.privIsCompleted = true;
+        if (!!this.privIsRecognizing) {
+            this.privIsRecognizing = false;
             this.detachAudioNode();
         }
     }

--- a/src/sdk/Connection.ts
+++ b/src/sdk/Connection.ts
@@ -1,0 +1,99 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+//
+
+import {
+    ServiceRecognizerBase,
+} from "../common.speech/Exports";
+import {
+    ConnectionEvent,
+    IDetachable,
+} from "../common/Exports";
+import {
+    ConnectionEventArgs,
+    Recognizer,
+} from "./Exports";
+
+/**
+ * Connection is a proxy class for managing connection to the speech service of the specified Recognizer.
+ * By default, a Recognizer autonomously manages connection to service when needed.
+ * The Connection class provides additional methods for users to explicitly open or close a connection and
+ * to subscribe to connection status changes.
+ * The use of Connection is optional, and mainly for scenarios where fine tuning of application
+ * behavior based on connection status is needed. Users can optionally call Open() to manually set up a connection
+ * in advance before starting recognition on the Recognizer associated with this Connection.
+ * If the Recognizer needs to connect or disconnect to service, it will
+ * setup or shutdown the connection independently. In this case the Connection will be notified by change of connection
+ * status via Connected/Disconnected events.
+ * Added in version 1.2.0.
+ */
+export class Connection {
+    private privServiceRecognizer: ServiceRecognizerBase;
+    private privEventListener: IDetachable;
+
+    /**
+     * Gets the Connection instance from the specified recognizer.
+     * @param recognizer The recognizer associated with the connection.
+     * @return The Connection instance of the recognizer.
+     */
+    public static fromRecognizer(recognizer: Recognizer): Connection {
+        const recoBase: ServiceRecognizerBase = recognizer.internalData as ServiceRecognizerBase;
+
+        const ret: Connection = new Connection();
+
+        ret.privServiceRecognizer = recoBase;
+        ret.privEventListener = ret.privServiceRecognizer.connectionEvents.attach((connectionEvent: ConnectionEvent): void => {
+            if (connectionEvent.name === "ConnectionEstablishedEvent") {
+                if (!!ret.connected) {
+                    ret.connected(new ConnectionEventArgs(connectionEvent.connectionId));
+                }
+            } else if (connectionEvent.name === "ConnectionClosedEvent") {
+                if (!!ret.disconnected) {
+                    ret.disconnected(new ConnectionEventArgs(connectionEvent.connectionId));
+                }
+            }
+        });
+
+        return ret;
+    }
+
+    /**
+     * Starts to set up connection to the service.
+     * Users can optionally call openConnection() to manually set up a connection in advance before starting recognition on the
+     * Recognizer associated with this Connection. After starting recognition, calling Open() will have no effect
+     *
+     * Note: On return, the connection might not be ready yet. Please subscribe to the Connected event to
+     * be notfied when the connection is established.
+     */
+    public openConnection(): void {
+        this.privServiceRecognizer.connect();
+    }
+
+    /**
+     * Closes the connection the service.
+     * Users can optionally call closeConnection() to manually shutdown the connection of the associated Recognizer.
+     *
+     * If closeConnection() is called during recognition, recognition will fail and cancel wtih an error.
+     */
+    public closeConnection(): void {
+        this.privServiceRecognizer.disconnect();
+    }
+
+    /**
+     * The Connected event to indicate that the recognizer is connected to service.
+     */
+    public connected: (args: ConnectionEventArgs) => void;
+
+    /**
+     * The Diconnected event to indicate that the recognizer is disconnected from service.
+     */
+    public disconnected: (args: ConnectionEventArgs) => void;
+
+    /**
+     * Dispose of associated resources.
+     */
+    public close(): void {
+        /* tslint:disable:no-empty */
+    }
+}

--- a/src/sdk/ConnectionEventArgs.ts
+++ b/src/sdk/ConnectionEventArgs.ts
@@ -1,0 +1,13 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+//
+
+import { SessionEventArgs } from "./Exports";
+
+/**
+ * Defines payload for connection events like Connected/Disconnected.
+ * Added in version 1.2.0
+ */
+export class ConnectionEventArgs extends SessionEventArgs {
+}

--- a/src/sdk/Exports.ts
+++ b/src/sdk/Exports.ts
@@ -37,3 +37,5 @@ export { TranslationRecognitionCanceledEventArgs } from "./TranslationRecognitio
 export { IntentRecognitionCanceledEventArgs } from "./IntentRecognitionCanceledEventArgs";
 export { CancellationDetails } from "./CancellationDetails";
 export { CancellationErrorCode } from "./CancellationErrorCodes";
+export { ConnectionEventArgs } from "./ConnectionEventArgs";
+export { Connection } from "./Connection";

--- a/tests/IntentRecognizerTests.ts
+++ b/tests/IntentRecognizerTests.ts
@@ -569,13 +569,16 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         expect(s).not.toBeUndefined();
         s.speechRecognitionLanguage = "en-US";
 
-        const r: sdk.IntentRecognizer = new sdk.IntentRecognizer(s);
+        let r: sdk.IntentRecognizer = new sdk.IntentRecognizer(s);
         expect(r instanceof sdk.Recognizer).toEqual(true);
         // Node.js doesn't have a microphone natively. So we'll take the specific message that indicates that microphone init failed as evidence it was attempted.
         r.recognizeOnceAsync(() => fail("RecognizeOnceAsync returned success when it should have failed"),
             (error: string): void => {
                 expect(error).toEqual("Error: Browser does not support Web Audio API (AudioContext is not available).");
             });
+
+        r = new sdk.IntentRecognizer(s);
+        objsToClose.push(r);
 
         r.startContinuousRecognitionAsync(() => fail("startContinuousRecognitionAsync returned success when it should have failed"),
             (error: string): void => {

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -2506,4 +2506,3 @@ test("Switch RecoModes during a connection (single->cont)", (done: jest.DoneCall
         done();
     });
 }, 20000);
-


### PR DESCRIPTION
Expose internalData object on base Recognizer class. This is used to allow the fromRecognizer* pattern on the connection object and other future objects that will be conjured from a recognizer.
Seperate the concept of a connection being established from one being configured with context information via the speech.config message.
Support multiple recognize* iterations being done in the same connection. Previously each recognizeOnce / startContinuousRecog call established a new connection.

Add & Update Tests.