### PR TITLE
Return properties collection with service JSON for recognition.

### DIFF
--- a/src/common.speech/IntentServiceRecognizer.ts
+++ b/src/common.speech/IntentServiceRecognizer.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { IAudioSource, IConnection } from "../common/Exports";
+import {
+    IAudioSource,
+    MessageType,
+} from "../common/Exports";
 import {
     CancellationErrorCode,
     CancellationReason,
@@ -61,6 +64,11 @@ export class IntentServiceRecognizer extends ServiceRecognizerBase {
         let result: IntentRecognitionResult;
         let ev: IntentRecognitionEventArgs;
 
+        const resultProps: PropertyCollection = new PropertyCollection();
+        if (connectionMessage.messageType === MessageType.Text) {
+            resultProps.setProperty(PropertyId.SpeechServiceResponse_JsonResult, connectionMessage.textBody);
+        }
+
         switch (connectionMessage.path.toLowerCase()) {
             case "speech.hypothesis":
                 const speechHypothesis: SpeechHypothesis = SpeechHypothesis.fromJSON(connectionMessage.textBody);
@@ -74,7 +82,7 @@ export class IntentServiceRecognizer extends ServiceRecognizerBase {
                     speechHypothesis.Offset + this.privRequestSession.currentTurnAudioOffset,
                     undefined,
                     connectionMessage.textBody,
-                    undefined);
+                    resultProps);
 
                 ev = new IntentRecognitionEventArgs(result, speechHypothesis.Offset + this.privRequestSession.currentTurnAudioOffset, this.privRequestSession.sessionId);
 
@@ -100,7 +108,7 @@ export class IntentServiceRecognizer extends ServiceRecognizerBase {
                     simple.Offset + this.privRequestSession.currentTurnAudioOffset,
                     undefined,
                     connectionMessage.textBody,
-                    undefined);
+                    resultProps);
 
                 ev = new IntentRecognitionEventArgs(result, result.offset + this.privRequestSession.currentTurnAudioOffset, this.privRequestSession.sessionId);
 

--- a/src/common.speech/SpeechServiceRecognizer.ts
+++ b/src/common.speech/SpeechServiceRecognizer.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { IAudioSource, IConnection } from "../common/Exports";
+import { IAudioSource } from "../common/Exports";
 import {
     CancellationErrorCode,
     CancellationReason,
     OutputFormat,
     PropertyCollection,
+    PropertyId,
     ResultReason,
     SpeechRecognitionCanceledEventArgs,
     SpeechRecognitionEventArgs,
@@ -50,6 +51,8 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
         errorCallBack?: (e: string) => void): void {
 
         let result: SpeechRecognitionResult;
+        const resultProps: PropertyCollection = new PropertyCollection();
+        resultProps.setProperty(PropertyId.SpeechServiceResponse_JsonResult, connectionMessage.textBody);
 
         switch (connectionMessage.path.toLowerCase()) {
             case "speech.hypothesis":
@@ -63,7 +66,7 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                     hypothesis.Offset + this.privRequestSession.currentTurnAudioOffset,
                     undefined,
                     connectionMessage.textBody,
-                    undefined);
+                    resultProps);
 
                 const ev = new SpeechRecognitionEventArgs(result, hypothesis.Duration, this.privRequestSession.sessionId);
 
@@ -98,7 +101,7 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                         undefined,
                         undefined,
                         connectionMessage.textBody,
-                        undefined);
+                        resultProps);
 
                     if (!!this.privSpeechRecognizer.canceled) {
                         const cancelEvent: SpeechRecognitionCanceledEventArgs = new SpeechRecognitionCanceledEventArgs(
@@ -123,7 +126,7 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                                 simple.Offset + this.privRequestSession.currentTurnAudioOffset,
                                 undefined,
                                 connectionMessage.textBody,
-                                undefined);
+                                resultProps);
                         } else {
                             const detailed: DetailedSpeechPhrase = DetailedSpeechPhrase.fromJSON(connectionMessage.textBody);
 
@@ -135,7 +138,7 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                                 detailed.Offset + this.privRequestSession.currentTurnAudioOffset,
                                 undefined,
                                 connectionMessage.textBody,
-                                undefined);
+                                resultProps);
                         }
 
                         const event: SpeechRecognitionEventArgs = new SpeechRecognitionEventArgs(result, result.offset, this.privRequestSession.sessionId);

--- a/tests/IntentRecognizerTests.ts
+++ b/tests/IntentRecognizerTests.ts
@@ -99,9 +99,11 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
             (p2: sdk.IntentRecognitionResult) => {
 
                 const res: sdk.IntentRecognitionResult = p2;
+                expect(res).not.toBeUndefined();
                 expect(res.errorDetails).toBeUndefined();
                 expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
-                expect(res).not.toBeUndefined();
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
                 ValidateResultMatchesWaveFile(res);
                 done();
             },
@@ -146,6 +148,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res.errorDetails).toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedIntent]);
                 expect(res.intentId).toEqual(Settings.LuisValidIntentId);
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
                 ValidateResultMatchesWaveFile(res);
                 done();
             },
@@ -249,6 +253,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res).not.toBeUndefined();
                 expect(sdk.ResultReason.NoMatch).toEqual(res.reason);
                 expect(res.text).toBeUndefined();
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
                 const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
                 expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
@@ -269,6 +275,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(sdk.ResultReason.NoMatch).toEqual(res.reason);
                 expect(res.errorDetails).toBeUndefined();
                 expect(res.text).toBeUndefined();
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
                 const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
                 expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
@@ -320,6 +328,9 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res).not.toBeUndefined();
                 expect(res.reason).toEqual(sdk.ResultReason.RecognizedIntent);
                 expect(res.intentId).toEqual(Settings.LuisValidIntentId);
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
                 ValidateResultMatchesWaveFile(res);
 
                 r.stopContinuousRecognitionAsync(() => {
@@ -358,6 +369,9 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res.errorDetails).toBeUndefined();
                 expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
                 expect(res.intentId).toBeUndefined();
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
                 ValidateResultMatchesWaveFile(res);
                 done();
             },
@@ -437,6 +451,9 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                     expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedIntent]);
                     expect(res.intentId).toEqual(Settings.LuisValidIntentId);
                     expect(res.text).toEqual(Settings.LuisWavFileText);
+                    expect(res.properties).not.toBeUndefined();
+                    expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
                     numIntents++;
                 } else {
                     expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.NoMatch]);
@@ -486,6 +503,9 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res.errorDetails).toBeUndefined();
                 expect(res.reason).toEqual(sdk.ResultReason.RecognizedIntent);
                 expect(res.intentId).toEqual(intentName);
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
                 ValidateResultMatchesWaveFile(res);
                 done();
             },
@@ -512,6 +532,9 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res.errorDetails).toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedIntent]);
                 expect(res.intentId).toEqual(Settings.LuisValidIntentId);
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
                 ValidateResultMatchesWaveFile(res);
                 expect(res.properties.getProperty(sdk.PropertyId.LanguageUnderstandingServiceResponse_JsonResult)).not.toBeUndefined();
                 done();
@@ -539,6 +562,9 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res.errorDetails).toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedIntent]);
                 expect(res.intentId).toEqual("alias");
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
                 ValidateResultMatchesWaveFile(res);
                 done();
             },

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -177,6 +177,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
             expect(result).not.toBeUndefined();
             expect(result.text).toEqual(Settings.WaveFileText);
+            expect(result.properties).not.toBeUndefined();
+            expect(result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
             done();
         }, (error: string) => {
@@ -220,6 +222,9 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                         expect(res.text).toEqual("What's the weather like?");
                         expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                         expect(telemetryEvents).toEqual(1);
+                        expect(res.properties).not.toBeUndefined();
+                        expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
                         done();
                     } catch (error) {
                         done.fail(error);
@@ -553,6 +558,9 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 eventDone = true;
                 expect(sdk.ResultReason[e.result.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                 expect(e.result.text).toEqual("What's the weather like?");
+                expect(e.result.properties).not.toBeUndefined();
+                expect(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
             } catch (error) {
                 done.fail(error);
             }
@@ -660,6 +668,9 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res).not.toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                 expect(res.text).toEqual("What's the weather like?");
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
                 done();
             },
             (error: string) => {
@@ -690,6 +701,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res).not.toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                 expect(res.text).toEqual("What's the weather like?");
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
                 done();
             },
@@ -752,6 +765,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res).not.toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                 expect(res.text).toEqual("What's the weather like?");
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
                 done();
             },
@@ -804,6 +819,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res).not.toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                 expect(res.text).toEqual("What's the weather like?");
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
                 done();
             },
@@ -887,6 +904,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res).not.toBeUndefined();
                 expect(sdk.ResultReason.NoMatch).toEqual(res.reason);
                 expect(res.text).toBeUndefined();
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
                 const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
                 expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
@@ -907,6 +926,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(sdk.ResultReason.NoMatch).toEqual(res.reason);
                 expect(res.errorDetails).toBeUndefined();
                 expect(res.text).toBeUndefined();
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
                 const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
                 expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
@@ -1005,6 +1026,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(p2.reason).toEqual(sdk.ResultReason.Canceled);
                 const cancelDetails: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(p2);
                 expect(sdk.CancellationReason[cancelDetails.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
+                expect(p2.properties).not.toBeUndefined();
+                expect(p2.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
                 if (true === oneCalled) {
                     done();
@@ -1059,6 +1082,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res).not.toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                 expect(res.text).toEqual("What's the weather?");
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
                 done();
             },
@@ -1103,6 +1128,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(res.reason).toEqual(sdk.ResultReason.NoMatch);
                 const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
                 expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
+                expect(res.properties).not.toBeUndefined();
+                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
                 done();
             },
@@ -1440,6 +1467,7 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
                 expect(sdk.CancellationErrorCode[e.ErrorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.ConnectionFailure]);
                 expect(e.errorDetails).toContain("1006");
+
                 doneCount++;
             } catch (error) {
                 done.fail(error);


### PR DESCRIPTION
The properties collection was being returned undefined in nearly all circumstances.

Instead now return a collection with the service's text response populated.