### PR TITLE
 Fixed issue with RequestSession.privIsSpeechEnded flag stuck at true.

### DIFF
--- a/src/common.speech/RequestSession.ts
+++ b/src/common.speech/RequestSession.ts
@@ -80,6 +80,7 @@ export class RequestSession {
     }
 
     public startNewRecognition(): void {
+        this.privIsSpeechEnded = false;
         this.privIsRecognizing = true;
         this.privTurnStartAudioOffset = 0;
         this.privLastRecoOffset = 0;


### PR DESCRIPTION
Starting with the v.1.3.0 of SDK subsequent calls of startContinuousRecognitionAsync() after a call to stopContinuousRecognitionAsync() sometimes result in a "silence", i.e. packets not being sent to the server.
It appears to be caused by previous calls to this.privRequestSession.onSpeechEnded(). As the session is shared between multiple calls to startContinuousRecognitionAsync(), the value of this.privRequestSession.privIsSpeechEnded gets "stuck" in a dirty state (true). This change takes care of that.