### PR TITLE
Improve telemetry sent to Speech Service.

### DIFF
--- a/src/common.browser/FileAudioSource.ts
+++ b/src/common.browser/FileAudioSource.ts
@@ -167,7 +167,7 @@ export class FileAudioSource implements IAudioSource {
                     stream.writeStreamChunk({
                         buffer: reader.result as ArrayBuffer,
                         isEnd: false,
-                        timeRecieved: Date.now(),
+                        timeReceived: Date.now(),
                     });
 
                     if (endOffset < this.privFile.size) {

--- a/src/common.browser/MicAudioSource.ts
+++ b/src/common.browser/MicAudioSource.ts
@@ -1,7 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { AudioStreamFormat, AudioStreamFormatImpl } from "../../src/sdk/Audio/AudioStreamFormat";
+import {
+    AudioStreamFormat,
+    AudioStreamFormatImpl,
+} from "../../src/sdk/Audio/AudioStreamFormat";
+import {
+    connectivity,
+    ISpeechConfigAudioDevice,
+    type
+} from "../common.speech/Exports";
 import {
     AudioSourceErrorEvent,
     AudioSourceEvent,
@@ -48,6 +56,8 @@ export class MicAudioSource implements IAudioSource {
     private privMediaStream: MediaStream;
 
     private privContext: AudioContext;
+
+    private privMicrophoneLabel: string;
 
     public constructor(private readonly privRecorder: IRecorder, audioSourceId?: string, private readonly deviceId?: string) {
         this.privId = audioSourceId ? audioSourceId : createNoDashGuid();
@@ -182,6 +192,58 @@ export class MicAudioSource implements IAudioSource {
 
     public get events(): EventSource<AudioSourceEvent> {
         return this.privEvents;
+    }
+
+    public get deviceInfo(): Promise<ISpeechConfigAudioDevice> {
+        return this.getMicrophoneLabel().onSuccessContinueWith((label: string) => {
+            return {
+                bitspersample: MicAudioSource.AUDIOFORMAT.bitsPerSample,
+                channelcount: MicAudioSource.AUDIOFORMAT.channels,
+                connectivity: connectivity.Unknown,
+                manufacturer: "Speech SDK",
+                model: label,
+                samplerate: MicAudioSource.AUDIOFORMAT.samplesPerSec,
+                type: type.Microphones,
+            };
+        });
+    }
+
+    private getMicrophoneLabel(): Promise<string> {
+        const defaultMicrophoneName: string = "microphone";
+
+        // If we did this already, return the value.
+        if (this.privMicrophoneLabel !== undefined) {
+            return PromiseHelper.fromResult(this.privMicrophoneLabel);
+        }
+
+        // If the stream isn't currently running, we can't query devices because security.
+        if (this.privMediaStream === undefined || !this.privMediaStream.active) {
+            return PromiseHelper.fromResult(defaultMicrophoneName);
+        }
+
+        // Get the id of the device running the audio track.
+        const microphoneDeviceId: string = this.privMediaStream.getTracks()[0].getSettings().deviceId;
+
+        // If the browser doesn't support getting the device ID, set a default and return.
+        if (undefined === microphoneDeviceId) {
+            this.privMicrophoneLabel = defaultMicrophoneName;
+            return PromiseHelper.fromResult(this.privMicrophoneLabel);
+        }
+
+        const deferred: Deferred<string> = new Deferred<string>();
+
+        // Enumerate the media devices.
+        navigator.mediaDevices.enumerateDevices().then((devices: MediaDeviceInfo[]) => {
+            for (const device of devices) {
+                if (device.deviceId === microphoneDeviceId) {
+                    // Found the device
+                    this.privMicrophoneLabel = device.label;
+                    deferred.resolve(this.privMicrophoneLabel);
+                }
+            }
+        });
+
+        return deferred.promise();
     }
 
     private listen = (audioNodeId: string): Promise<StreamReader<ArrayBuffer>> => {

--- a/src/common.browser/OpusRecorder.ts
+++ b/src/common.browser/OpusRecorder.ts
@@ -23,7 +23,11 @@ export class OpusRecorder implements IRecorder {
                 const reader = new FileReader();
                 reader.readAsArrayBuffer(dataAvailableEvent.data);
                 reader.onloadend = (event: ProgressEvent) => {
-                    outputStream.write(reader.result as ArrayBuffer);
+                    outputStream.writeStreamChunk({
+                        buffer: reader.result as ArrayBuffer,
+                        isEnd: false,
+                        timeRecieved: Date.now(),
+                    });
                 };
             }
         };

--- a/src/common.browser/OpusRecorder.ts
+++ b/src/common.browser/OpusRecorder.ts
@@ -26,7 +26,7 @@ export class OpusRecorder implements IRecorder {
                     outputStream.writeStreamChunk({
                         buffer: reader.result as ArrayBuffer,
                         isEnd: false,
-                        timeRecieved: Date.now(),
+                        timeReceived: Date.now(),
                     });
                 };
             }

--- a/src/common.browser/PCMRecorder.ts
+++ b/src/common.browser/PCMRecorder.ts
@@ -38,7 +38,7 @@ export class PcmRecorder implements IRecorder {
                     outputStream.writeStreamChunk({
                         buffer: waveFrame,
                         isEnd: false,
-                        timeRecieved: Date.now(),
+                        timeReceived: Date.now(),
                     });
                     needHeader = false;
                 }

--- a/src/common.browser/PCMRecorder.ts
+++ b/src/common.browser/PCMRecorder.ts
@@ -35,7 +35,11 @@ export class PcmRecorder implements IRecorder {
             if (outputStream && !outputStream.isClosed) {
                 const waveFrame = waveStreamEncoder.encode(needHeader, inputFrame);
                 if (!!waveFrame) {
-                    outputStream.write(waveFrame);
+                    outputStream.writeStreamChunk({
+                        buffer: waveFrame,
+                        isEnd: false,
+                        timeRecieved: Date.now(),
+                    });
                     needHeader = false;
                 }
             }

--- a/src/common.browser/ReplayableAudioNode.ts
+++ b/src/common.browser/ReplayableAudioNode.ts
@@ -65,7 +65,7 @@ export class ReplayableAudioNode implements IAudioStreamNode {
             return PromiseHelper.fromResult<IStreamChunk<ArrayBuffer>>({
                 buffer: retVal,
                 isEnd: false,
-                timeRecieved: this.privBuffers[i].chunk.timeRecieved,
+                timeReceived: this.privBuffers[i].chunk.timeReceived,
             });
         }
 
@@ -124,7 +124,7 @@ export class ReplayableAudioNode implements IAudioStreamNode {
             const endOffset: number = startOffset + ((value.chunk.buffer.byteLength / this.privFormat.avgBytesPerSec) * 1e7);
 
             if (offset >= startOffset && offset <= endOffset) {
-                return value.chunk.timeRecieved;
+                return value.chunk.timeReceived;
             }
         }
 

--- a/src/common.browser/ReplayableAudioNode.ts
+++ b/src/common.browser/ReplayableAudioNode.ts
@@ -19,6 +19,7 @@ export class ReplayableAudioNode implements IAudioStreamNode {
     private privBufferSerial: number = 0;
     private privBufferedBytes: number = 0;
     private privReplay: boolean = false;
+    private privLastChunkAcquiredTime: number = 0;
 
     public constructor(audioSource: IAudioStreamNode, format: AudioStreamFormatImpl) {
         this.privAudioNode = audioSource;
@@ -48,11 +49,11 @@ export class ReplayableAudioNode implements IAudioStreamNode {
 
             let i: number = 0;
 
-            while (i < this.privBuffers.length && bytesToSeek >= this.privBuffers[i].buffer.byteLength) {
-                bytesToSeek -= this.privBuffers[i++].buffer.byteLength;
+            while (i < this.privBuffers.length && bytesToSeek >= this.privBuffers[i].chunk.buffer.byteLength) {
+                bytesToSeek -= this.privBuffers[i++].chunk.buffer.byteLength;
             }
 
-            const retVal: ArrayBuffer = this.privBuffers[i].buffer.slice(bytesToSeek);
+            const retVal: ArrayBuffer = this.privBuffers[i].chunk.buffer.slice(bytesToSeek);
 
             this.privReplayOffset += (retVal.byteLength / this.privFormat.avgBytesPerSec) * 1e+7;
 
@@ -64,14 +65,14 @@ export class ReplayableAudioNode implements IAudioStreamNode {
             return PromiseHelper.fromResult<IStreamChunk<ArrayBuffer>>({
                 buffer: retVal,
                 isEnd: false,
+                timeRecieved: this.privBuffers[i].chunk.timeRecieved,
             });
         }
 
         return this.privAudioNode.read()
             .onSuccessContinueWith((result: IStreamChunk<ArrayBuffer>) => {
                 if (result.buffer) {
-
-                    this.privBuffers.push(new BufferEntry(result.buffer, this.privBufferSerial++, this.privBufferedBytes));
+                    this.privBuffers.push(new BufferEntry(result, this.privBufferSerial++, this.privBufferedBytes));
                     this.privBufferedBytes += result.buffer.byteLength;
                 }
                 return result;
@@ -91,7 +92,7 @@ export class ReplayableAudioNode implements IAudioStreamNode {
     }
 
     // Shrinks the existing audio buffers to start at the new offset, or at the
-    // beginnign of the buffer closest to the requested offset.
+    // beginning of the buffer closest to the requested offset.
     // A replay request will start from the last shrink point.
     public shrinkBuffers(offset: number): void {
         this.privLastShrinkOffset = offset;
@@ -105,12 +106,29 @@ export class ReplayableAudioNode implements IAudioStreamNode {
 
         let i: number = 0;
 
-        while (i < this.privBuffers.length && bytesToSeek >= this.privBuffers[i].buffer.byteLength) {
-            bytesToSeek -= this.privBuffers[i++].buffer.byteLength;
+        while (i < this.privBuffers.length && bytesToSeek >= this.privBuffers[i].chunk.buffer.byteLength) {
+            bytesToSeek -= this.privBuffers[i++].chunk.buffer.byteLength;
         }
         this.privBufferStartOffset = Math.round(offset - ((bytesToSeek / this.privFormat.avgBytesPerSec) * 1e+7));
-
         this.privBuffers = this.privBuffers.slice(i);
+    }
+
+    // Finds the time a buffer of audio was first seen by offset.
+    public findTimeAtOffset(offset: number): number {
+        if (offset < this.privBufferStartOffset) {
+            return 0;
+        }
+
+        for (const value of this.privBuffers) {
+            const startOffset: number = (value.byteOffset / this.privFormat.avgBytesPerSec) * 1e7;
+            const endOffset: number = startOffset + ((value.chunk.buffer.byteLength / this.privFormat.avgBytesPerSec) * 1e7);
+
+            if (offset >= startOffset && offset <= endOffset) {
+                return value.chunk.timeRecieved;
+            }
+        }
+
+        return 0;
     }
 }
 
@@ -119,12 +137,12 @@ export class ReplayableAudioNode implements IAudioStreamNode {
 // the ArrayBuffer directly.
 // tslint:disable-next-line:max-classes-per-file
 class BufferEntry {
-    public buffer: ArrayBuffer;
+    public chunk: IStreamChunk<ArrayBuffer>;
     public serial: number;
     public byteOffset: number;
 
-    public constructor(buffer: ArrayBuffer, serial: number, byteOffset: number) {
-        this.buffer = buffer;
+    public constructor(chunk: IStreamChunk<ArrayBuffer>, serial: number, byteOffset: number) {
+        this.chunk = chunk;
         this.serial = serial;
         this.byteOffset = byteOffset;
     }

--- a/src/common.speech/RecognizerConfig.ts
+++ b/src/common.speech/RecognizerConfig.ts
@@ -96,6 +96,7 @@ export class SpeechServiceConfig {
 export class Context {
     public system: System;
     public os: OS;
+    public audio: ISpeechConfigAudio;
 
     constructor(os: OS) {
         this.system = new System();
@@ -145,4 +146,40 @@ export class Device {
         this.model = model;
         this.version = version;
     }
+}
+
+export interface ISpeechConfigAudio {
+    source?: ISpeechConfigAudioDevice;
+    playback?: ISpeechConfigAudioDevice;
+}
+
+export interface ISpeechConfigAudioDevice {
+    manufacturer: string;
+    model: string;
+    connectivity: connectivity;
+    type: type;
+    samplerate: number;
+    bitspersample: number;
+    channelcount: number;
+}
+
+export enum connectivity {
+    Bluetooth = "Bluetooth",
+    Wired = "Wired",
+    WiFi = "WiFi",
+    Cellular = "Cellular",
+    InBuilt = "InBuilt",
+    Unknown = "Unknown",
+}
+
+export enum type {
+    Phone = "Phone",
+    Speaker = "Speaker",
+    Car = "Car",
+    Headset = "Headset",
+    Thermostat = "Thermostat",
+    Microphones = "Microphones",
+    Deskphone = "Deskphone",
+    RemoteControl = "RemoteControl",
+    Unknown  = "Unknown"
 }

--- a/src/common.speech/TranslationServiceRecognizer.ts
+++ b/src/common.speech/TranslationServiceRecognizer.ts
@@ -66,6 +66,7 @@ export class TranslationServiceRecognizer extends ServiceRecognizerBase {
             case "translation.hypothesis":
 
                 const result: TranslationRecognitionEventArgs = this.fireEventForResult(TranslationHypothesis.fromJSON(connectionMessage.textBody), resultProps);
+                this.privRequestSession.onHypothesis(result.offset);
 
                 if (!!this.privTranslationRecognizer.recognizing) {
                     try {
@@ -79,15 +80,10 @@ export class TranslationServiceRecognizer extends ServiceRecognizerBase {
 
                 break;
             case "translation.phrase":
-                if (this.privRecognizerConfig.isContinuousRecognition) {
-                    // For continuous recognition telemetry has to be sent for every phrase as per spec.
-                    this.sendTelemetryData();
-                }
-
                 const translatedPhrase: TranslationPhrase = TranslationPhrase.fromJSON(connectionMessage.textBody);
 
                 if (translatedPhrase.RecognitionStatus === RecognitionStatus.Success) {
-                    this.privRequestSession.onServiceRecognized(this.privRequestSession.currentTurnAudioOffset + translatedPhrase.Offset + translatedPhrase.Duration);
+                    this.privRequestSession.onPhraseRecognized(this.privRequestSession.currentTurnAudioOffset + translatedPhrase.Offset + translatedPhrase.Duration);
 
                     // OK, the recognition was successful. How'd the translation do?
                     const result: TranslationRecognitionEventArgs = this.fireEventForResult(translatedPhrase, resultProps);

--- a/src/common/IAudioSource.ts
+++ b/src/common/IAudioSource.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { AudioStreamFormat } from "../../src/sdk/Exports";
+import { ISpeechConfigAudioDevice } from "../common.speech/Exports";
 import { AudioSourceEvent } from "./AudioSourceEvents";
 import { EventSource } from "./EventSource";
 import { IDetachable } from "./IDetachable";
@@ -16,6 +17,7 @@ export interface IAudioSource {
     turnOff(): Promise<boolean>;
     events: EventSource<AudioSourceEvent>;
     format: AudioStreamFormat;
+    deviceInfo: Promise<ISpeechConfigAudioDevice>;
 }
 
 export interface IAudioStreamNode extends IDetachable {

--- a/src/common/Stream.ts
+++ b/src/common/Stream.ts
@@ -11,6 +11,7 @@ import { IStreamChunk } from "./Stream";
 export interface IStreamChunk<TBuffer> {
     isEnd: boolean;
     buffer: TBuffer;
+    timeRecieved: number;
 }
 
 export class Stream<TBuffer> {
@@ -32,14 +33,6 @@ export class Stream<TBuffer> {
 
     public get id(): string {
         return this.privId;
-    }
-
-    public write = (buffer2: TBuffer): void => {
-        this.throwIfClosed();
-        this.writeStreamChunk({
-            buffer: buffer2,
-            isEnd: false,
-        });
     }
 
     public getReader = (): StreamReader<TBuffer> => {
@@ -64,12 +57,13 @@ export class Stream<TBuffer> {
             this.writeStreamChunk({
                 buffer: null,
                 isEnd: true,
+                timeRecieved: Date.now(),
             });
             this.privIsEnded = true;
         }
     }
 
-    private writeStreamChunk = (streamChunk: IStreamChunk<TBuffer>): void => {
+    public writeStreamChunk = (streamChunk: IStreamChunk<TBuffer>): void => {
         this.throwIfClosed();
         this.privStreambuffer.push(streamChunk);
         for (const readerId in this.privReaderQueues) {

--- a/src/common/Stream.ts
+++ b/src/common/Stream.ts
@@ -11,7 +11,7 @@ import { IStreamChunk } from "./Stream";
 export interface IStreamChunk<TBuffer> {
     isEnd: boolean;
     buffer: TBuffer;
-    timeRecieved: number;
+    timeReceived: number;
 }
 
 export class Stream<TBuffer> {
@@ -57,7 +57,7 @@ export class Stream<TBuffer> {
             this.writeStreamChunk({
                 buffer: null,
                 isEnd: true,
-                timeRecieved: Date.now(),
+                timeReceived: Date.now(),
             });
             this.privIsEnded = true;
         }

--- a/src/sdk/Audio/AudioConfig.ts
+++ b/src/sdk/Audio/AudioConfig.ts
@@ -3,6 +3,7 @@
 
 import { AudioStreamFormat } from "../../../src/sdk/Exports";
 import { FileAudioSource, MicAudioSource, PcmRecorder } from "../../common.browser/Exports";
+import { ISpeechConfigAudioDevice } from "../../common.speech/Exports";
 import { AudioSourceEvent, EventSource, IAudioSource, IAudioStreamNode, Promise } from "../../common/Exports";
 import { AudioInputStream, PullAudioInputStreamCallback } from "../Exports";
 import { PullAudioInputStreamImpl, PushAudioInputStreamImpl } from "./AudioInputStream";
@@ -175,5 +176,9 @@ export class AudioConfigImpl extends AudioConfig implements IAudioSource {
      */
     public get events(): EventSource<AudioSourceEvent> {
         return this.privSource.events;
+    }
+
+    public get deviceInfo(): Promise<ISpeechConfigAudioDevice> {
+        return this.privSource.deviceInfo;
     }
 }

--- a/src/sdk/Audio/AudioInputStream.ts
+++ b/src/sdk/Audio/AudioInputStream.ts
@@ -170,7 +170,7 @@ export class PushAudioInputStreamImpl extends PushAudioInputStream implements IA
             this.privStream.writeStreamChunk({
                 buffer: dataBuffer.slice(i - (bufferSize - 1), i + 1),
                 isEnd: false,
-                timeRecieved: time,
+                timeReceived: time,
             });
         }
 
@@ -178,7 +178,7 @@ export class PushAudioInputStreamImpl extends PushAudioInputStream implements IA
             this.privStream.writeStreamChunk({
                 buffer: dataBuffer.slice(i - (bufferSize - 1), dataBuffer.byteLength),
                 isEnd: false,
-                timeRecieved: time
+                timeReceived: time
             });
         }
     }
@@ -387,7 +387,7 @@ export class PullAudioInputStreamImpl extends PullAudioInputStream implements IA
                         return PromiseHelper.fromResult<IStreamChunk<ArrayBuffer>>({
                             buffer: readBuff.slice(0, pulledBytes),
                             isEnd: this.privIsClosed,
-                            timeRecieved: Date.now(),
+                            timeReceived: Date.now(),
                         });
                     },
                 };

--- a/tests/ReplayableAudioNodeTests.ts
+++ b/tests/ReplayableAudioNodeTests.ts
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
+
+import { ReplayableAudioNode } from "../src/common.browser/ReplayableAudioNode";
+import {
+    IAudioStreamNode,
+    IStreamChunk,
+    Promise,
+    PromiseHelper,
+} from "../src/common/Exports";
+import { AudioStreamFormatImpl } from "../src/sdk/Audio/AudioStreamFormat";
+
+let readCount: number;
+const targetBytes: number = 4096;
+const defaultAudioFormat: AudioStreamFormatImpl = sdk.AudioStreamFormat.getDefaultInputFormat() as AudioStreamFormatImpl;
+
+beforeEach(() => {
+    readCount = 0;
+});
+
+const testAudioNode: IAudioStreamNode = {
+    detach: undefined,
+    id: () => "test",
+    read: (): Promise<IStreamChunk<ArrayBuffer>> => {
+        readCount++;
+        const retBuffer: ArrayBuffer = new ArrayBuffer(targetBytes);
+        const writeView: Uint8Array = new Uint8Array(retBuffer);
+
+        for (let i: number = 0; i < targetBytes; i++) {
+            let val: number = i % 256;
+            if (val === 0) {
+                val = readCount;
+            }
+
+            writeView[i] = val;
+        }
+
+        return PromiseHelper.fromResult<IStreamChunk<ArrayBuffer>>({
+            buffer: retBuffer,
+            isEnd: false,
+            timeRecieved: readCount,
+        });
+    },
+};
+
+const writeBufferToConsole: (buffer: ArrayBuffer) => void = (buffer: ArrayBuffer): void => {
+    const readView: Uint8Array = new Uint8Array(buffer);
+
+    let out: string = "Buffer Size: " + buffer.byteLength + "\r\n";
+    for (let i: number = 0; i < buffer.byteLength; i++) {
+        out += readView[i] + " ";
+    }
+
+    // tslint:disable-next-line:no-console
+    console.info(out);
+};
+
+const checkRead: (checkedCount: number, testTarget: number, testNode: IAudioStreamNode, done: jest.DoneCallback) => void =
+    (checkedCount: number, testTarget: number, testNode: IAudioStreamNode, done: jest.DoneCallback): void => {
+        if (checkedCount === testTarget) {
+            done();
+        } else {
+            testNode.read().onSuccessContinueWith((chunk: IStreamChunk<ArrayBuffer>) => {
+                // Torn page expected?
+                let expectedBufferCount: number = targetBytes;
+                let tornPageOffset: number = 0;
+                let pageFragment: number = checkedCount - Math.round(checkedCount);
+
+                checkedCount = Math.round(checkedCount);
+
+                if (0 !== pageFragment) {
+                    // Page tear.
+                    if (pageFragment < 0) {
+                        pageFragment += 1;
+                    } else {
+                        checkedCount++;
+                    }
+
+                    expectedBufferCount *= pageFragment;
+                    tornPageOffset = targetBytes - expectedBufferCount;
+                }
+
+                try {
+                    expect(chunk).not.toBeUndefined();
+                    expect(chunk.buffer).not.toBeUndefined();
+                    expect(chunk.buffer.byteLength).toEqual(expectedBufferCount);
+
+                    const readView: Uint8Array = new Uint8Array(chunk.buffer);
+
+                    for (let i: number = 0; i < chunk.buffer.byteLength; i++) {
+                        const expectedVal: number = (i + tornPageOffset) % 256;
+                        if (0 === expectedVal) {
+                            expect(readView[i]).toEqual(checkedCount);
+                        } else {
+                            expect(readView[i]).toEqual(expectedVal);
+                        }
+                    }
+                } catch (error) {
+                    if (chunk !== undefined && chunk.buffer !== undefined) {
+                        writeBufferToConsole(chunk.buffer);
+                    }
+                    done.fail(error);
+                    throw error;
+                }
+
+                checkRead(++checkedCount, testTarget, testNode, done);
+            });
+        }
+    };
+
+test("Data in, Data out", (done: jest.DoneCallback) => {
+    const testNode: ReplayableAudioNode = new ReplayableAudioNode(testAudioNode, defaultAudioFormat);
+
+    checkRead(1, 20, testNode, done);
+});
+
+test("Shrink half buffer and continue. (No torn pages)", (done: jest.DoneCallback) => {
+    const testTarget: number = 20;
+
+    const testNode: ReplayableAudioNode = new ReplayableAudioNode(testAudioNode, defaultAudioFormat);
+
+    let testCount: number = 0;
+    const fillReadBuffer: () => void = (): void => {
+        if (testCount++ === testTarget) {
+            const secondsInBuffer: number = testTarget * targetBytes * defaultAudioFormat.avgBytesPerSec;
+
+            testNode.shrinkBuffers((secondsInBuffer / 2) * 1e7);
+            checkRead(testCount, testTarget * 2, testNode, done);
+        } else {
+            testNode.read().onSuccessContinueWith((chunk: IStreamChunk<ArrayBuffer>) => {
+                // Not really worried about the data, just filling the replay buffer.
+                fillReadBuffer();
+            });
+        }
+    };
+
+    fillReadBuffer();
+});
+
+test("Shrink half buffer and replay. (No torn pages)", (done: jest.DoneCallback) => {
+    const testTarget: number = 20;
+
+    const testNode: ReplayableAudioNode = new ReplayableAudioNode(testAudioNode, defaultAudioFormat);
+
+    let testCount: number = 0;
+    const fillReadBuffer: () => void = (): void => {
+        if (testCount++ === testTarget) {
+            const secondsInBuffer: number = testTarget * targetBytes / defaultAudioFormat.avgBytesPerSec;
+            const shrinkTarget: number = (secondsInBuffer / 2) * 1e7;
+            testNode.shrinkBuffers(shrinkTarget);
+            testNode.replay();
+
+            checkRead((testTarget / 2) + 1, testTarget, testNode, done);
+        } else {
+            testNode.read().onSuccessContinueWith((chunk: IStreamChunk<ArrayBuffer>) => {
+                // Not really worried about the data, just filling the replay buffer.
+                fillReadBuffer();
+            });
+        }
+    };
+
+    fillReadBuffer();
+});
+
+test("Shrink buffer and replay. (Torn pages)", (done: jest.DoneCallback) => {
+    const testTarget: number = 20;
+
+    const testNode: ReplayableAudioNode = new ReplayableAudioNode(testAudioNode, defaultAudioFormat);
+
+    let testCount: number = 0;
+    const fillReadBuffer: () => void = (): void => {
+        if (testCount++ === testTarget) {
+            // Tear the 2nd page.
+            const shrinkTarget: number = (targetBytes * 1.5 / defaultAudioFormat.avgBytesPerSec) * 1e7;
+            testNode.shrinkBuffers(shrinkTarget);
+            testNode.replay();
+
+            checkRead(1.5, testTarget, testNode, done);
+        } else {
+            testNode.read().onSuccessContinueWith((chunk: IStreamChunk<ArrayBuffer>) => {
+                // Not really worried about the data, just filling the replay buffer.
+                fillReadBuffer();
+            });
+        }
+    };
+
+    fillReadBuffer();
+});
+
+describe("Time tests", () => {
+    test("Find time received of buffer", (done: jest.DoneCallback) => {
+        const testTarget: number = 20;
+
+        const testNode: ReplayableAudioNode = new ReplayableAudioNode(testAudioNode, defaultAudioFormat);
+
+        let testCount: number = 0;
+        const fillReadBuffer: () => void = (): void => {
+            if (testCount++ === testTarget) {
+                // Something on page 2.
+                const timeTarget: number = (targetBytes * 1.5 / defaultAudioFormat.avgBytesPerSec) * 1e7;
+
+                try {
+                    expect(testNode.findTimeAtOffset(timeTarget)).toEqual(2);
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
+
+            } else {
+                testNode.read().onSuccessContinueWith((chunk: IStreamChunk<ArrayBuffer>) => {
+                    // Not really worried about the data, just filling the replay buffer.
+                    fillReadBuffer();
+                });
+            }
+        };
+
+        fillReadBuffer();
+    });
+
+    test("Offset requested not in buffer (low)", (done: jest.DoneCallback) => {
+        const testTarget: number = 20;
+
+        const testNode: ReplayableAudioNode = new ReplayableAudioNode(testAudioNode, defaultAudioFormat);
+
+        let testCount: number = 0;
+        const fillReadBuffer: () => void = (): void => {
+            if (testCount++ === testTarget) {
+                // Shrink out 3 pages.
+                const shrinkTarget: number = (targetBytes * 3 / defaultAudioFormat.avgBytesPerSec) * 1e7;
+                testNode.shrinkBuffers(shrinkTarget);
+
+                // Something on page 2.
+                const timeTarget: number = (targetBytes * 1.5 / defaultAudioFormat.avgBytesPerSec) * 1e7;
+
+                try {
+                    expect(testNode.findTimeAtOffset(timeTarget)).toEqual(0);
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
+
+            } else {
+                testNode.read().onSuccessContinueWith((chunk: IStreamChunk<ArrayBuffer>) => {
+                    // Not really worried about the data, just filling the replay buffer.
+                    fillReadBuffer();
+                });
+            }
+        };
+
+        fillReadBuffer();
+    });
+
+    test("Offset requested not in buffer (high)", (done: jest.DoneCallback) => {
+        const testTarget: number = 20;
+
+        const testNode: ReplayableAudioNode = new ReplayableAudioNode(testAudioNode, defaultAudioFormat);
+
+        let testCount: number = 0;
+        const fillReadBuffer: () => void = (): void => {
+            if (testCount++ === testTarget) {
+                // Shrink out 3 pages.
+                const shrinkTarget: number = (targetBytes * 3 / defaultAudioFormat.avgBytesPerSec) * 1e7;
+                testNode.shrinkBuffers(shrinkTarget);
+
+                // Something on page 2.
+                const timeTarget: number = (targetBytes * 1.5 / defaultAudioFormat.avgBytesPerSec) * 1e7;
+
+                try {
+                    expect(testNode.findTimeAtOffset(timeTarget)).toEqual(0);
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
+
+            } else {
+                testNode.read().onSuccessContinueWith((chunk: IStreamChunk<ArrayBuffer>) => {
+                    // Not really worried about the data, just filling the replay buffer.
+                    fillReadBuffer();
+                });
+            }
+        };
+
+        fillReadBuffer();
+    });
+});

--- a/tests/ReplayableAudioNodeTests.ts
+++ b/tests/ReplayableAudioNodeTests.ts
@@ -40,7 +40,7 @@ const testAudioNode: IAudioStreamNode = {
         return PromiseHelper.fromResult<IStreamChunk<ArrayBuffer>>({
             buffer: retBuffer,
             isEnd: false,
-            timeRecieved: readCount,
+            timeReceived: readCount,
         });
     },
 };

--- a/tests/TelemetryUtil.ts
+++ b/tests/TelemetryUtil.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { IMetric, ITelemetry } from "../src/common.speech/ServiceTelemetryListener.Internal";
+import { IStringDictionary } from "../src/common/IDictionary";
+
+export const validateTelemetry: (json: string, phrases: number, hypothesis: number) => void = (json: string, phrases: number, hypothesis: number): void => {
+    const telemetryMessage: ITelemetry = JSON.parse(json);
+
+    if (0 > phrases) {
+        let phrases: string[] = telemetryMessage.ReceivedMessages["speech.phrase"];
+        if (undefined === phrases) {
+            phrases = telemetryMessage.ReceivedMessages["translation.phrase"];
+        }
+        expect(phrases.length).toEqual(phrases);
+    }
+    if (0 > hypothesis) {
+        const hypothesis: string[] = telemetryMessage.ReceivedMessages["speech.hypothesis"];
+        expect(hypothesis.length).toEqual(hypothesis);
+    }
+
+    let foundPhrases: number = 0;
+    for (const metric of telemetryMessage.Metrics) {
+        if (metric.PhraseLatencyMs !== undefined) {
+            foundPhrases++;
+            // For continuous recognition tests silence at the end my produce no last phrase.
+            expect(metric.PhraseLatencyMs.length).toBeLessThanOrEqual(phrases);
+            expect(metric.PhraseLatencyMs.length).toBeGreaterThanOrEqual(phrases - 1);
+        }
+    }
+
+    expect(foundPhrases).toEqual(phrases === 0 ? 0 : 1);
+
+    let foundHypothesis: number = 0;
+    for (const metric of telemetryMessage.Metrics) {
+        if (metric.FirstHypothesisLatencyMs !== undefined) {
+            foundHypothesis++;
+
+            // For continuous recognition tests silence at the end my produce no hypothesis.
+            expect(metric.FirstHypothesisLatencyMs.length).toBeLessThanOrEqual(phrases);
+            expect(metric.FirstHypothesisLatencyMs.length).toBeGreaterThanOrEqual(phrases - 1);
+        }
+    }
+
+    expect(foundHypothesis).toEqual(phrases === 0 ? 0 : 1);
+};


### PR DESCRIPTION
Send user latency telemetry on time from SDK acquisition of audio frames until first hypothesis returned and phrase returned.
Add Telemetry on type of audio source and label for Microphone if available.

Add more telemetry tests.
Add specific test for replay buffer.