### PR TITLE
Remove throttling for the first 5 seconds of audio. 

### DIFF
--- a/src/common.speech/RequestSession.ts
+++ b/src/common.speech/RequestSession.ts
@@ -36,6 +36,7 @@ export class RequestSession {
     private privTurnStartAudioOffset: number = 0;
     private privLastRecoOffset: number = 0;
     private privHypothesisReceived: boolean = false;
+    private privBytesSent: number = 0;
 
     protected privSessionId: string;
 
@@ -74,6 +75,11 @@ export class RequestSession {
         return this.privTurnStartAudioOffset;
     }
 
+    // The number of bytes sent for the current connection.
+    // Counter is reset to 0 each time a connection is established.
+    public get bytesSent(): number {
+        return this.privBytesSent;
+    }
     public listenForServiceTelemetry(eventSource: IEventSource<PlatformEvent>): void {
         if (!!this.privServiceTelemetryListener) {
             this.privDetachables.push(eventSource.attachListener(this.privServiceTelemetryListener));
@@ -119,6 +125,7 @@ export class RequestSession {
                 this.privAudioNode.replay();
             }
             this.privTurnStartAudioOffset = this.privLastRecoOffset;
+            this.privBytesSent = 0;
             return;
         } else if (statusCode === 403) {
             this.onComplete();
@@ -152,6 +159,10 @@ export class RequestSession {
         this.privLastRecoOffset = offset;
         this.privHypothesisReceived = false;
         this.privAudioNode.shrinkBuffers(offset);
+    }
+
+    public onAudioSent(bytesSent: number): void {
+        this.privBytesSent += bytesSent;
     }
 
     public dispose = (error?: string): void => {

--- a/tests/IntentRecognizerTests.ts
+++ b/tests/IntentRecognizerTests.ts
@@ -96,6 +96,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         const r: sdk.IntentRecognizer = BuildRecognizerFromWaveFile();
         objsToClose.push(r);
 
+        r.canceled = (o: sdk.Recognizer, e: sdk.IntentRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
         r.recognizeOnceAsync(
             (p2: sdk.IntentRecognitionResult) => {
 
@@ -142,6 +150,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         r.addIntentWithLanguageModel(Settings.LuisValidIntentId, lm);
 
+        r.canceled = (o: sdk.Recognizer, e: sdk.IntentRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
         r.recognizeOnceAsync(
             (p2: sdk.IntentRecognitionResult) => {
                 const res: sdk.IntentRecognitionResult = p2;
@@ -185,9 +201,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         let bytesSent: number = 0;
 
         // To make sure we don't send a ton of extra data.
-        // 5s * 16K * 2 * 1.25;
         // For reference, before the throttling was implemented, we sent 6-10x the required data.
-        const expectedBytesSent: number = 5 * 16000 * 2 * 1.25;
+        const startTime: number = Date.now();
 
         p = sdk.AudioInputStream.createPullStream(
             {
@@ -200,7 +215,13 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
 
-        testInitialSilienceTimeout(config, done, () => expect(bytesSent).toBeLessThan(expectedBytesSent));
+        testInitialSilienceTimeout(config, done, (): void => {
+            const elapsed: number = Date.now() - startTime;
+
+            // We should have sent 5 seconds of audio unthrottled and then 2x the time reco took until we got a response.
+            const expectedBytesSent: number = (5 * 16000 * 2) + (2 * elapsed * 32000 / 1000);
+            expect(bytesSent).toBeLessThanOrEqual(expectedBytesSent);
+        });
     });
 
     test("InitialSilenceTimeout (push)", (done: jest.DoneCallback) => {
@@ -232,9 +253,6 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
     const testInitialSilienceTimeout = (config: sdk.AudioConfig, done: jest.DoneCallback, addedChecks?: () => void): void => {
         const s: sdk.SpeechConfig = BuildSpeechConfig();
         objsToClose.push(s);
-
-        // To validate the data isn't sent too fast.
-        const startTime: number = Date.now();
 
         const r: sdk.IntentRecognizer = new sdk.IntentRecognizer(s, config);
         objsToClose.push(r);
@@ -281,8 +299,6 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
                 const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
                 expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
-                expect(Date.now()).toBeGreaterThan(startTime + ((res.offset / 1e+4) / 2));
-
             },
             (error: string) => {
                 fail(error);
@@ -362,6 +378,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         const lm: sdk.LanguageUnderstandingModel = sdk.LanguageUnderstandingModel.fromAppId(Settings.LuisAppId);
 
         r.addIntentWithLanguageModel(Settings.LuisValidIntentId + "-Bad", lm);
+
+        r.canceled = (o: sdk.Recognizer, e: sdk.IntentRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
 
         r.recognizeOnceAsync(
             (p2: sdk.IntentRecognitionResult) => {
@@ -497,6 +521,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         r.addIntentWithLanguageModel(Settings.LuisValidIntentId, lm, intentName);
 
+        r.canceled = (o: sdk.Recognizer, e: sdk.IntentRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
         r.recognizeOnceAsync(
             (p2: sdk.IntentRecognitionResult) => {
                 const res: sdk.IntentRecognitionResult = p2;
@@ -525,6 +557,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         const lm: sdk.LanguageUnderstandingModel = sdk.LanguageUnderstandingModel.fromAppId(Settings.LuisAppId);
 
         r.addAllIntents(lm);
+
+        r.canceled = (o: sdk.Recognizer, e: sdk.IntentRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
 
         r.recognizeOnceAsync(
             (p2: sdk.IntentRecognitionResult) => {
@@ -555,6 +595,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         const lm: sdk.LanguageUnderstandingModel = sdk.LanguageUnderstandingModel.fromAppId(Settings.LuisAppId);
 
         r.addAllIntents(lm, "alias");
+
+        r.canceled = (o: sdk.Recognizer, e: sdk.IntentRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
 
         r.recognizeOnceAsync(
             (p2: sdk.IntentRecognitionResult) => {
@@ -897,6 +945,14 @@ test("Ambiguous Speech default as expected", (done: jest.DoneCallback) => {
     const r: sdk.IntentRecognizer = BuildRecognizerFromWaveFile(undefined, Settings.AmbiguousWaveFile);
     objsToClose.push(r);
 
+    r.canceled = (o: sdk.Recognizer, e: sdk.IntentRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
     r.recognizeOnceAsync(
         (p2: sdk.IntentRecognitionResult) => {
 
@@ -921,6 +977,14 @@ test("Phraselist assists speech Reco.", (done: jest.DoneCallback) => {
 
     const phraseList: sdk.PhraseListGrammar = sdk.PhraseListGrammar.fromRecognizer(r);
     phraseList.addPhrase("Wreck a nice beach.");
+
+    r.canceled = (o: sdk.Recognizer, e: sdk.IntentRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
 
     r.recognizeOnceAsync(
         (p2: sdk.IntentRecognitionResult) => {
@@ -988,6 +1052,14 @@ test("Phraselist Clear works.", (done: jest.DoneCallback) => {
     const dynamicPhrase: sdk.PhraseListGrammar = sdk.PhraseListGrammar.fromRecognizer(r);
     dynamicPhrase.addPhrase("Wreck a nice beach.");
 
+    r.canceled = (o: sdk.Recognizer, e: sdk.IntentRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
     r.recognized = (r: sdk.Recognizer, e: sdk.IntentRecognitionEventArgs): void => {
         try {
             const res: sdk.IntentRecognitionResult = e.result;
@@ -1041,6 +1113,14 @@ test("Phraselist extra phraselists have no effect.", (done: jest.DoneCallback) =
     const phraseList: sdk.PhraseListGrammar = sdk.PhraseListGrammar.fromRecognizer(r);
     phraseList.addPhrase("Wreck a nice beach.");
     phraseList.addPhrase("Escaped robot fights for his life, film at 11.");
+
+    r.canceled = (o: sdk.Recognizer, e: sdk.IntentRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
 
     r.recognizeOnceAsync(
         (p2: sdk.IntentRecognitionResult) => {

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -177,13 +177,25 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         expect(r.outputFormat === sdk.OutputFormat.Detailed);
 
-        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
-            expect(result).not.toBeUndefined();
-            expect(result.text).toEqual(Settings.WaveFileText);
-            expect(result.properties).not.toBeUndefined();
-            expect(result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
 
-            done();
+        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
+            try {
+                expect(result).not.toBeUndefined();
+                expect(result.text).toEqual(Settings.WaveFileText);
+                expect(result.properties).not.toBeUndefined();
+                expect(result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
+                done();
+            } catch (error) {
+                done.fail(error);
+            }
         }, (error: string) => {
             done.fail(error);
         });
@@ -226,13 +238,25 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
             expect(r.outputFormat === sdk.OutputFormat.Detailed);
 
-            r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
-                expect(result).not.toBeUndefined();
-                expect(result.text).toEqual(Settings.WaveFileText);
-                expect(result.properties).not.toBeUndefined();
-                expect(result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+            r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+                try {
+                    expect(e.errorDetails).toBeUndefined();
+                } catch (error) {
+                    done.fail(error);
+                }
+            };
 
-                done();
+            r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
+                try {
+                    expect(result).not.toBeUndefined();
+                    expect(result.text).toEqual(Settings.WaveFileText);
+                    expect(result.properties).not.toBeUndefined();
+                    expect(result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
             }, (error: string) => {
                 done.fail(error);
             });
@@ -290,8 +314,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                     try {
                         const res: sdk.SpeechRecognitionResult = p2;
                         expect(res).not.toBeUndefined();
-                        expect(res.text).toEqual("What's the weather like?");
                         expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+                        expect(res.text).toEqual("What's the weather like?");
                         expect(telemetryEvents).toEqual(1);
                         expect(res.properties).not.toBeUndefined();
                         expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
@@ -306,6 +330,7 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                     done.fail(error);
                 });
         });
+
         test("testStopContinuousRecognitionAsyncWithTelemetry", (done: jest.DoneCallback) => {
             // tslint:disable-next-line:no-console
             console.info("Name: testStopContinuousRecognitionAsyncWithTelemetry");
@@ -413,6 +438,11 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
             eventsMap[Canceled] = eventIdentifier++;
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
         };
 
         // todo eventType should be renamed and be a function getEventType()
@@ -442,61 +472,65 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         r.recognizeOnceAsync(
             (res: sdk.SpeechRecognitionResult) => {
-                expect(res).not.toBeUndefined();
-                expect(res.text).toEqual("What's the weather like?");
-                expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
+                try {
+                    expect(res).not.toBeUndefined();
+                    expect(res.text).toEqual("What's the weather like?");
+                    expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
 
-                // session events are first and last event
-                const LAST_RECORDED_EVENT_ID: number = --eventIdentifier;
+                    // session events are first and last event
+                    const LAST_RECORDED_EVENT_ID: number = --eventIdentifier;
 
-                expect(LAST_RECORDED_EVENT_ID).toBeGreaterThan(FIRST_EVENT_ID);
+                    expect(LAST_RECORDED_EVENT_ID).toBeGreaterThan(FIRST_EVENT_ID);
 
-                expect(Session + SessionStartedEvent in eventsMap).toEqual(true);
-                expect(eventsMap[Session + SessionStartedEvent]).toEqual(FIRST_EVENT_ID);
+                    expect(Session + SessionStartedEvent in eventsMap).toEqual(true);
+                    expect(eventsMap[Session + SessionStartedEvent]).toEqual(FIRST_EVENT_ID);
 
-                if (Session + SessionStoppedEvent in eventsMap) {
-                    expect(LAST_RECORDED_EVENT_ID).toEqual(eventsMap[Session + SessionStoppedEvent]);
-                }
-                // end events come after start events.
-                if (Session + SessionStoppedEvent in eventsMap) {
+                    if (Session + SessionStoppedEvent in eventsMap) {
+                        expect(LAST_RECORDED_EVENT_ID).toEqual(eventsMap[Session + SessionStoppedEvent]);
+                    }
+                    // end events come after start events.
+                    if (Session + SessionStoppedEvent in eventsMap) {
+                        expect(eventsMap[Session + SessionStartedEvent])
+                            .toBeLessThan(eventsMap[Session + SessionStoppedEvent]);
+                    }
+
+                    expect(eventsMap[SpeechStartDetectedEvent])
+                        .toBeLessThan(eventsMap[SpeechEndDetectedEvent]);
+                    expect((FIRST_EVENT_ID + 1)).toEqual(eventsMap[SpeechStartDetectedEvent]);
+
+                    // make sure, first end of speech, then final result
+                    expect((LAST_RECORDED_EVENT_ID - 1)).toEqual(eventsMap[SpeechEndDetectedEvent]);
+
+                    expect((LAST_RECORDED_EVENT_ID)).toEqual(eventsMap[Recognized]);
+
+                    // recognition events come after session start but before session end events
                     expect(eventsMap[Session + SessionStartedEvent])
-                        .toBeLessThan(eventsMap[Session + SessionStoppedEvent]);
+                        .toBeLessThan(eventsMap[SpeechStartDetectedEvent]);
+
+                    if (Session + SessionStoppedEvent in eventsMap) {
+                        expect(eventsMap[SpeechEndDetectedEvent])
+                            .toBeLessThan(eventsMap[Session + SessionStoppedEvent]);
+                    }
+
+                    // there is no partial result reported after the final result
+                    // (and check that we have intermediate and final results recorded)
+                    if (Recognizing in eventsMap) {
+                        expect(eventsMap[Recognizing])
+                            .toBeGreaterThan(eventsMap[SpeechStartDetectedEvent]);
+                    }
+
+                    // speech should stop before getting the final result.
+                    expect(eventsMap[Recognized]).toBeGreaterThan(eventsMap[SpeechEndDetectedEvent]);
+
+                    expect(eventsMap[Recognizing]).toBeLessThan(eventsMap[Recognized]);
+
+                    // make sure events we don't expect, don't get raised
+                    expect(Canceled in eventsMap).toBeFalsy();
+
+                    done();
+                } catch (error) {
+                    done.fail(error);
                 }
-
-                expect(eventsMap[SpeechStartDetectedEvent])
-                    .toBeLessThan(eventsMap[SpeechEndDetectedEvent]);
-                expect((FIRST_EVENT_ID + 1)).toEqual(eventsMap[SpeechStartDetectedEvent]);
-
-                // make sure, first end of speech, then final result
-                expect((LAST_RECORDED_EVENT_ID - 1)).toEqual(eventsMap[SpeechEndDetectedEvent]);
-
-                expect((LAST_RECORDED_EVENT_ID)).toEqual(eventsMap[Recognized]);
-
-                // recognition events come after session start but before session end events
-                expect(eventsMap[Session + SessionStartedEvent])
-                    .toBeLessThan(eventsMap[SpeechStartDetectedEvent]);
-
-                if (Session + SessionStoppedEvent in eventsMap) {
-                    expect(eventsMap[SpeechEndDetectedEvent])
-                        .toBeLessThan(eventsMap[Session + SessionStoppedEvent]);
-                }
-
-                // there is no partial result reported after the final result
-                // (and check that we have intermediate and final results recorded)
-                if (Recognizing in eventsMap) {
-                    expect(eventsMap[Recognizing])
-                        .toBeGreaterThan(eventsMap[SpeechStartDetectedEvent]);
-                }
-
-                // speech should stop before getting the final result.
-                expect(eventsMap[Recognized]).toBeGreaterThan(eventsMap[SpeechEndDetectedEvent]);
-
-                expect(eventsMap[Recognizing]).toBeLessThan(eventsMap[Recognized]);
-
-                // make sure events we don't expect, don't get raised
-                expect(Canceled in eventsMap).toBeFalsy();
-
-                done();
             }, (error: string) => {
                 done.fail(error);
             });
@@ -752,17 +786,29 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         expect(r).not.toBeUndefined();
         expect(r instanceof sdk.Recognizer);
 
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
                 const res: sdk.SpeechRecognitionResult = p2;
+                try {
+                    expect(res).not.toBeUndefined();
+                    expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+                    expect(res.text).toEqual("What's the weather like?");
+                    expect(res.properties).not.toBeUndefined();
+                    expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
-                expect(res).not.toBeUndefined();
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
-                expect(res.text).toEqual("What's the weather like?");
-                expect(res.properties).not.toBeUndefined();
-                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
 
-                done();
             },
             (error: string) => {
                 done.fail(error);
@@ -785,17 +831,29 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         expect(r).not.toBeUndefined();
         expect(r instanceof sdk.Recognizer);
 
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
-                const res: sdk.SpeechRecognitionResult = p2;
+                try {
+                    const res: sdk.SpeechRecognitionResult = p2;
 
-                expect(res).not.toBeUndefined();
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
-                expect(res.text).toEqual("What's the weather like?");
-                expect(res.properties).not.toBeUndefined();
-                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+                    expect(res).not.toBeUndefined();
+                    expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+                    expect(res.text).toEqual("What's the weather like?");
+                    expect(res.properties).not.toBeUndefined();
+                    expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
-                done();
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
             },
             (error: string) => {
                 done.fail(error);
@@ -849,17 +907,28 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         expect(r).not.toBeUndefined();
         expect(r instanceof sdk.Recognizer);
 
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
                 const res: sdk.SpeechRecognitionResult = p2;
+                try {
+                    expect(res).not.toBeUndefined();
+                    expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+                    expect(res.text).toEqual("What's the weather like?");
+                    expect(res.properties).not.toBeUndefined();
+                    expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
-                expect(res).not.toBeUndefined();
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
-                expect(res.text).toEqual("What's the weather like?");
-                expect(res.properties).not.toBeUndefined();
-                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
-
-                done();
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
             },
             (error: string) => {
                 done.fail(error);
@@ -903,17 +972,29 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         expect(r instanceof sdk.Recognizer);
         objsToClose.push(r);
 
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
-                const res: sdk.SpeechRecognitionResult = p2;
+                try {
+                    const res: sdk.SpeechRecognitionResult = p2;
 
-                expect(res).not.toBeUndefined();
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
-                expect(res.text).toEqual("What's the weather like?");
-                expect(res.properties).not.toBeUndefined();
-                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+                    expect(res).not.toBeUndefined();
+                    expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+                    expect(res.text).toEqual("What's the weather like?");
+                    expect(res.properties).not.toBeUndefined();
+                    expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
-                done();
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
             },
             (error: string) => {
                 done.fail(error);
@@ -927,9 +1008,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         let bytesSent: number = 0;
 
         // To make sure we don't send a ton of extra data.
-        // 5s * 16K * 2 * 1.25;
         // For reference, before the throttling was implemented, we sent 6-10x the required data.
-        const expectedBytesSent: number = 5 * 16000 * 2 * 1.25;
+        const startTime: number = Date.now();
 
         p = sdk.AudioInputStream.createPullStream(
             {
@@ -942,7 +1022,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
 
-        testInitialSilienceTimeout(config, done, () => expect(bytesSent).toBeLessThan(expectedBytesSent));
+        testInitialSilienceTimeout(config, done, (): void => {
+            const elapsed: number = Date.now() - startTime;
+
+            // We should have sent 5 seconds of audio unthrottled and then 2x the time reco took until we got a response.
+            const expectedBytesSent: number = (5 * 16000 * 2) + (2 * elapsed * 32000 / 1000);
+            expect(bytesSent).toBeLessThanOrEqual(expectedBytesSent);
+
+        });
     }, 15000);
 
     test("InitialSilenceTimeout (push)", (done: jest.DoneCallback) => {
@@ -973,9 +1060,6 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
     const testInitialSilienceTimeout = (config: sdk.AudioConfig, done: jest.DoneCallback, addedChecks?: () => void): void => {
         const s: sdk.SpeechConfig = BuildSpeechConfig();
         objsToClose.push(s);
-
-        // To validate the data isn't sent too fast.
-        const startTime: number = Date.now();
 
         const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s, config);
         objsToClose.push(r);
@@ -1010,20 +1094,22 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
-                const res: sdk.SpeechRecognitionResult = p2;
-                numReports++;
+                try {
+                    const res: sdk.SpeechRecognitionResult = p2;
+                    numReports++;
 
-                expect(res).not.toBeUndefined();
-                expect(sdk.ResultReason.NoMatch).toEqual(res.reason);
-                expect(res.errorDetails).toBeUndefined();
-                expect(res.text).toBeUndefined();
-                expect(res.properties).not.toBeUndefined();
-                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+                    expect(res).not.toBeUndefined();
+                    expect(sdk.ResultReason.NoMatch).toEqual(res.reason);
+                    expect(res.errorDetails).toBeUndefined();
+                    expect(res.text).toBeUndefined();
+                    expect(res.properties).not.toBeUndefined();
+                    expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
-                const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
-                expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
-                expect(Date.now()).toBeGreaterThanOrEqual(startTime + ((res.offset / 1e+4) / 2));
-
+                    const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
+                    expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
+                } catch (error) {
+                    done.fail(error);
+                }
             },
             (error: string) => {
                 fail(error);
@@ -1057,17 +1143,28 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         expect(r).not.toBeUndefined();
         expect(r instanceof sdk.Recognizer);
 
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
-                const res: sdk.SpeechRecognitionResult = p2;
-                expect(res).not.toBeUndefined();
-                expect("What's the weather like?").toEqual(res.text);
-                expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
+                try {
+                    const res: sdk.SpeechRecognitionResult = p2;
+                    expect(res).not.toBeUndefined();
+                    expect("What's the weather like?").toEqual(res.text);
+                    expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
 
-                r.close();
-                s.close();
-                done();
-
+                    r.close();
+                    s.close();
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
             },
             (error: string) => {
                 r.close();
@@ -1114,16 +1211,20 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
-                expect(p2.reason).toEqual(sdk.ResultReason.Canceled);
-                const cancelDetails: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(p2);
-                expect(sdk.CancellationReason[cancelDetails.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
-                expect(p2.properties).not.toBeUndefined();
-                expect(p2.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+                try {
+                    expect(p2.reason).toEqual(sdk.ResultReason.Canceled);
+                    const cancelDetails: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(p2);
+                    expect(sdk.CancellationReason[cancelDetails.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
+                    expect(p2.properties).not.toBeUndefined();
+                    expect(p2.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
-                if (true === oneCalled) {
-                    done();
-                } else {
-                    oneCalled = true;
+                    if (true === oneCalled) {
+                        done();
+                    } else {
+                        oneCalled = true;
+                    }
+                } catch (error) {
+                    done.fail(error);
                 }
             },
             (error: string) => {
@@ -1166,17 +1267,28 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         expect(r).not.toBeUndefined();
         expect(r instanceof sdk.Recognizer);
 
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
                 const res: sdk.SpeechRecognitionResult = p2;
+                try {
+                    expect(res).not.toBeUndefined();
+                    expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+                    expect(res.text).toEqual("What's the weather?");
+                    expect(res.properties).not.toBeUndefined();
+                    expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
-                expect(res).not.toBeUndefined();
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
-                expect(res.text).toEqual("What's the weather?");
-                expect(res.properties).not.toBeUndefined();
-                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
-
-                done();
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
             },
             (error: string) => {
                 done.fail(error);
@@ -1213,16 +1325,20 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         };
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
-                const res: sdk.SpeechRecognitionResult = p2;
+                try {
+                    const res: sdk.SpeechRecognitionResult = p2;
 
-                expect(res).not.toBeUndefined();
-                expect(res.reason).toEqual(sdk.ResultReason.NoMatch);
-                const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
-                expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
-                expect(res.properties).not.toBeUndefined();
-                expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+                    expect(res).not.toBeUndefined();
+                    expect(res.reason).toEqual(sdk.ResultReason.NoMatch);
+                    const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
+                    expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
+                    expect(res.properties).not.toBeUndefined();
+                    expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
 
-                done();
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
             },
             (error: string) => {
                 done.fail(error);
@@ -1259,6 +1375,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                     done.fail(error);
                 }
             });
+        };
+
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
         };
 
         r.recognizeOnceAsync();
@@ -1407,6 +1531,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         const r: sdk.SpeechRecognizer = BuildRecognizerFromWaveFile(s);
         objsToClose.push(r);
+
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
 
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
@@ -1860,16 +1992,28 @@ test("Multiple RecognizeOnce calls share a connection", (done: jest.DoneCallback
         disconnected = true;
     };
 
+    r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
     r.recognizeOnceAsync(
         (p2: sdk.SpeechRecognitionResult) => {
-            const res: sdk.SpeechRecognitionResult = p2;
+            try {
+                const res: sdk.SpeechRecognitionResult = p2;
 
-            expect(res).not.toBeUndefined();
-            expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
-            expect(res.text).toEqual("What's the weather like?");
-            expect(disconnected).toEqual(false);
-            firstReco = true;
-            sendSilence = false;
+                expect(res).not.toBeUndefined();
+                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+                expect(res.text).toEqual("What's the weather like?");
+                expect(disconnected).toEqual(false);
+                firstReco = true;
+                sendSilence = false;
+            } catch (error) {
+                done.fail(error);
+            }
         },
         (error: string) => {
             done.fail(error);
@@ -1880,14 +2024,18 @@ test("Multiple RecognizeOnce calls share a connection", (done: jest.DoneCallback
     }, () => {
         r.recognizeOnceAsync(
             (p2: sdk.SpeechRecognitionResult) => {
-                const res: sdk.SpeechRecognitionResult = p2;
+                try {
+                    const res: sdk.SpeechRecognitionResult = p2;
 
-                expect(res).not.toBeUndefined();
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
-                expect(res.text).toEqual("What's the weather like?");
-                expect(disconnected).toEqual(false);
-                expect(connected).toEqual(1);
-                done();
+                    expect(res).not.toBeUndefined();
+                    expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+                    expect(res.text).toEqual("What's the weather like?");
+                    expect(disconnected).toEqual(false);
+                    expect(connected).toEqual(1);
+                    done();
+                } catch (error) {
+                    done.fail(error);
+                }
             },
             (error: string) => {
                 done.fail(error);
@@ -1947,6 +2095,14 @@ test("Multiple ContReco calls share a connection", (done: jest.DoneCallback) => 
 
     connection.disconnected = (e: sdk.ConnectionEventArgs): void => {
         disconnected = true;
+    };
+
+    r.canceled = (r: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
     };
 
     r.recognized = (r: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
@@ -2065,6 +2221,14 @@ test("StopContinous Reco does", (done: jest.DoneCallback) => {
             expect(res.text).toEqual("What's the weather like?");
             expect(disconnected).toEqual(false);
             recoCount++;
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    r.canceled = (r: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
         } catch (error) {
             done.fail(error);
         }
@@ -2255,6 +2419,7 @@ test("Open during reco has no effect.", (done: jest.DoneCallback) => {
 
     r.canceled = (r: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
         try {
+            expect(e.errorDetails).toBeUndefined();
             expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.EndOfStream]);
             done();
         } catch (error) {
@@ -2355,6 +2520,14 @@ test("Connecting before reco works for cont", (done: jest.DoneCallback) => {
         }
     };
 
+    r.canceled = (r: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
     connection.openConnection();
 
     WaitForCondition(() => {
@@ -2449,6 +2622,14 @@ test("Switch RecoModes during a connection (cont->single)", (done: jest.DoneCall
         }
     };
 
+    r.canceled = (r: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
     r.startContinuousRecognitionAsync(
         undefined,
         (error: string) => {
@@ -2522,6 +2703,14 @@ test("Switch RecoModes during a connection (single->cont)", (done: jest.DoneCall
     expect(r).not.toBeUndefined();
     expect(r instanceof sdk.Recognizer);
 
+    r.canceled = (r: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
     let disconnected: boolean = false;
     let recoCount: number = 0;
 
@@ -2583,15 +2772,26 @@ test("Ambiguous Speech default as expected", (done: jest.DoneCallback) => {
     const r: sdk.SpeechRecognizer = BuildRecognizerFromWaveFile(undefined, Settings.AmbiguousWaveFile);
     objsToClose.push(r);
 
+    r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
     r.recognizeOnceAsync(
         (p2: sdk.SpeechRecognitionResult) => {
-
-            const res: sdk.SpeechRecognitionResult = p2;
-            expect(res.errorDetails).toBeUndefined();
-            expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
-            expect(res).not.toBeUndefined();
-            expect(res.text).toEqual("Recognize speech.");
-            done();
+            try {
+                const res: sdk.SpeechRecognitionResult = p2;
+                expect(res.errorDetails).toBeUndefined();
+                expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
+                expect(res).not.toBeUndefined();
+                expect(res.text).toEqual("Recognize speech.");
+                done();
+            } catch (error) {
+                done.fail(error);
+            }
         },
         (error: string) => {
             done.fail(error);
@@ -2609,15 +2809,26 @@ test("Service accepts random speech.context sections w/o error", (done: jest.Don
     const serviceBase: ServiceRecognizerBase = r.internalData as ServiceRecognizerBase;
     serviceBase.speechContext.setSection("BogusSection", { Value: "Some Text." });
 
+    r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
     r.recognizeOnceAsync(
         (p2: sdk.SpeechRecognitionResult) => {
-
-            const res: sdk.SpeechRecognitionResult = p2;
-            expect(res.errorDetails).toBeUndefined();
-            expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
-            expect(res).not.toBeUndefined();
-            expect(res.text).toEqual("Recognize speech.");
-            done();
+            try {
+                const res: sdk.SpeechRecognitionResult = p2;
+                expect(res.errorDetails).toBeUndefined();
+                expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
+                expect(res).not.toBeUndefined();
+                expect(res.text).toEqual("Recognize speech.");
+                done();
+            } catch (error) {
+                done.fail(error);
+            }
         },
         (error: string) => {
             done.fail(error);
@@ -2634,15 +2845,26 @@ test("Phraselist assists speech Reco.", (done: jest.DoneCallback) => {
     const phraseList: sdk.PhraseListGrammar = sdk.PhraseListGrammar.fromRecognizer(r);
     phraseList.addPhrase("Wreck a nice beach");
 
+    r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
     r.recognizeOnceAsync(
         (p2: sdk.SpeechRecognitionResult) => {
-
-            const res: sdk.SpeechRecognitionResult = p2;
-            expect(res.errorDetails).toBeUndefined();
-            expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
-            expect(res).not.toBeUndefined();
-            expect(res.text).toEqual("Wreck a nice beach.");
-            done();
+            try {
+                const res: sdk.SpeechRecognitionResult = p2;
+                expect(res.errorDetails).toBeUndefined();
+                expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
+                expect(res).not.toBeUndefined();
+                expect(res.text).toEqual("Wreck a nice beach.");
+                done();
+            } catch (error) {
+                done.fail(error);
+            }
         },
         (error: string) => {
             done.fail(error);
@@ -2660,15 +2882,26 @@ test("Phraselist extra phraselists have no effect.", (done: jest.DoneCallback) =
     phraseList.addPhrase("Wreck a nice beach");
     phraseList.addPhrase("Escaped robot fights for his life, film at 11.");
 
+    r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
     r.recognizeOnceAsync(
         (p2: sdk.SpeechRecognitionResult) => {
-
-            const res: sdk.SpeechRecognitionResult = p2;
-            expect(res.errorDetails).toBeUndefined();
-            expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
-            expect(res).not.toBeUndefined();
-            expect(res.text).toEqual("Wreck a nice beach.");
-            done();
+            try {
+                const res: sdk.SpeechRecognitionResult = p2;
+                expect(res.errorDetails).toBeUndefined();
+                expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
+                expect(res).not.toBeUndefined();
+                expect(res.text).toEqual("Wreck a nice beach.");
+                done();
+            } catch (error) {
+                done.fail(error);
+            }
         },
         (error: string) => {
             done.fail(error);
@@ -2737,6 +2970,14 @@ test("Phraselist Clear works.", (done: jest.DoneCallback) => {
                 expect(res.text).toEqual("Recognize speech.");
             }
             recoCount++;
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    r.canceled = (r: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
         } catch (error) {
             done.fail(error);
         }

--- a/tests/TranslationRecognizerTests.ts
+++ b/tests/TranslationRecognizerTests.ts
@@ -216,6 +216,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 }
             };
 
+            r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+                try {
+                    expect(e.errorDetails).toBeUndefined();
+                } catch (error) {
+                    done.fail(error);
+                }
+            };
+
             r.recognizeOnceAsync(
                 (res: sdk.TranslationRecognitionResult) => {
                     expect(res).not.toBeUndefined();
@@ -243,6 +251,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
         objsToClose.push(r);
+
+        r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
 
         r.recognizeOnceAsync(
             (res: sdk.TranslationRecognitionResult) => {
@@ -284,6 +300,11 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs) => {
             eventsMap[Canceled] = eventIdentifier++;
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
         };
 
         // TODO eventType should be renamed and be a function getEventType()
@@ -365,6 +386,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
         objsToClose.push(r);
 
+        r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
+
         r.startContinuousRecognitionAsync(() => {
 
             // Just long enough to start the connection, but not as long as recognition takes.
@@ -423,6 +452,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 done.fail(error);
             }
         });
+
+        r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.fail(error);
+            }
+        };
 
         r.startContinuousRecognitionAsync();
 
@@ -523,6 +560,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
                     const r2: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(speechConfig, config);
                     objsToClose.push(r2);
+
+                    r2.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+                        try {
+                            expect(e.errorDetails).toBeUndefined();
+                        } catch (error) {
+                            done.fail(error);
+                        }
+                    };
 
                     r2.recognizeOnceAsync((speech: sdk.SpeechRecognitionResult) => {
                         expect(speech.errorDetails).toBeUndefined();
@@ -675,6 +720,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
                     const r2: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s2, config);
                     objsToClose.push(r2);
+
+                    r2.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+                        try {
+                            expect(e.errorDetails).toBeUndefined();
+                        } catch (error) {
+                            done.fail(error);
+                        }
+                    };
 
                     r2.recognizeOnceAsync((speech: sdk.SpeechRecognitionResult) => {
                         expect(speech.errorDetails).toBeUndefined();
@@ -887,9 +940,8 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         let bytesSent: number = 0;
 
         // To make sure we don't send a ton of extra data.
-        // 5s * 16K * 2 * 1.25;
         // For reference, before the throttling was implemented, we sent 6-10x the required data.
-        const expectedBytesSent: number = 15 * 16000 * 2 * 1.25;
+        const startTime: number = Date.now();
 
         p = sdk.AudioInputStream.createPullStream(
             {
@@ -902,7 +954,14 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
 
-        testInitialSilienceTimeout(config, done, () => expect(bytesSent).toBeLessThan(expectedBytesSent));
+        testInitialSilienceTimeout(config, done, (): void => {
+            const elapsed: number = Date.now() - startTime;
+
+            // We should have sent 5 seconds of audio unthrottled and then 2x the time reco took until we got a response.
+            const expectedBytesSent: number = (5 * 16000 * 2) + (2 * elapsed * 32000 / 1000);
+            expect(bytesSent).toBeLessThanOrEqual(expectedBytesSent);
+
+        });
     }, 15000);
 
     test("InitialSilenceTimeout (push)", (done: jest.DoneCallback) => {
@@ -935,9 +994,6 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         s.addTargetLanguage("de-DE");
         s.speechRecognitionLanguage = "en-US";
-
-        // To validate the data isn't sent too fast.
-        const startTime: number = Date.now();
 
         const r: sdk.TranslationRecognizer = new sdk.TranslationRecognizer(s, config);
         objsToClose.push(r);
@@ -980,8 +1036,6 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
                 const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
                 expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
-                expect(Date.now()).toBeGreaterThanOrEqual(startTime + ((res.offset / 1e+4) / 2));
-
             },
             (error: string) => {
                 fail(error);
@@ -1470,6 +1524,14 @@ test("Multiple Phrase Latency Reporting", (done: jest.DoneCallback) => {
     };
 
     let lastOffset: number = 0;
+
+    r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
 
     r.recognized = (r: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs): void => {
         try {

--- a/tests/TranslationRecognizerTests.ts
+++ b/tests/TranslationRecognizerTests.ts
@@ -1128,7 +1128,7 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         r.recognizeOnceAsync(
             (res: sdk.TranslationRecognitionResult) => {
                 expect(res).not.toBeUndefined();
-                expect(res.errorDetails).toContain("400036");
+                expect(res.errorDetails).not.toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                 expect(res.translations).toBeUndefined();
                 expect(res.text).toEqual("What's the weather like?");


### PR DESCRIPTION
After that throttle at 2x realtime.
Tracking the amount of data sent on the request session to each reconnection will fast flush any data.

Added more logging to tests to reduce the number of timeouts when things to wrong and get better error messages back.