### PR TITLE
Fix error when quote exceeded

### DIFF
--- a/src/common.speech/EnumTranslation.ts
+++ b/src/common.speech/EnumTranslation.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { CancellationReason, ResultReason } from "../sdk/Exports";
+import {
+    CancellationErrorCode,
+    CancellationReason,
+    ResultReason
+} from "../sdk/Exports";
 import { RecognitionStatus } from "./Exports";
 
 export class EnumTranslation {
@@ -22,7 +26,6 @@ export class EnumTranslation {
                 reason = ResultReason.Canceled;
                 break;
         }
-
         return reason;
     }
 
@@ -43,4 +46,23 @@ export class EnumTranslation {
         }
         return reason;
     }
+
+    public static implTranslateCancelErrorCode(recognitionStatus: RecognitionStatus): CancellationErrorCode {
+        let reason: CancellationErrorCode = CancellationErrorCode.NoError;
+        switch (recognitionStatus) {
+            case RecognitionStatus.Error:
+                reason = CancellationErrorCode.ServiceError;
+                break;
+            case RecognitionStatus.TooManyRequests:
+                reason = CancellationErrorCode.TooManyRequests;
+                break;
+            default:
+                reason = CancellationErrorCode.NoError;
+                break;
+        }
+
+        return reason;
+
+    }
+
 }

--- a/src/common.speech/RequestSession.ts
+++ b/src/common.speech/RequestSession.ts
@@ -37,8 +37,8 @@ export class RequestSession {
     private privLastRecoOffset: number = 0;
     private privHypothesisReceived: boolean = false;
     private privBytesSent: number = 0;
-
-    protected privSessionId: string;
+    private privRecogNumber: number = 0;
+    private privSessionId: string;
 
     constructor(audioSourceId: string) {
         this.privAudioSourceId = audioSourceId;
@@ -75,6 +75,10 @@ export class RequestSession {
         return this.privTurnStartAudioOffset;
     }
 
+    public get recogNumber(): number {
+        return this.privRecogNumber;
+    }
+
     // The number of bytes sent for the current connection.
     // Counter is reset to 0 each time a connection is established.
     public get bytesSent(): number {
@@ -92,6 +96,7 @@ export class RequestSession {
         this.privTurnStartAudioOffset = 0;
         this.privLastRecoOffset = 0;
         this.privRequestId = createNoDashGuid();
+        this.privRecogNumber++;
         this.privServiceTelemetryListener = new ServiceTelemetryListener(this.privRequestId, this.privAudioSourceId, this.privAudioNodeId);
         this.onEvent(new RecognitionTriggeredEvent(this.requestId, this.privSessionId, this.privAudioSourceId, this.privAudioNodeId));
     }
@@ -186,7 +191,7 @@ export class RequestSession {
     }
 
     public onStopRecognizing(): void {
-        this.privIsRecognizing = false;
+        this.onComplete();
     }
 
     // Should be called with the audioNode for this session has indicated that it is out of speech.

--- a/src/common.speech/ServiceMessages/Enums.ts
+++ b/src/common.speech/ServiceMessages/Enums.ts
@@ -32,4 +32,5 @@ export enum RecognitionStatus {
     BabbleTimeout,
     Error,
     EndOfDictation,
+    TooManyRequests,
 }

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -566,15 +566,18 @@ export abstract class ServiceRecognizerBase implements IDisposable {
         // Max amount to send before we start to throttle
         const fastLaneSizeMs: string = this.privRecognizerConfig.parameters.getProperty("SPEECH-TransmitLengthBeforThrottleMs", "5000");
         const maxSendUnthrottledBytes: number = audioFormat.avgBytesPerSec / 1000 * parseInt(fastLaneSizeMs, 10);
+        const startRecogNumber: number = this.privRequestSession.recogNumber;
 
         const readAndUploadCycle = () => {
 
             // If speech is done, stop sending audio.
-            if (!this.privIsDisposed && !this.privRequestSession.isSpeechEnded && this.privRequestSession.isRecognizing) {
+            if (!this.privIsDisposed &&
+                !this.privRequestSession.isSpeechEnded &&
+                this.privRequestSession.isRecognizing &&
+                this.privRequestSession.recogNumber === startRecogNumber) {
                 this.fetchConnection().on((connection: IConnection) => {
                     audioStreamNode.read().on(
                         (audioStreamChunk: IStreamChunk<ArrayBuffer>) => {
-
                             // we have a new audio chunk to upload.
                             if (this.privRequestSession.isSpeechEnded) {
                                 // If service already recognized audio end then don't send any more audio

--- a/src/common.speech/SpeechServiceRecognizer.ts
+++ b/src/common.speech/SpeechServiceRecognizer.ts
@@ -92,28 +92,12 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                 if (ResultReason.Canceled === resultReason) {
                     const cancelReason: CancellationReason = EnumTranslation.implTranslateCancelResult(simple.RecognitionStatus);
 
-                    result = new SpeechRecognitionResult(
-                        this.privRequestSession.requestId,
-                        resultReason,
+                    this.cancelRecognitionLocal(
+                        cancelReason,
+                        EnumTranslation.implTranslateCancelErrorCode(simple.RecognitionStatus),
                         undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        connectionMessage.textBody,
-                        resultProps);
+                        successCallback);
 
-                    if (!!this.privSpeechRecognizer.canceled) {
-                        const cancelEvent: SpeechRecognitionCanceledEventArgs = new SpeechRecognitionCanceledEventArgs(
-                            cancelReason,
-                            undefined,
-                            cancelReason === CancellationReason.Error ? CancellationErrorCode.ServiceError : CancellationErrorCode.NoError,
-                            undefined,
-                            this.privRequestSession.sessionId);
-                        try {
-                            this.privSpeechRecognizer.canceled(this.privSpeechRecognizer, cancelEvent);
-                            /* tslint:disable:no-empty */
-                        } catch { }
-                    }
                 } else {
                     if (!(this.privRequestSession.isSpeechEnded && resultReason === ResultReason.NoMatch && simple.RecognitionStatus !== RecognitionStatus.InitialSilenceTimeout)) {
                         if (this.privRecognizerConfig.parameters.getProperty(OutputFormatPropertyName) === OutputFormat[OutputFormat.Simple]) {
@@ -152,23 +136,23 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                             }
                         }
                     }
+                    // report result to promise.
+                    if (!!successCallback) {
+                        try {
+                            successCallback(result);
+                        } catch (e) {
+                            if (!!errorCallBack) {
+                                errorCallBack(e);
+                            }
+                        }
+                        // Only invoke the call back once.
+                        // and if it's successful don't invoke the
+                        // error after that.
+                        successCallback = undefined;
+                        errorCallBack = undefined;
+                    }
                 }
 
-                // report result to promise.
-                if (!!successCallback) {
-                    try {
-                        successCallback(result);
-                    } catch (e) {
-                        if (!!errorCallBack) {
-                            errorCallBack(e);
-                        }
-                    }
-                    // Only invoke the call back once.
-                    // and if it's successful don't invoke the
-                    // error after that.
-                    successCallback = undefined;
-                    errorCallBack = undefined;
-                }
                 break;
             default:
                 break;


### PR DESCRIPTION
When a subscription exceeds its quota, continuous recognition doesn't stop and report the correct error.

Now, cancel the recognition and return the correct error code.

Also, found a bug where when start / stop / start was called in rapid succession the audio pump from the first start could continue to run based on timing. 