### PR TITLE
Update properties & URL parameter support on config objects.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,6 +69,7 @@
             loader: 'source-map-loader'
           }],
         },
+        mode: 'none',
         plugins: [
           new dtsBundleWebpack({
             name: 'microsoft.cognitiveservices.speech.sdk.bundle',

--- a/src/common.speech/ConnectionFactoryBase.ts
+++ b/src/common.speech/ConnectionFactoryBase.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import {
+    ServicePropertiesPropertyName,
+} from "../common.speech/Exports";
+import { IConnection, IStringDictionary } from "../common/Exports";
+import { OutputFormat, PropertyId } from "../sdk/Exports";
+import { AuthInfo, IConnectionFactory, RecognitionMode, RecognizerConfig, WebsocketMessageFormatter } from "./Exports";
+import { QueryParameterNames } from "./QueryParameterNames";
+
+export abstract class ConnectionFactoryBase implements IConnectionFactory {
+    public abstract create(
+        config: RecognizerConfig,
+        authInfo: AuthInfo,
+        connectionId?: string): IConnection;
+
+    protected setCommonUrlParams(
+        config: RecognizerConfig,
+        queryParams: IStringDictionary<string>,
+        endpoint: string): void {
+
+        this.setUrlParameter(PropertyId.SpeechServiceConnection_EnableAudioLogging,
+            QueryParameterNames.EnableAudioLogging,
+            config,
+            queryParams,
+            endpoint);
+
+        this.setUrlParameter(PropertyId.SpeechServiceResponse_RequestWordLevelTimestamps,
+            QueryParameterNames.EnableWordLevelTimestamps,
+            config,
+            queryParams,
+            endpoint);
+
+        this.setUrlParameter(PropertyId.SpeechServiceResponse_ProfanityOption,
+            QueryParameterNames.Profanify,
+            config,
+            queryParams,
+            endpoint);
+
+        this.setUrlParameter(PropertyId.SpeechServiceConnection_InitialSilenceTimeoutMs,
+            QueryParameterNames.InitialSilenceTimeoutMs,
+            config,
+            queryParams,
+            endpoint);
+
+        this.setUrlParameter(PropertyId.SpeechServiceConnection_EndSilenceTimeoutMs,
+            QueryParameterNames.EndSilenceTimeoutMs,
+            config,
+            queryParams,
+            endpoint);
+
+        this.setUrlParameter(PropertyId.SpeechServiceResponse_StablePartialResultThreshold,
+            QueryParameterNames.StableIntermediateThreshold,
+            config,
+            queryParams,
+            endpoint);
+
+        const serviceProperties: IStringDictionary<string> = JSON.parse(config.parameters.getProperty(ServicePropertiesPropertyName, "{}"));
+
+        Object.keys(serviceProperties).forEach((value: string, num: number, array: string[]) => {
+            queryParams[value] = serviceProperties[value];
+        });
+    }
+
+    protected setUrlParameter(
+        propId: PropertyId,
+        parameterName: string,
+        config: RecognizerConfig,
+        queryParams: IStringDictionary<string>,
+        endpoint: string): void {
+
+        const value: string = config.parameters.getProperty(propId, undefined);
+
+        if (value && (!endpoint || endpoint.search(parameterName) === -1)) {
+            queryParams[parameterName] = value.toLocaleLowerCase();
+        }
+    }
+}

--- a/src/common.speech/Exports.ts
+++ b/src/common.speech/Exports.ts
@@ -36,3 +36,5 @@ export * from "./DynamicGrammarInterfaces";
 
 export const OutputFormatPropertyName: string = "OutputFormat";
 export const CancellationErrorCodePropertyName: string = "CancellationErrorCode";
+export const ServicePropertiesPropertyName: string = "ServiceProperties";
+export const ForceDictationPropertyName: string = "ForceDication";

--- a/src/common.speech/IntentConnectionFactory.ts
+++ b/src/common.speech/IntentConnectionFactory.ts
@@ -5,8 +5,16 @@ import {
     ProxyInfo,
     WebsocketConnection,
 } from "../common.browser/Exports";
-import { IConnection, IStringDictionary } from "../common/Exports";
-import { PropertyId } from "../sdk/Exports";
+import {
+    IConnection,
+    IStringDictionary
+} from "../common/Exports";
+import {
+    PropertyId
+} from "../sdk/Exports";
+import {
+    ConnectionFactoryBase
+} from "./ConnectionFactoryBase";
 import {
     AuthInfo,
     IConnectionFactory,
@@ -17,7 +25,7 @@ import {
 const TestHooksParamName: string = "testhooks";
 const ConnectionIdHeader: string = "X-ConnectionId";
 
-export class IntentConnectionFactory implements IConnectionFactory {
+export class IntentConnectionFactory extends ConnectionFactoryBase {
 
     public create = (
         config: RecognizerConfig,
@@ -35,6 +43,8 @@ export class IntentConnectionFactory implements IConnectionFactory {
             format: "simple",
             language: config.parameters.getProperty(PropertyId.SpeechServiceConnection_RecoLanguage),
         };
+
+        this.setCommonUrlParams(config, queryParams, endpoint);
 
         const headers: IStringDictionary<string> = {};
         headers[authInfo.headerName] = authInfo.token;

--- a/src/common.speech/IntentServiceRecognizer.ts
+++ b/src/common.speech/IntentServiceRecognizer.ts
@@ -252,9 +252,10 @@ export class IntentServiceRecognizer extends ServiceRecognizerBase {
         error: string,
         cancelRecoCallback: (e: SpeechRecognitionResult) => void): void {
 
+        const properties: PropertyCollection = new PropertyCollection();
+        properties.setProperty(CancellationErrorCodePropertyName, CancellationErrorCode[errorCode]);
+
         if (!!this.privIntentRecognizer.canceled) {
-            const properties: PropertyCollection = new PropertyCollection();
-            properties.setProperty(CancellationErrorCodePropertyName, CancellationErrorCode[errorCode]);
 
             const cancelEvent: IntentRecognitionCanceledEventArgs = new IntentRecognitionCanceledEventArgs(
                 cancellationReason,
@@ -267,23 +268,23 @@ export class IntentServiceRecognizer extends ServiceRecognizerBase {
                 this.privIntentRecognizer.canceled(this.privIntentRecognizer, cancelEvent);
                 /* tslint:disable:no-empty */
             } catch { }
+        }
 
-            if (!!cancelRecoCallback) {
-                const result: IntentRecognitionResult = new IntentRecognitionResult(
-                    undefined, // Intent Id
-                    requestId,
-                    ResultReason.Canceled,
-                    undefined, // Text
-                    undefined, // Druation
-                    undefined, // Offset
-                    error,
-                    undefined, // Json
-                    properties);
-                try {
-                    cancelRecoCallback(result);
-                    /* tslint:disable:no-empty */
-                } catch { }
-            }
+        if (!!cancelRecoCallback) {
+            const result: IntentRecognitionResult = new IntentRecognitionResult(
+                undefined, // Intent Id
+                requestId,
+                ResultReason.Canceled,
+                undefined, // Text
+                undefined, // Druation
+                undefined, // Offset
+                error,
+                undefined, // Json
+                properties);
+            try {
+                cancelRecoCallback(result);
+                /* tslint:disable:no-empty */
+            } catch { }
         }
     }
 }

--- a/src/common.speech/QueryParameterNames.ts
+++ b/src/common.speech/QueryParameterNames.ts
@@ -23,4 +23,25 @@ export class QueryParameterNames {
     public static get TranslationToParamName(): string {
         return "to";
     }
+    public static get Profanify(): string {
+        return "profanity";
+    }
+    public static get EnableAudioLogging(): string {
+        return "storeAudio";
+    }
+    public static get EnableWordLevelTimestamps(): string {
+        return "wordLevelTimestamps";
+    }
+    public static get InitialSilenceTimeoutMs(): string {
+        return "initialSilenceTimeoutMs";
+    }
+    public static get EndSilenceTimeoutMs(): string {
+        return "endSilenceTimeoutMs";
+    }
+    public static get StableIntermediateThreshold(): string {
+        return "stableIntermediateThreshold";
+    }
+    public static get StableTranslation(): string {
+        return "stableTranslation";
+    }
 }

--- a/src/common.speech/SpeechConnectionFactory.ts
+++ b/src/common.speech/SpeechConnectionFactory.ts
@@ -5,13 +5,32 @@ import {
     ProxyInfo,
     WebsocketConnection,
 } from "../common.browser/Exports";
-import { OutputFormatPropertyName } from "../common.speech/Exports";
-import { IConnection, IStringDictionary } from "../common/Exports";
-import { OutputFormat, PropertyId } from "../sdk/Exports";
-import { AuthInfo, IConnectionFactory, RecognitionMode, RecognizerConfig, WebsocketMessageFormatter } from "./Exports";
-import { QueryParameterNames } from "./QueryParameterNames";
+import {
+    ForceDictationPropertyName,
+    OutputFormatPropertyName,
+} from "../common.speech/Exports";
+import {
+    IConnection,
+    IStringDictionary
+} from "../common/Exports";
+import {
+    OutputFormat,
+    PropertyId
+} from "../sdk/Exports";
+import {
+    ConnectionFactoryBase
+} from "./ConnectionFactoryBase";
+import {
+    AuthInfo,
+    RecognitionMode,
+    RecognizerConfig,
+    WebsocketMessageFormatter
+} from "./Exports";
+import {
+    QueryParameterNames
+} from "./QueryParameterNames";
 
-export class SpeechConnectionFactory implements IConnectionFactory {
+export class SpeechConnectionFactory extends ConnectionFactoryBase {
 
     private readonly interactiveRelativeUri: string = "/speech/recognition/interactive/cognitiveservices/v1";
     private readonly conversationRelativeUri: string = "/speech/recognition/conversation/cognitiveservices/v1";
@@ -43,6 +62,8 @@ export class SpeechConnectionFactory implements IConnectionFactory {
             queryParams[QueryParameterNames.FormatParamName] = config.parameters.getProperty(OutputFormatPropertyName, OutputFormat[OutputFormat.Simple]).toLowerCase();
         }
 
+        this.setCommonUrlParams(config, queryParams, endpoint);
+
         if (!endpoint) {
             const region: string = config.parameters.getProperty(PropertyId.SpeechServiceConnection_Region, undefined);
 
@@ -50,7 +71,11 @@ export class SpeechConnectionFactory implements IConnectionFactory {
 
             switch (config.recognitionMode) {
                 case RecognitionMode.Conversation:
-                    endpoint = host + this.conversationRelativeUri;
+                    if (config.parameters.getProperty(ForceDictationPropertyName, "false") === "true") {
+                        endpoint = host + this.dictationRelativeUri;
+                    } else {
+                        endpoint = host + this.conversationRelativeUri;
+                    }
                     break;
                 case RecognitionMode.Dictation:
                     endpoint = host + this.dictationRelativeUri;

--- a/src/common.speech/TranslationConnectionFactory.ts
+++ b/src/common.speech/TranslationConnectionFactory.ts
@@ -9,18 +9,24 @@ import {
     IConnection,
     IStringDictionary,
 } from "../common/Exports";
-import { PropertyId } from "../sdk/Exports";
+import {
+    PropertyId
+} from "../sdk/Exports";
+import {
+    ConnectionFactoryBase
+} from "./ConnectionFactoryBase";
 import {
     AuthInfo,
     IConnectionFactory,
     RecognizerConfig,
     WebsocketMessageFormatter,
 } from "./Exports";
+import { QueryParameterNames } from "./QueryParameterNames";
 
 const TestHooksParamName: string = "testhooks";
 const ConnectionIdHeader: string = "X-ConnectionId";
 
-export class TranslationConnectionFactory implements IConnectionFactory {
+export class TranslationConnectionFactory extends ConnectionFactoryBase {
 
     public create = (
         config: RecognizerConfig,
@@ -38,6 +44,15 @@ export class TranslationConnectionFactory implements IConnectionFactory {
             from: config.parameters.getProperty(PropertyId.SpeechServiceConnection_RecoLanguage),
             to: config.parameters.getProperty(PropertyId.SpeechServiceConnection_TranslationToLanguages),
         };
+
+        this.setCommonUrlParams(config, queryParams, endpoint);
+        this.setUrlParameter(
+            PropertyId.SpeechServiceResponse_TranslationRequestStablePartialResult,
+            QueryParameterNames.StableTranslation,
+            config,
+            queryParams,
+            endpoint
+        );
 
         const voiceName: string = "voice";
         const featureName: string = "features";

--- a/src/common.speech/TranslationServiceRecognizer.ts
+++ b/src/common.speech/TranslationServiceRecognizer.ts
@@ -231,9 +231,11 @@ export class TranslationServiceRecognizer extends ServiceRecognizerBase {
         errorCode: CancellationErrorCode,
         error: string,
         cancelRecoCallback: (e: SpeechRecognitionResult) => void): void {
+
+        const properties: PropertyCollection = new PropertyCollection();
+        properties.setProperty(CancellationErrorCodePropertyName, CancellationErrorCode[errorCode]);
+
         if (!!this.privTranslationRecognizer.canceled) {
-            const properties: PropertyCollection = new PropertyCollection();
-            properties.setProperty(CancellationErrorCodePropertyName, CancellationErrorCode[errorCode]);
 
             const cancelEvent: TranslationRecognitionCanceledEventArgs = new TranslationRecognitionCanceledEventArgs(
                 sessionId,
@@ -246,23 +248,23 @@ export class TranslationServiceRecognizer extends ServiceRecognizerBase {
                 this.privTranslationRecognizer.canceled(this.privTranslationRecognizer, cancelEvent);
                 /* tslint:disable:no-empty */
             } catch { }
+        }
 
-            if (!!cancelRecoCallback) {
-                const result: TranslationRecognitionResult = new TranslationRecognitionResult(
-                    undefined, // Translations
-                    requestId,
-                    ResultReason.Canceled,
-                    undefined, // Text
-                    undefined, // Druation
-                    undefined, // Offset
-                    error,
-                    undefined, // Json
-                    properties);
-                try {
-                    cancelRecoCallback(result);
-                    /* tslint:disable:no-empty */
-                } catch { }
-            }
+        if (!!cancelRecoCallback) {
+            const result: TranslationRecognitionResult = new TranslationRecognitionResult(
+                undefined, // Translations
+                requestId,
+                ResultReason.Canceled,
+                undefined, // Text
+                undefined, // Druation
+                undefined, // Offset
+                error,
+                undefined, // Json
+                properties);
+            try {
+                cancelRecoCallback(result);
+                /* tslint:disable:no-empty */
+            } catch { }
         }
     }
 

--- a/src/sdk/Exports.ts
+++ b/src/sdk/Exports.ts
@@ -40,3 +40,5 @@ export { CancellationErrorCode } from "./CancellationErrorCodes";
 export { ConnectionEventArgs } from "./ConnectionEventArgs";
 export { Connection } from "./Connection";
 export { PhraseListGrammar } from "./PhraseListGrammar";
+export { ServicePropertyChannel } from "./ServicePropertyChannel";
+export { ProfanityOption } from "./ProfanityOption";

--- a/src/sdk/ProfanityOption.ts
+++ b/src/sdk/ProfanityOption.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Profanity option.
+ * Added in version 1.7.0.
+ */
+export enum ProfanityOption {
+    Masked = 0,
+    Removed = 1,
+    Raw = 2
+}

--- a/src/sdk/PropertyId.ts
+++ b/src/sdk/PropertyId.ts
@@ -194,4 +194,68 @@ export enum PropertyId {
      * @member PropertyId.LanguageUnderstandingServiceResponse_JsonResult
      */
     LanguageUnderstandingServiceResponse_JsonResult,
+
+   /**
+    * The URL string built from speech configuration.
+    * This property is intended to be read-only. The SDK is using it internally.
+    * NOTE: Added in version 1.7.0.
+    */
+    SpeechServiceConnection_Url,
+
+   /**
+    * The initial silence timeout value (in milliseconds) used by the service.
+    * Added in version 1.7.0
+    */
+    SpeechServiceConnection_InitialSilenceTimeoutMs,
+
+   /**
+    * The end silence timeout value (in milliseconds) used by the service.
+    * Added in version 1.7.0
+    */
+    SpeechServiceConnection_EndSilenceTimeoutMs,
+
+   /**
+    * A boolean value specifying whether audio logging is enabled in the service or not.
+    * Added in version 1.7.0
+    */
+    SpeechServiceConnection_EnableAudioLogging,
+
+   /**
+    * The requested Cognitive Services Speech Service response output profanity setting.
+    * Allowed values are "masked", "removed", and "raw".
+    * Added in version 1.7.0.
+    */
+    SpeechServiceResponse_ProfanityOption,
+
+   /**
+    * A string value specifying which post processing option should be used by service.
+    * Allowed values are "TrueText".
+    * Added in version 1.7.0
+    */
+    SpeechServiceResponse_PostProcessingOption,
+
+   /**
+    *  A boolean value specifying whether to include word-level timestamps in the response result.
+    * Added in version 1.7.0
+    */
+    SpeechServiceResponse_RequestWordLevelTimestamps,
+
+   /**
+    * The number of times a word has to be in partial results to be returned.
+    * Added in version 1.7.0
+    */
+    SpeechServiceResponse_StablePartialResultThreshold,
+
+   /**
+    * A string value specifying the output format option in the response result. Internal use only.
+    * Added in version 1.7.0.
+    */
+    SpeechServiceResponse_OutputFormatOption,
+
+   /**
+    * A boolean value to request for stabilizing translation partial results by omitting words in the end.
+    * Added in version 1.7.0.
+    */
+    SpeechServiceResponse_TranslationRequestStablePartialResult,
+
 }

--- a/src/sdk/ServicePropertyChannel.ts
+++ b/src/sdk/ServicePropertyChannel.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Defines channels used to pass property settings to service.
+ * Added in version 1.7.0.
+ */
+export enum ServicePropertyChannel {
+    /**
+     * Uses URI query parameter to pass property settings to service.
+     */
+    UriQueryParameter = 0.
+}

--- a/src/sdk/SpeechTranslationConfig.ts
+++ b/src/sdk/SpeechTranslationConfig.ts
@@ -1,9 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { OutputFormatPropertyName } from "../common.speech/Exports";
+import {
+    ForceDictationPropertyName,
+    OutputFormatPropertyName,
+    ServicePropertiesPropertyName
+} from "../common.speech/Exports";
+import { IStringDictionary } from "../common/Exports";
 import { Contracts } from "./Contracts";
-import { OutputFormat, PropertyCollection, PropertyId, SpeechConfig } from "./Exports";
+import {
+    OutputFormat,
+    ProfanityOption,
+    PropertyCollection,
+    PropertyId,
+    ServicePropertyChannel,
+    SpeechConfig,
+} from "./Exports";
 
 /**
  * Speech translation configuration.
@@ -173,6 +185,7 @@ export abstract class SpeechTranslationConfig extends SpeechConfig {
  */
 // tslint:disable-next-line:max-classes-per-file
 export class SpeechTranslationConfigImpl extends SpeechTranslationConfig {
+
     private privSpeechProperties: PropertyCollection;
 
     public constructor() {
@@ -376,4 +389,27 @@ export class SpeechTranslationConfigImpl extends SpeechTranslationConfig {
     public close(): void {
         return;
     }
+
+    public setServiceProperty(name: string, value: string, channel: ServicePropertyChannel): void {
+        const currentProperties: IStringDictionary<string> = JSON.parse(this.privSpeechProperties.getProperty(ServicePropertiesPropertyName, "{}"));
+
+        currentProperties[name] = value;
+
+        this.privSpeechProperties.setProperty(ServicePropertiesPropertyName, JSON.stringify(currentProperties));
+    }
+
+    public setProfanity(profanity: ProfanityOption): void {
+        this.privSpeechProperties.setProperty(PropertyId.SpeechServiceResponse_ProfanityOption, ProfanityOption[profanity]);
+    }
+
+    public enableAudioLogging(): void {
+        this.privSpeechProperties.setProperty(PropertyId.SpeechServiceConnection_EnableAudioLogging, "true");
+    }
+    public requestWordLevelTimestamps(): void {
+        this.privSpeechProperties.setProperty(PropertyId.SpeechServiceResponse_RequestWordLevelTimestamps, "true");
+    }
+    public enableDictation(): void {
+        this.privSpeechProperties.setProperty(ForceDictationPropertyName, "true");
+    }
+
 }

--- a/src/sdk/TranslationRecognizer.ts
+++ b/src/sdk/TranslationRecognizer.ts
@@ -189,6 +189,7 @@ export class TranslationRecognizer extends Recognizer {
                 RecognitionMode.Conversation,
                 (e: TranslationRecognitionResult) => {
                     this.implRecognizerStop();
+
                     if (!!cb) {
                         cb(e);
                     }


### PR DESCRIPTION
 Add new properties to public SDK and stub methods to impl classes.

This brings the JS SDK into parity with the native implementation.

Minor test refactor to enable more tests.

Fixed a bug in the translation & intent recognizers where if the canceled event was not suscribed to,
recognizeOnceAsync would not indicate recognation had canceled due to an internal error.