### PR TITLE
Fix for unhandled null audio chunks breaking successive listenOnce calls

### DIFF
--- a/src/common.browser/MicAudioSource.ts
+++ b/src/common.browser/MicAudioSource.ts
@@ -161,9 +161,9 @@ export class MicAudioSource implements IAudioSource {
                 return {
                     detach: () => {
                         streamReader.close();
+                        this.turnOff();
                         delete this.privStreams[audioNodeId];
                         this.onEvent(new AudioStreamNodeDetachedEvent(this.privId, audioNodeId));
-                        this.turnOff();
                     },
                     id: () => {
                         return audioNodeId;

--- a/src/common.browser/ReplayableAudioNode.ts
+++ b/src/common.browser/ReplayableAudioNode.ts
@@ -71,7 +71,7 @@ export class ReplayableAudioNode implements IAudioStreamNode {
 
         return this.privAudioNode.read()
             .onSuccessContinueWith((result: IStreamChunk<ArrayBuffer>) => {
-                if (result.buffer) {
+                if (result && result.buffer) {
                     this.privBuffers.push(new BufferEntry(result, this.privBufferSerial++, this.privBufferedBytes));
                     this.privBufferedBytes += result.buffer.byteLength;
                 }

--- a/src/common.speech/DialogServiceAdapter.ts
+++ b/src/common.speech/DialogServiceAdapter.ts
@@ -442,7 +442,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
                                 let payload: ArrayBuffer;
                                 let sendDelay: number;
 
-                                if (audioStreamChunk.isEnd) {
+                                if (!audioStreamChunk || audioStreamChunk.isEnd) {
                                     payload = null;
                                     sendDelay = 0;
                                 } else {
@@ -466,7 +466,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
                                         new SpeechConnectionMessage(
                                             MessageType.Binary, "audio", this.privDialogRequestSession.requestId, null, payload));
 
-                                    if (!audioStreamChunk.isEnd) {
+                                    if (audioStreamChunk && !audioStreamChunk.isEnd) {
                                         uploaded.continueWith((_: PromiseResult<boolean>) => {
 
                                             // Regardless of success or failure, schedule the next upload.


### PR DESCRIPTION
During shutdown, we never see an audio chunk with "isEnd" set to true since this only happens when the stream is closed and we are cleaning up the streams before closing them. Even then, we weren't checking for null audio chunks and would hit null deref exceptions when we tried reading the isEnd property which would cause subsequent SR attempts to fail.