### PR TITLE
Honor service property ids when set

### DIFF
--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -78,6 +78,8 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
             headers[authHeader] = applicationId;
         }
 
+        this.setCommonUrlParams(config, queryParams, endpoint);
+
         return new WebsocketConnection(endpoint, queryParams, headers, new WebsocketMessageFormatter(), ProxyInfo.fromRecognizerConfig(config), connectionId);
     }
 }


### PR DESCRIPTION
Adding a call to the factory base method that parses out specified service properties, as added in 1.7

While the usage of these may change soon, for now this is the only way to specify "service properties" so we need this change to support it.

usage example:
config.setServiceProperty("some_propertyName", "some_value", SpeechSDK.ServicePropertyChannel.UriQueryParameter)