### PR TITLE
Send a wave header based on the AudioFormat specified.

### DIFF
--- a/src/common.browser/FileAudioSource.ts
+++ b/src/common.browser/FileAudioSource.ts
@@ -58,7 +58,7 @@ export class FileAudioSource implements IAudioSource {
         this.privFile = file;
     }
 
-    public get format(): AudioStreamFormat {
+    public get format(): AudioStreamFormatImpl {
         return FileAudioSource.FILEFORMAT;
     }
 

--- a/src/common.browser/MicAudioSource.ts
+++ b/src/common.browser/MicAudioSource.ts
@@ -75,7 +75,7 @@ export class MicAudioSource implements IAudioSource {
         this.privEvents = new EventSource<AudioSourceEvent>();
     }
 
-    public get format(): AudioStreamFormat {
+    public get format(): AudioStreamFormatImpl {
         return MicAudioSource.AUDIOFORMAT;
     }
 

--- a/src/common.browser/PCMRecorder.ts
+++ b/src/common.browser/PCMRecorder.ts
@@ -34,7 +34,7 @@ export class PcmRecorder implements IRecorder {
             const inputFrame = event.inputBuffer.getChannelData(0);
 
             if (outputStream && !outputStream.isClosed) {
-                const waveFrame = waveStreamEncoder.encode(needHeader, inputFrame);
+                const waveFrame = waveStreamEncoder.encode(inputFrame);
                 if (!!waveFrame) {
                     outputStream.writeStreamChunk({
                         buffer: waveFrame,
@@ -60,7 +60,7 @@ export class PcmRecorder implements IRecorder {
                         const inputFrame: Float32Array = ev.data as Float32Array;
 
                         if (outputStream && !outputStream.isClosed) {
-                            const waveFrame = waveStreamEncoder.encode(needHeader, inputFrame);
+                            const waveFrame = waveStreamEncoder.encode(inputFrame);
                             if (!!waveFrame) {
                                 outputStream.writeStreamChunk({
                                     buffer: waveFrame,

--- a/src/common/IAudioSource.ts
+++ b/src/common/IAudioSource.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { AudioStreamFormat } from "../../src/sdk/Exports";
+import { AudioStreamFormatImpl } from "../../src/sdk/Audio/AudioStreamFormat";
 import { ISpeechConfigAudioDevice } from "../common.speech/Exports";
 import { AudioSourceEvent } from "./AudioSourceEvents";
 import { EventSource } from "./EventSource";
@@ -16,7 +16,7 @@ export interface IAudioSource {
     detach(audioNodeId: string): void;
     turnOff(): Promise<boolean>;
     events: EventSource<AudioSourceEvent>;
-    format: AudioStreamFormat;
+    format: AudioStreamFormatImpl;
     deviceInfo: Promise<ISpeechConfigAudioDevice>;
     setProperty?(name: string, value: string): void;
     getProperty?(name: string, def?: string): string;

--- a/src/sdk/Audio/AudioConfig.ts
+++ b/src/sdk/Audio/AudioConfig.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { AudioStreamFormat } from "../../../src/sdk/Exports";
+import { AudioStreamFormatImpl } from "../../../src/sdk/Audio/AudioStreamFormat";
 import { FileAudioSource, MicAudioSource, PcmRecorder } from "../../common.browser/Exports";
 import { ISpeechConfigAudioDevice } from "../../common.speech/Exports";
 import { AudioSourceEvent, EventSource, IAudioSource, IAudioStreamNode, Promise } from "../../common/Exports";
@@ -128,7 +128,7 @@ export class AudioConfigImpl extends AudioConfig implements IAudioSource {
     /**
      * Format information for the audio
      */
-    public get format(): AudioStreamFormat {
+    public get format(): AudioStreamFormatImpl {
         return this.privSource.format;
     }
 

--- a/src/sdk/Audio/AudioInputStream.ts
+++ b/src/sdk/Audio/AudioInputStream.ts
@@ -152,7 +152,7 @@ export class PushAudioInputStreamImpl extends PushAudioInputStream implements IA
     /**
      * Format information for the audio
      */
-    public get format(): AudioStreamFormat {
+    public get format(): AudioStreamFormatImpl {
         return this.privFormat;
     }
 
@@ -327,7 +327,7 @@ export class PullAudioInputStreamImpl extends PullAudioInputStream implements IA
     /**
      * Format information for the audio
      */
-    public get format(): AudioStreamFormat {
+    public get format(): AudioStreamFormatImpl {
         return this.privFormat;
     }
 

--- a/tests/IntentRecognizerTests.ts
+++ b/tests/IntentRecognizerTests.ts
@@ -44,8 +44,8 @@ afterEach(() => {
 const ValidateResultMatchesWaveFile = (res: sdk.SpeechRecognitionResult): void => {
     expect(res).not.toBeUndefined();
     expect(res.text).toEqual(Settings.LuisWavFileText);
-    expect(Math.abs(res.duration - Settings.LuisWaveFileDuration) / Settings.LuisWaveFileDuration).toBeLessThanOrEqual(0.05);
-    expect(Math.abs(res.offset - Settings.LuisWaveFileOffset) / Settings.LuisWaveFileOffset).toBeLessThanOrEqual(0.05);
+    expect(Math.abs(res.duration - Settings.LuisWaveFileDuration) / Settings.LuisWaveFileDuration).toBeLessThanOrEqual(0.10);
+    expect(Math.abs(res.offset - Settings.LuisWaveFileOffset) / Settings.LuisWaveFileOffset).toBeLessThanOrEqual(0.10);
 };
 
 const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechConfig, audioFileName?: string) => sdk.IntentRecognizer = (speechConfig?: sdk.SpeechConfig, audioFileName?: string): sdk.IntentRecognizer => {

--- a/tests/WaveFileAudioInputStream.ts
+++ b/tests/WaveFileAudioInputStream.ts
@@ -19,7 +19,7 @@ export class WaveFileAudioInput {
     public static LoadArrayFromFile(filename: string): ArrayBuffer {
         const fileContents: Buffer = fs.readFileSync(filename);
 
-        const ret = Uint8Array.from(fileContents);
+        const ret = Uint8Array.from(fileContents.slice(44));
 
         return ret.buffer;
     }


### PR DESCRIPTION
The change to MTS service side has increased enforcement of the data in the WAV header, and the SDK needs to send a correct header.

This will send one based on the audio stream format specified when a stream is created.