### PR TITLE
Fix reconnect spamming

### DIFF
--- a/src/common.speech/DialogServiceAdapter.ts
+++ b/src/common.speech/DialogServiceAdapter.ts
@@ -508,6 +508,8 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
                     || this.privDialogConnectionPromise.result().result.state() === ConnectionState.Disconnected)) {
                 this.agentConfigSent = false;
                 this.privDialogConnectionPromise = null;
+                this.terminateMessageLoop = true;
+                return this.configConnection();
             } else {
                 return this.privDialogConnectionPromise;
             }
@@ -717,6 +719,10 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
             } else {
                 return this.privConnectionConfigPromise;
             }
+        }
+
+        if (this.terminateMessageLoop) {
+            return PromiseHelper.fromResult<IConnection>(undefined);
         }
 
         this.privConnectionConfigPromise = this.dialogConnectImpl().onSuccessContinueWithPromise((connection: IConnection): Promise<IConnection> => {


### PR DESCRIPTION
In the current design, the message listener and connection configuration can get into an error state where they repeatedly call one another, resulting in continuous attempts to connect. Ultimately this causes an out-of-memory on the client.

Now, if the termination of the connection/messaging loop has been flagged it will take effect before the next attempt to reconnect.