### PR TITLE
Fix missing null check for Android WebView

### DIFF
--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -611,7 +611,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                             let payload: ArrayBuffer;
                             let sendDelay: number;
 
-                            if (audioStreamChunk.isEnd) {
+                            if (!audioStreamChunk || audioStreamChunk.isEnd) {
                                 payload = null;
                                 sendDelay = 0;
                             } else {


### PR DESCRIPTION
Encountered an undefined reference while trying to get this working in an Ionic app on Android API 29 emulator. This fixes the undefined reference (and matches the approach taken in the [`DialogServiceAdapter`](https://github.com/microsoft/cognitive-services-speech-sdk-js/blob/d30a67c1f9319c72a3eba4446abfee12aa8d9d61/src/common.speech/DialogServiceAdapter.ts#L440)).

Fixes #128 