### PR TITLE
Handle errors on TTS responses

### DIFF
--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -66,7 +66,10 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         const {resourcePath, version, authHeader} = getDialogSpecificValues(dialogType);
 
         const headers: IStringDictionary<string> = {};
-        headers[authInfo.headerName] = authInfo.token;
+
+        if (authInfo.token !== undefined && authInfo.token !== "") {
+            headers[authInfo.headerName] = authInfo.token;
+        }
         headers[QueryParameterNames.ConnectionIdHeader] = connectionId;
 
         let endpoint: string;

--- a/src/common.speech/DialogServiceAdapter.ts
+++ b/src/common.speech/DialogServiceAdapter.ts
@@ -698,6 +698,8 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
                 });
             }, (error: string) => {
                 this.terminateMessageLoop = true;
+                communicationCustodian.resolve(undefined);
+                return PromiseHelper.fromResult<IConnection>(undefined);
             });
 
             return communicationCustodian.promise();
@@ -731,6 +733,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
         }
 
         if (this.terminateMessageLoop) {
+            this.terminateMessageLoop = false;
             return PromiseHelper.fromError(`Connection to service terminated.`);
         }
 


### PR DESCRIPTION
If TTS sends a malformed message, the websocket connection errors and no further activities are received. This change allows the connection to terminate and signal the need for a new connection on the next reco/activity.