### PR TITLE
Read custom endpoint from config properties

### DIFF
--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -71,18 +71,17 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         }
         headers[QueryParameterNames.ConnectionIdHeader] = connectionId;
 
+        if (applicationId !== "") {
+            headers[authHeader] = applicationId;
+        }
+
         let endpoint: string = config.parameters.getProperty(PropertyId.SpeechServiceConnection_Endpoint, "");
         if (endpoint === "") {
-            // ApplicationId is only required for CustomCommands
+            // ApplicationId is only required for CustomCommands, so we're using that to determine default endpoint
             if (applicationId === "") {
                 endpoint = `wss://${region}.${baseUrl}/${pathSuffix}/${version}`;
             } else {
                 endpoint = `wss://${region}.${baseUrl}/${resourcePath}/${pathSuffix}/${version}`;
-                headers[authHeader] = applicationId;
-            }
-        } else {
-            if (applicationId !== "") {
-                headers[authHeader] = applicationId;
             }
         }
 

--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -66,7 +66,7 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         const {resourcePath, version, authHeader} = getDialogSpecificValues(dialogType);
 
         const headers: IStringDictionary<string> = {};
-        if (authInfo.token !== undefined && authInfo.token !== "") {
+        if (authInfo.token != null && authInfo.token !== "") {
             headers[authInfo.headerName] = authInfo.token;
         }
         headers[QueryParameterNames.ConnectionIdHeader] = connectionId;

--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -66,16 +66,24 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         const {resourcePath, version, authHeader} = getDialogSpecificValues(dialogType);
 
         const headers: IStringDictionary<string> = {};
-        headers[authInfo.headerName] = authInfo.token;
+        if (authInfo.token !== undefined && authInfo.token !== "") {
+            headers[authInfo.headerName] = authInfo.token;
+        }
         headers[QueryParameterNames.ConnectionIdHeader] = connectionId;
 
-        let endpoint: string;
-        // ApplicationId is only required for CustomCommands
-        if (applicationId === "") {
-            endpoint = `wss://${region}.${baseUrl}/${pathSuffix}/${version}`;
+        let endpoint: string = config.parameters.getProperty(PropertyId.SpeechServiceConnection_Endpoint, "");
+        if (endpoint === "") {
+            // ApplicationId is only required for CustomCommands
+            if (applicationId === "") {
+                endpoint = `wss://${region}.${baseUrl}/${pathSuffix}/${version}`;
+            } else {
+                endpoint = `wss://${region}.${baseUrl}/${resourcePath}/${pathSuffix}/${version}`;
+                headers[authHeader] = applicationId;
+            }
         } else {
-            endpoint = `wss://${region}.${baseUrl}/${resourcePath}/${pathSuffix}/${version}`;
-            headers[authHeader] = applicationId;
+            if (applicationId !== "") {
+                headers[authHeader] = applicationId;
+            }
         }
 
         this.setCommonUrlParams(config, queryParams, endpoint);


### PR DESCRIPTION
Allows users to set a custom endpoint, else will default to the Dialog or CustomCommands endpoints