### PR TITLE
Capture the error from OnError and append it to the reason .

### DIFF
--- a/src/common.browser/WebsocketMessageAdapter.ts
+++ b/src/common.browser/WebsocketMessageAdapter.ts
@@ -30,7 +30,6 @@ import * as HttpsProxyAgent from "https-proxy-agent";
 import * as tls from "tls";
 import * as ws from "ws";
 import * as ocsp from "../../external/ocsp/ocsp";
-import { throws } from "assert";
 
 interface ISendItem {
     Message: ConnectionMessage;


### PR DESCRIPTION
When a connection fails we can get the underlying error in node and put in the cancel message whcih will improve error detection for node.js users.