### PR TITLE
change default audio output format to 24k Hz in browser

### DIFF
--- a/src/sdk/Audio/AudioOutputFormat.ts
+++ b/src/sdk/Audio/AudioOutputFormat.ts
@@ -307,7 +307,7 @@ export class AudioOutputFormatImpl extends AudioStreamFormatImpl {
 
     public static getDefaultOutputFormat(): AudioOutputFormatImpl {
         return AudioOutputFormatImpl.fromSpeechSynthesisOutputFormatString(
-            (typeof window !== "undefined") ? "audio-16khz-64kbitrate-mono-mp3" : "riff-16khz-16bit-mono-pcm");
+            (typeof window !== "undefined") ? "audio-24khz-48kbitrate-mono-mp3" : "riff-16khz-16bit-mono-pcm");
     }
 
     /**


### PR DESCRIPTION
per PMs' request.
`audio-24khz-48kbitrate-mono-mp3` is also the format used in edge read aloud.