### PR TITLE
Initialize the test hook variable for the OCSP cache

### DIFF
--- a/src/common.browser/CertChecks.ts
+++ b/src/common.browser/CertChecks.ts
@@ -10,6 +10,7 @@ import {
     OCSPCacheEntryExpiredEvent,
     OCSPCacheEntryNeedsRefreshEvent,
     OCSPCacheFetchErrorEvent,
+    OCSPCacheHitEvent,
     OCSPCacheMissEvent,
     OCSPCacheUpdatehCompleteEvent,
     OCSPCacheUpdateNeededEvent,
@@ -36,7 +37,7 @@ import * as net from "net";
 export class CertCheckAgent {
 
     // Test hook to enable forcing expiration / refresh to happen.
-    public static testTimeOffset: number;
+    public static testTimeOffset: number = 0;
 
     // Test hook to disable stapling for cache testing.
     public static forceDisableOCSPStapling: boolean = false;
@@ -223,6 +224,8 @@ export class CertCheckAgent {
                 if ((cachedNextTime - (Date.now() + this.testTimeOffset)) < minUpdate) {
                     this.onEvent(new OCSPCacheEntryNeedsRefreshEvent(signature, cachedStartTime, cachedNextTime));
                     this.UpdateCache(ocspRequest, proxyInfo).catch();
+                } else {
+                    this.onEvent(new OCSPCacheHitEvent(signature, cachedStartTime, cachedNextTime));
                 }
             }
         } catch (error) {

--- a/src/common.browser/CertChecks.ts
+++ b/src/common.browser/CertChecks.ts
@@ -263,9 +263,9 @@ export class CertCheckAgent {
                         }, (error: Error) => {
                             reject(error);
                         });
+                    } else {
+                        reject(error);
                     }
-
-                    reject(error);
                 } else {
                     if (!cacheValue) {
                         CertCheckAgent.StoreCacheEntry(ocspRequest.id.toString("hex"), ocspResponse);

--- a/src/common.browser/CertChecks.ts
+++ b/src/common.browser/CertChecks.ts
@@ -33,6 +33,7 @@ import Agent from "agent-base";
 import Cache from "async-disk-cache";
 import HttpsProxyAgent from "https-proxy-agent";
 import * as net from "net";
+import { OCSPCacheUpdateErrorEvent } from "../common/OCSPEvents";
 
 export class CertCheckAgent {
 
@@ -223,7 +224,10 @@ export class CertCheckAgent {
 
                 if ((cachedNextTime - (Date.now() + this.testTimeOffset)) < minUpdate) {
                     this.onEvent(new OCSPCacheEntryNeedsRefreshEvent(signature, cachedStartTime, cachedNextTime));
-                    this.UpdateCache(ocspRequest, proxyInfo).catch();
+                    this.UpdateCache(ocspRequest, proxyInfo).catch((error: string) => {
+                        // Well, not much we can do here.
+                        this.onEvent(new OCSPCacheUpdateErrorEvent(signature, error.toString()));
+                    });
                 } else {
                     this.onEvent(new OCSPCacheHitEvent(signature, cachedStartTime, cachedNextTime));
                 }

--- a/src/common/OCSPEvents.ts
+++ b/src/common/OCSPEvents.ts
@@ -99,6 +99,22 @@ export class OCSPCacheEntryNeedsRefreshEvent extends OCSPEvent {
 }
 
 // tslint:disable-next-line:max-classes-per-file
+export class OCSPCacheHitEvent extends OCSPEvent {
+    private privExpireTime: number;
+    private privStartTime: number;
+    private privExpireTimeString: string;
+    private privStartTimeString: string;
+
+    constructor(serialNumber: string, startTime: number, expireTime: number) {
+        super("OCSPCacheHitEvent", EventType.Debug, serialNumber);
+        this.privExpireTime = expireTime;
+        this.privExpireTimeString = new Date(expireTime).toLocaleDateString();
+        this.privStartTime = startTime;
+        this.privStartTimeString = new Date(startTime).toLocaleTimeString();
+    }
+}
+
+// tslint:disable-next-line:max-classes-per-file
 export class OCSPVerificationFailedEvent extends OCSPEvent {
     private privError: string;
 

--- a/src/common/OCSPEvents.ts
+++ b/src/common/OCSPEvents.ts
@@ -140,3 +140,13 @@ export class OCSPResponseRetrievedEvent extends OCSPEvent {
         super("OCSPResponseRetrievedEvent", EventType.Debug, serialNumber);
     }
 }
+
+// tslint:disable-next-line:max-classes-per-file
+export class OCSPCacheUpdateErrorEvent extends OCSPEvent {
+    private privError: string;
+
+    constructor(serialNumber: string, error: string) {
+        super("OCSPCacheUpdateErrorEvent", EventType.Debug, serialNumber);
+        this.privError = error;
+    }
+}


### PR DESCRIPTION
Not having the value initialized results in the cache refresh computation failing and the certificate not being proactively refreshed.

Also, added a logging event on a cache hit to show the time left on a OCSP response.