### PR TITLE
Add SendMessageAsync support

### DIFF
--- a/src/common.browser/WebsocketMessageAdapter.ts
+++ b/src/common.browser/WebsocketMessageAdapter.ts
@@ -76,6 +76,10 @@ export class WebsocketMessageAdapter {
         this.privConnectionState = ConnectionState.None;
         this.privUri = uri;
         this.privHeaders = headers;
+
+        // Add the connection ID to the headers
+        this.privHeaders["X-ConnectionId"] = this.privConnectionId;
+
         this.privLastErrorReceived = "";
     }
 

--- a/src/common.speech/RecognizerConfig.ts
+++ b/src/common.speech/RecognizerConfig.ts
@@ -117,7 +117,7 @@ export class System {
 
     constructor() {
         // Note: below will be patched for official builds.
-        const SPEECHSDK_CLIENTSDK_VERSION = "1.6.0-alpha.0.1";
+        const SPEECHSDK_CLIENTSDK_VERSION = "1.13.0-alpha.0.1";
 
         this.name = "SpeechSDK";
         this.version = SPEECHSDK_CLIENTSDK_VERSION;

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -345,6 +345,27 @@ export abstract class ServiceRecognizerBase implements IDisposable {
 
     public sendMessage(message: string): void { }
 
+    public sendNetworkMessage(path: string, payload: string | ArrayBuffer, success?: () => void, err?: (error: string) => void): void {
+        const type: MessageType = typeof payload === "string" ? MessageType.Text : MessageType.Binary;
+        const contentType: string = typeof payload === "string" ? "application/json" : "";
+
+        this.fetchConnection().on((connection: IConnection) => {
+            connection.send(new SpeechConnectionMessage(type, path, this.privRequestSession.requestId, contentType, payload)).on(() => {
+                if (!!success) {
+                    success();
+                }
+            }, (error: string) => {
+                if (!!err) {
+                    err(error);
+                }
+            });
+        }, (error: string) => {
+            if (!!err) {
+                err(error);
+            }
+        });
+    }
+
     public set activityTemplate(messagePayload: string) { this.privActivityTemplate = messagePayload; }
     public get activityTemplate(): string { return this.privActivityTemplate; }
 

--- a/src/sdk/Connection.ts
+++ b/src/sdk/Connection.ts
@@ -126,6 +126,18 @@ export class Connection {
     }
 
     /**
+     * Sends a message to the speech service.
+     * Added in version 1.13.0.
+     * @param path The WebSocket path of the message
+     * @param payload The payload of the message. This is a json string or a ArrayBuffer.
+     * @param success A callback to indicate success.
+     * @param error A callback to indicate an error.
+     */
+    public sendMessageAsync(path: string, payload: string | ArrayBuffer, success?: () => void, error?: (error: string) => void): void {
+        this.privInternalData.sendNetworkMessage(path, payload, success, error);
+    }
+
+    /**
      * Any message from service that is not being processed by any other top level recognizers.
      *
      * Will be removed in 2.0.

--- a/src/sdk/ConnectionMessage.ts
+++ b/src/sdk/ConnectionMessage.ts
@@ -10,6 +10,7 @@ import {
 import {
     PropertyCollection
 } from "./PropertyCollection";
+import { PropertyId } from "./PropertyId";
 
 /**
  * ConnectionMessage represents implementation specific messages sent to and received from
@@ -70,7 +71,13 @@ export class ConnectionMessageImpl {
     constructor(message: IntConnectionMessage) {
         this.privConnectionMessage = message;
         this.privProperties = new PropertyCollection();
+        if (!!this.privConnectionMessage.headers["X-ConnectionId"]) {
+            this.privProperties.setProperty(PropertyId.Speech_SessionId, this.privConnectionMessage.headers["X-ConnectionId"]);
+        }
 
+        Object.keys(this.privConnectionMessage.headers).forEach((header: string, index: number, array: string[]): void => {
+            this.privProperties.setProperty(header, this.privConnectionMessage.headers[header]);
+        });
     }
 
     /**


### PR DESCRIPTION
Similar to what's already in the native code base, allow binary or text messages.

Add tests. One test is to ensure that the messages can be sent before audio is streamed if the audio source is kept bottled up.