### PR TITLE
get safari-friendly audioContext instance

### DIFF
--- a/src/common.browser/MicAudioSource.ts
+++ b/src/common.browser/MicAudioSource.ts
@@ -307,17 +307,7 @@ export class MicAudioSource implements IAudioSource {
             return;
         }
 
-        // https://developer.mozilla.org/en-US/docs/Web/API/AudioContext
-        if (typeof (AudioContext) === "undefined") {
-            throw new Error("Browser does not support Web Audio API (AudioContext is not available).");
-        }
-
-        // Browsers without sampleRate constraint support can't connect nodes with different sample rates
-        if (navigator.mediaDevices.getSupportedConstraints().sampleRate) {
-            this.privContext = new AudioContext({ sampleRate: MicAudioSource.AUDIOFORMAT.samplesPerSec });
-        } else {
-            this.privContext = new AudioContext();
-        }
+        this.privContext = AudioStreamFormat.getAudioContext(MicAudioSource.AUDIOFORMAT.samplesPerSec);
     }
 
     private destroyAudioContext = (): void => {

--- a/src/common.browser/MicAudioSource.ts
+++ b/src/common.browser/MicAudioSource.ts
@@ -307,7 +307,7 @@ export class MicAudioSource implements IAudioSource {
             return;
         }
 
-        this.privContext = AudioStreamFormat.getAudioContext(MicAudioSource.AUDIOFORMAT.samplesPerSec);
+        this.privContext = AudioStreamFormatImpl.getAudioContext(MicAudioSource.AUDIOFORMAT.samplesPerSec);
     }
 
     private destroyAudioContext = (): void => {

--- a/src/sdk/Audio/AudioStreamFormat.ts
+++ b/src/sdk/Audio/AudioStreamFormat.ts
@@ -19,6 +19,31 @@ export abstract class AudioStreamFormat {
     }
 
     /**
+     * Creates an audio context appropriate to current browser
+     * @member AudioStreamFormat.getAudioContext
+     * @function
+     * @public
+     * @returns {AudioContext} An audio context instance
+     */
+    public static getAudioContext(sampleRate?: number): AudioContext {
+        // Workaround for Speech SDK bug in Safari.
+        const AudioContext = (window as any).AudioContext // our preferred impl
+            || (window as any).webkitAudioContext // fallback, mostly when on Safari
+            || false; // could not find.
+
+        // https://developer.mozilla.org/en-US/docs/Web/API/AudioContext
+        if (!!AudioContext) {
+            if (sampleRate !== undefined && navigator.mediaDevices.getSupportedConstraints().sampleRate) {
+                return new AudioContext({ sampleRate });
+            } else {
+                return new AudioContext();
+            }
+        } else {
+            throw new Error("Browser does not support Web Audio API (AudioContext is not available).");
+        }
+    }
+
+    /**
      * Creates an audio stream format object with the specified pcm waveformat characteristics.
      * @member AudioStreamFormat.getWaveFormatPCM
      * @function

--- a/src/sdk/Audio/AudioStreamFormat.ts
+++ b/src/sdk/Audio/AudioStreamFormat.ts
@@ -19,31 +19,6 @@ export abstract class AudioStreamFormat {
     }
 
     /**
-     * Creates an audio context appropriate to current browser
-     * @member AudioStreamFormat.getAudioContext
-     * @function
-     * @public
-     * @returns {AudioContext} An audio context instance
-     */
-    public static getAudioContext(sampleRate?: number): AudioContext {
-        // Workaround for Speech SDK bug in Safari.
-        const AudioContext = (window as any).AudioContext // our preferred impl
-            || (window as any).webkitAudioContext // fallback, mostly when on Safari
-            || false; // could not find.
-
-        // https://developer.mozilla.org/en-US/docs/Web/API/AudioContext
-        if (!!AudioContext) {
-            if (sampleRate !== undefined && navigator.mediaDevices.getSupportedConstraints().sampleRate) {
-                return new AudioContext({ sampleRate });
-            } else {
-                return new AudioContext();
-            }
-        } else {
-            throw new Error("Browser does not support Web Audio API (AudioContext is not available).");
-        }
-    }
-
-    /**
      * Creates an audio stream format object with the specified pcm waveformat characteristics.
      * @member AudioStreamFormat.getWaveFormatPCM
      * @function
@@ -131,6 +106,31 @@ export class AudioStreamFormatImpl extends AudioStreamFormat {
      */
     public static getDefaultInputFormat(): AudioStreamFormatImpl {
         return new AudioStreamFormatImpl();
+    }
+
+    /**
+     * Creates an audio context appropriate to current browser
+     * @member AudioStreamFormatImpl.getAudioContext
+     * @function
+     * @public
+     * @returns {AudioContext} An audio context instance
+     */
+    public static getAudioContext(sampleRate?: number): AudioContext {
+        // Workaround for Speech SDK bug in Safari.
+        const AudioContext = (window as any).AudioContext // our preferred impl
+            || (window as any).webkitAudioContext // fallback, mostly when on Safari
+            || false; // could not find.
+
+        // https://developer.mozilla.org/en-US/docs/Web/API/AudioContext
+        if (!!AudioContext) {
+            if (sampleRate !== undefined && navigator.mediaDevices.getSupportedConstraints().sampleRate) {
+                return new AudioContext({ sampleRate });
+            } else {
+                return new AudioContext();
+            }
+        } else {
+            throw new Error("Browser does not support Web Audio API (AudioContext is not available).");
+        }
     }
 
     /**

--- a/src/sdk/Audio/BaseAudioPlayer.ts
+++ b/src/sdk/Audio/BaseAudioPlayer.ts
@@ -23,9 +23,33 @@ export class BaseAudioPlayer {
     /**
      * Creates and initializes an instance of this class.
      * @constructor
+     * @param {AudioStreamFormat} audioFormat audio stream format recognized by the player.
      */
-    public constructor(audioFormat: AudioStreamFormat) {
+    public constructor(audioFormat?: AudioStreamFormat) {
+        if (audioFormat === undefined) {
+            audioFormat = AudioStreamFormat.getDefaultInputFormat();
+        }
         this.init(audioFormat);
+    }
+
+    /**
+     * play Audio from result using safari-friendly audioContext methods
+     * @member BaseAudioPlayer.prototype.playResultAudio
+     * @function
+     * @public
+     * @param {ArrayBuffer} audioData audio data to be played.
+     */
+    public playResultAudio(audioData: ArrayBuffer): void {
+        if (this.audioContext === null) {
+            this.createAudioContext();
+        }
+        const source: AudioBufferSourceNode = this.audioContext.createBufferSource();
+        const destination: AudioDestinationNode = this.audioContext.destination;
+        this.audioContext.decodeAudioData(audioData, (newBuffer: AudioBuffer): void => {
+            source.buffer = newBuffer;
+            source.connect(destination);
+            source.start(0);
+        });
     }
 
     /**
@@ -69,7 +93,7 @@ export class BaseAudioPlayer {
 
     private createAudioContext(): void {
         // new ((window as any).AudioContext || (window as any).webkitAudioContext)();
-        this.audioContext = new AudioContext();
+        this.audioContext = AudioStreamFormat.getAudioContext();
 
         // TODO: Various examples shows this gain node, it does not seem to be needed unless we plan
         // to control the volume, not likely


### PR DESCRIPTION
... add playResultAudio method to BaseAudioPlayer
Addresses issue "Safari fallback to webkitAudioContext is done in the sample app instead of the SDK."