### PR TITLE
Updates to ID usage, parity with native SDK

### DIFF
--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -72,7 +72,6 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         if (authInfo.token != null && authInfo.token !== "") {
             headers[authInfo.headerName] = authInfo.token;
         }
-        headers[QueryParameterNames.ConnectionIdHeader] = connectionId;
 
         if (applicationId !== "") {
             headers[authHeader] = applicationId;

--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -33,6 +33,7 @@ const customCommands: IBackendValues = {
 };
 
 const pathSuffix: string = "api";
+const connectionID: string = "connectionId";
 
 function getDialogSpecificValues(dialogType: string): IBackendValues {
     switch (dialogType) {
@@ -62,6 +63,7 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         const queryParams: IStringDictionary<string> = {};
         queryParams[QueryParameterNames.LanguageParamName] = language;
         queryParams[QueryParameterNames.FormatParamName] = config.parameters.getProperty(PropertyId.SpeechServiceResponse_OutputFormatOption, OutputFormat[OutputFormat.Simple]).toLowerCase();
+        queryParams[connectionID] = connectionId;
 
         const {resourcePath, version, authHeader} = getDialogSpecificValues(dialogType);
 
@@ -70,7 +72,6 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         if (authInfo.token != null && authInfo.token !== "") {
             headers[authInfo.headerName] = authInfo.token;
         }
-        headers[QueryParameterNames.ConnectionIdHeader] = connectionId;
 
         if (applicationId !== "") {
             headers[authHeader] = applicationId;

--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -72,6 +72,7 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         if (authInfo.token != null && authInfo.token !== "") {
             headers[authInfo.headerName] = authInfo.token;
         }
+        headers[QueryParameterNames.ConnectionIdHeader] = connectionId;
 
         if (applicationId !== "") {
             headers[authHeader] = applicationId;

--- a/src/common.speech/DialogServiceAdapter.ts
+++ b/src/common.speech/DialogServiceAdapter.ts
@@ -59,7 +59,6 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
     private terminateMessageLoop: boolean;
     private agentConfigSent: boolean;
     private privLastResult: SpeechRecognitionResult;
-    private privLastInteractionId: string;
 
     // Turns are of two kinds:
     // 1: SR turns, end when the SR result is returned and then turn end.
@@ -330,7 +329,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
             return Promise.resolve();
         }
 
-        const sessionStartEventArgs: SessionEventArgs = new SessionEventArgs(this.privLastInteractionId);
+        const sessionStartEventArgs: SessionEventArgs = new SessionEventArgs(this.privRequestSession.sessionId);
 
         if (!!this.privRecognizer.sessionStarted) {
             this.privRecognizer.sessionStarted(this.privRecognizer, sessionStartEventArgs);
@@ -543,7 +542,6 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
 
     private sendAgentContext = (connection: IConnection): Promise<void> => {
         const guid: string = createGuid();
-        this.privLastInteractionId = guid;
 
         const speechActivityTemplate = this.privDialogServiceConnector.properties.getProperty(PropertyId.Conversation_Speech_Activity_Template);
 

--- a/src/common.speech/DialogServiceAdapter.ts
+++ b/src/common.speech/DialogServiceAdapter.ts
@@ -59,6 +59,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
     private terminateMessageLoop: boolean;
     private agentConfigSent: boolean;
     private privLastResult: SpeechRecognitionResult;
+    private privLastInteractionId: string;
 
     // Turns are of two kinds:
     // 1: SR turns, end when the SR result is returned and then turn end.
@@ -305,6 +306,8 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
         this.privRequestSession.startNewRecognition();
         this.privRequestSession.listenForServiceTelemetry(this.privDialogAudioSource.events);
 
+        this.privRecognizerConfig.parameters.setProperty(PropertyId.Speech_SessionId, this.privRequestSession.sessionId);
+
         // Start the connection to the service. The promise this will create is stored and will be used by configureConnection().
         const conPromise: Promise<IConnection> = this.connectImpl();
 
@@ -327,7 +330,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
             return Promise.resolve();
         }
 
-        const sessionStartEventArgs: SessionEventArgs = new SessionEventArgs(this.privRequestSession.sessionId);
+        const sessionStartEventArgs: SessionEventArgs = new SessionEventArgs(this.privLastInteractionId);
 
         if (!!this.privRecognizer.sessionStarted) {
             this.privRecognizer.sessionStarted(this.privRecognizer, sessionStartEventArgs);
@@ -540,6 +543,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
 
     private sendAgentContext = (connection: IConnection): Promise<void> => {
         const guid: string = createGuid();
+        this.privLastInteractionId = guid;
 
         const speechActivityTemplate = this.privDialogServiceConnector.properties.getProperty(PropertyId.Conversation_Speech_Activity_Template);
 

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -74,7 +74,6 @@ export abstract class ServiceRecognizerBase implements IDisposable {
     protected privRecognizer: Recognizer;
     protected privSuccessCallback: (e: SpeechRecognitionResult) => void;
     protected privErrorCallback: (e: string) => void;
-    protected privAlignPayload: boolean = false;
 
     public constructor(
         authentication: IAuthentication,
@@ -665,9 +664,11 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                     !this.privRequestSession.isSpeechEnded &&
                     this.privRequestSession.isRecognizing &&
                     this.privRequestSession.recogNumber === startRecogNumber) {
-                    await connection.send(
-                        new SpeechConnectionMessage(
-                            MessageType.Binary, "audio", this.privRequestSession.requestId, null, payload));
+                    connection.send(
+                        new SpeechConnectionMessage(MessageType.Binary, "audio", this.privRequestSession.requestId, null, payload)
+                    ).catch(() => {
+                        this.privRequestSession.onServiceTurnEndResponse(this.privRecognizerConfig.isContinuousRecognition).catch(() => { });
+                    });
 
                     if (!audioStreamChunk?.isEnd) {
                         // this.writeBufferToConsole(payload);

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -514,7 +514,8 @@ export abstract class ServiceRecognizerBase implements IDisposable {
         }
 
         this.privAuthFetchEventId = createNoDashGuid();
-        this.privConnectionId = createNoDashGuid();
+        const sessionId: string = this.privRecognizerConfig.parameters.getProperty(PropertyId.Speech_SessionId, undefined);
+        this.privConnectionId = (sessionId !== undefined) ? sessionId : createNoDashGuid();
 
         this.privRequestSession.onPreConnectionStart(this.privAuthFetchEventId, this.privConnectionId);
 

--- a/src/common.speech/TranscriptionServiceRecognizer.ts
+++ b/src/common.speech/TranscriptionServiceRecognizer.ts
@@ -48,7 +48,6 @@ export class TranscriptionServiceRecognizer extends ServiceRecognizerBase {
         super(authentication, connectionFactory, audioSource, recognizerConfig, transcriber);
         this.privTranscriberRecognizer = transcriber;
         this.sendPrePayloadJSONOverride = this.sendTranscriptionStartJSON;
-        this.privAlignPayload = true;
     }
 
     public async sendSpeechEventAsync(info: ConversationInfo, command: string): Promise<void> {

--- a/tests/ConversationTranscriberTests.ts
+++ b/tests/ConversationTranscriberTests.ts
@@ -386,3 +386,64 @@ test("Create Conversation with one channel audio (aligned)", (done: jest.DoneCal
             done.fail(error);
         });
 });
+test("Create Conversation and force disconnect", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Create Conversation and force disconnect");
+    const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+    // Use 12s timeout since backend timeout is 10s.
+    s.setServiceProperty("maxConnectionDurationSecs", "12", sdk.ServicePropertyChannel.UriQueryParameter);
+    objsToClose.push(s);
+
+    const c: sdk.Conversation = CreateConversation(s);
+    objsToClose.push(c);
+
+    const t: sdk.ConversationTranscriber = BuildTranscriber();
+    t.canceled = (o: sdk.ConversationTranscriber, e: sdk.ConversationTranscriptionCanceledEventArgs) => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+            expect(e.reason).toEqual(sdk.CancellationReason.EndOfStream);
+            done();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    t.joinConversationAsync(c,
+        () => {
+            try {
+                expect(t.properties).not.toBeUndefined();
+                c.addParticipantAsync(GetParticipantKatie(),
+                    () => {
+                        try {
+                            expect(c.participants).not.toBeUndefined();
+                            expect(c.participants.length).toEqual(1);
+                            // Adds steve as a participant to the conversation.
+                            c.addParticipantAsync(GetParticipantSteve(),
+                                () => {
+                                    try {
+                                        expect(c.participants).not.toBeUndefined();
+                                        expect(c.participants.length).toEqual(2);
+                                    } catch (error) {
+                                        done.fail(error);
+                                    }
+
+                                    /* tslint:disable:no-empty */
+                                    t.startTranscribingAsync(
+                                        /* tslint:disable:no-empty */
+                                        () => { },
+                                        (err: string) => {
+                                            done.fail(err);
+                                        });
+                                });
+                        } catch (error) {
+                            done.fail(error);
+                        }
+                    });
+            } catch (error) {
+                done.fail(error);
+            }
+        },
+        (error: string) => {
+            done.fail(error);
+        });
+}, 240000);


### PR DESCRIPTION
Addressing a few issues, I think the first two might be due to overloaded uses of the idea of "session".

In native, for DialogServiceConnector, a turn interaction (like SessionStarted/Stopped) uses the interactionId of the latest context message
https://msasg.visualstudio.com/Skyman/_git/Carbon?path=%2Fsource%2Fcore%2Fsr%2Faudio_stream_session.cpp&version=GBmaster&line=1162&lineEnd=1163&lineStartColumn=1&lineEndColumn=1&lineStyle=plain

Also in native, sessionId is used as the connectionId to correlate logs:
https://msasg.visualstudio.com/Skyman/_git/Carbon?path=%2Fsource%2Fcore%2Fsr%2Fusp_reco_engine_adapter.cpp&version=GBmaster&line=345&lineEnd=347&lineStartColumn=1&lineEndColumn=112&lineStyle=plain

During connection setup the query parameter "connectionId" is not set, instead X-ConnectionId is set which should only be a header param
