### PR TITLE
Update config object to allow detailed service responses

### DIFF
--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -62,7 +62,7 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
 
         const queryParams: IStringDictionary<string> = {};
         queryParams[QueryParameterNames.LanguageParamName] = language;
-        queryParams[QueryParameterNames.FormatParamName] = config.parameters.getProperty(PropertyId.SpeechServiceResponse_OutputFormatOption, OutputFormat[OutputFormat.Simple]).toLowerCase();
+        queryParams[QueryParameterNames.FormatParamName] = config.parameters.getProperty(OutputFormatPropertyName, OutputFormat[OutputFormat.Simple]).toLowerCase();
         queryParams[connectionID] = connectionId;
 
         const {resourcePath, version, authHeader} = getDialogSpecificValues(dialogType);

--- a/src/sdk/DialogServiceConfig.ts
+++ b/src/sdk/DialogServiceConfig.ts
@@ -3,6 +3,7 @@
 
 import { Contracts } from "./Contracts";
 import { PropertyCollection, PropertyId, ServicePropertyChannel, SpeechConfigImpl } from "./Exports";
+import { OutputFormat } from "./OutputFormat";
 
 /**
  * Class that defines base configurations for dialog service connector
@@ -140,6 +141,14 @@ export class DialogServiceConfigImpl extends DialogServiceConfig {
     public set speechRecognitionLanguage(value: string) {
         Contracts.throwIfNullOrWhitespace(value, "value");
         this.privSpeechConfig.speechRecognitionLanguage = value;
+    }
+
+    public get outputFormat(): OutputFormat {
+        return this.privSpeechConfig.outputFormat;
+    }
+
+    public set outputFormat(value: OutputFormat) {
+        this.privSpeechConfig.outputFormat = value;
     }
 
     /**

--- a/tests/DialogServiceConnectorTests.ts
+++ b/tests/DialogServiceConnectorTests.ts
@@ -172,7 +172,7 @@ test("Create DialogServiceConnector, BotFrameworkConfig.fromSubscription", () =>
 test("Output format, default", () => {
     // tslint:disable-next-line:no-console
     console.info("Name: Output format, default");
-    
+
     const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
     objsToClose.push(dialogConfig);
 
@@ -258,7 +258,7 @@ describe.each([true, false])("Service-based tests", (forceNodeWebSocket: boolean
         });
     });
 
-    test("GetDetailedOutputFormat", (done: jest.DoneCallback) => { 
+    test("GetDetailedOutputFormat", (done: jest.DoneCallback) => {
         // tslint:disable-next-line:no-console
         console.info("Name: GetDetailedOutputFormat");
 
@@ -268,12 +268,12 @@ describe.each([true, false])("Service-based tests", (forceNodeWebSocket: boolean
 
         const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
         objsToClose.push(connector);
-        
+
         let recoCounter: number = 0;
         connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
             expect(result).not.toBeUndefined();
-                        
-            let resultProps = result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult);
+
+            const resultProps = result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult);
             (expect(resultProps).toContain("NBest"));
             recoCounter++;
         },


### PR DESCRIPTION
The config object didn't provide methods for setting the OutputFormat, added those and updated the factory to query the appropriate property.
Added a basic test looking for a field in the "detailed" result, currently searching for an "NBest" field in the payload.