### PR TITLE
[Audio Config] - Add support media stream track

### DIFF
--- a/src/common.browser/MicAudioSource.ts
+++ b/src/common.browser/MicAudioSource.ts
@@ -63,7 +63,7 @@ export class MicAudioSource implements IAudioSource {
 
     public constructor(
         private readonly privRecorder: IRecorder,
-        private readonly deviceId?: string,        
+        private readonly deviceId?: string,
         audioSourceId?: string,
         private readonly mediaStream?: MediaStream
         ) {

--- a/src/common.browser/MicAudioSource.ts
+++ b/src/common.browser/MicAudioSource.ts
@@ -65,12 +65,13 @@ export class MicAudioSource implements IAudioSource {
         private readonly privRecorder: IRecorder,
         private readonly deviceId?: string,
         audioSourceId?: string,
-        private readonly mediaStream?: MediaStream
+        mediaStream?: MediaStream
         ) {
 
         this.privOutputChunkSize = MicAudioSource.AUDIOFORMAT.avgBytesPerSec / 10;
         this.privId = audioSourceId ? audioSourceId : createNoDashGuid();
         this.privEvents = new EventSource<AudioSourceEvent>();
+        this.privMediaStream = mediaStream || null;
     }
 
     public get format(): Promise<AudioStreamFormatImpl> {
@@ -125,8 +126,7 @@ export class MicAudioSource implements IAudioSource {
         } else {
             const next = () => {
                 this.onEvent(new AudioSourceInitializingEvent(this.privId)); // no stream id
-                if (this.mediaStream) {
-                    this.privMediaStream = this.mediaStream;
+                if (this.privMediaStream) {
                     this.onEvent(new AudioSourceReadyEvent(this.privId));
                     this.privInitializeDeferral.resolve();
                 } else {

--- a/src/sdk/Audio/AudioConfig.ts
+++ b/src/sdk/Audio/AudioConfig.ts
@@ -68,6 +68,20 @@ export abstract class AudioConfig {
     }
 
     /**
+     * Creates an AudioConfig object representing a microphone with the specified MediaStreamTrack.
+     * @member AudioConfig.fromMediaStreamInput
+     * @function
+     * @public
+     * @param {MediaStream} mediaStream - Specifies the mediaStreamTrack to be used.
+     *        Default microphone is used the value is omitted.
+     * @returns {AudioConfig} The audio input configuration being created.
+     */
+    public static fromMediaStreamInput(mediaStream?: MediaStream): AudioConfig {
+        const pcmRecorder = new PcmRecorder();
+        return new AudioConfigImpl(new MicAudioSource(pcmRecorder, null, null, mediaStream));
+    }
+
+    /**
      * Creates an AudioConfig object representing the specified file.
      * @member AudioConfig.fromWavFileInput
      * @function

--- a/src/sdk/Audio/AudioConfig.ts
+++ b/src/sdk/Audio/AudioConfig.ts
@@ -72,7 +72,7 @@ export abstract class AudioConfig {
      * @member AudioConfig.fromMediaStreamInput
      * @function
      * @public
-     * @param {MediaStream} mediaStream - Specifies the mediaStreamTrack to be used.
+     * @param {MediaStream} mediaStream - Specifies the mediaStream to be used.
      *        Default microphone is used the value is omitted.
      * @returns {AudioConfig} The audio input configuration being created.
      */

--- a/src/sdk/Audio/AudioConfig.ts
+++ b/src/sdk/Audio/AudioConfig.ts
@@ -68,20 +68,6 @@ export abstract class AudioConfig {
     }
 
     /**
-     * Creates an AudioConfig object representing a microphone with the specified MediaStreamTrack.
-     * @member AudioConfig.fromMediaStreamInput
-     * @function
-     * @public
-     * @param {MediaStream} mediaStream - Specifies the mediaStream to be used.
-     *        Default microphone is used the value is omitted.
-     * @returns {AudioConfig} The audio input configuration being created.
-     */
-    public static fromMediaStreamInput(mediaStream?: MediaStream): AudioConfig {
-        const pcmRecorder = new PcmRecorder();
-        return new AudioConfigImpl(new MicAudioSource(pcmRecorder, null, null, mediaStream));
-    }
-
-    /**
      * Creates an AudioConfig object representing the specified file.
      * @member AudioConfig.fromWavFileInput
      * @function
@@ -98,17 +84,22 @@ export abstract class AudioConfig {
      * @member AudioConfig.fromStreamInput
      * @function
      * @public
-     * @param {AudioInputStream | PullAudioInputStreamCallback} audioStream - Specifies the custom audio input
+     * @param {AudioInputStream | PullAudioInputStreamCallback | MediaStream} audioStream - Specifies the custom audio input
      *        stream. Currently, only WAV / PCM is supported.
      * @returns {AudioConfig} The audio input configuration being created.
      */
-    public static fromStreamInput(audioStream: AudioInputStream | PullAudioInputStreamCallback): AudioConfig {
+    public static fromStreamInput(audioStream: AudioInputStream | PullAudioInputStreamCallback
+        | MediaStream): AudioConfig {
         if (audioStream instanceof PullAudioInputStreamCallback) {
             return new AudioConfigImpl(new PullAudioInputStreamImpl(audioStream as PullAudioInputStreamCallback));
         }
 
         if (audioStream instanceof AudioInputStream) {
             return new AudioConfigImpl(audioStream as PushAudioInputStreamImpl);
+        }
+        if (audioStream instanceof MediaStream) {
+            const pcmRecorder = new PcmRecorder();
+            return new AudioConfigImpl(new MicAudioSource(pcmRecorder, null, null, audioStream));
         }
 
         throw new Error("Not Supported Type");


### PR DESCRIPTION
Hi, 

I added a new function in the Audio Config file to allow the injection of a MediaTrack. This is useful when you are using the SDK with a third party library for Video (for example, [Vonage](https://tokbox.com/developer/guides/basics/))