### PR TITLE
fix sending speech.config many times in one TTS session

### DIFF
--- a/src/common.speech/SynthesisAdapterBase.ts
+++ b/src/common.speech/SynthesisAdapterBase.ts
@@ -216,26 +216,29 @@ export class SynthesisAdapterBase implements IDisposable {
         this.privErrorCallback = errorCallBack;
 
         this.privSynthesisTurn.startNewSynthesis(requestId, text, isSSML, audioDestination);
+
         try {
-            const connection: IConnection = await this.fetchConnection();
-            await this.sendSynthesisContext(connection);
-            await this.sendSsmlMessage(connection, ssml, requestId);
-            const synthesisStartEventArgs: SpeechSynthesisEventArgs = new SpeechSynthesisEventArgs(
-                new SpeechSynthesisResult(
-                    requestId,
-                    ResultReason.SynthesizingAudioStarted,
-                )
-            );
-
-            if (!!this.privSpeechSynthesizer.synthesisStarted) {
-                this.privSpeechSynthesizer.synthesisStarted(this.privSpeechSynthesizer, synthesisStartEventArgs);
-            }
-
-            const messageRetrievalPromise = this.receiveMessage();
+            await this.connectImpl();
         } catch (e) {
             this.cancelSynthesisLocal(CancellationReason.Error, CancellationErrorCode.ConnectionFailure, e);
             return Promise.reject(e);
         }
+
+        const connection: IConnection = await this.fetchConnection();
+        await this.sendSynthesisContext(connection);
+        await this.sendSsmlMessage(connection, ssml, requestId);
+        const synthesisStartEventArgs: SpeechSynthesisEventArgs = new SpeechSynthesisEventArgs(
+            new SpeechSynthesisResult(
+                requestId,
+                ResultReason.SynthesizingAudioStarted,
+            )
+        );
+
+        if (!!this.privSpeechSynthesizer.synthesisStarted) {
+            this.privSpeechSynthesizer.synthesisStarted(this.privSpeechSynthesizer, synthesisStartEventArgs);
+        }
+
+        const messageRetrievalPromise = this.receiveMessage();
     }
 
     // Cancels synthesis.

--- a/src/common.speech/SynthesisAdapterBase.ts
+++ b/src/common.speech/SynthesisAdapterBase.ts
@@ -219,26 +219,25 @@ export class SynthesisAdapterBase implements IDisposable {
 
         try {
             await this.connectImpl();
+            const connection: IConnection = await this.fetchConnection();
+            await this.sendSynthesisContext(connection);
+            await this.sendSsmlMessage(connection, ssml, requestId);
+            const synthesisStartEventArgs: SpeechSynthesisEventArgs = new SpeechSynthesisEventArgs(
+                new SpeechSynthesisResult(
+                    requestId,
+                    ResultReason.SynthesizingAudioStarted,
+                )
+            );
+
+            if (!!this.privSpeechSynthesizer.synthesisStarted) {
+                this.privSpeechSynthesizer.synthesisStarted(this.privSpeechSynthesizer, synthesisStartEventArgs);
+            }
+
+            const messageRetrievalPromise = this.receiveMessage();
         } catch (e) {
             this.cancelSynthesisLocal(CancellationReason.Error, CancellationErrorCode.ConnectionFailure, e);
             return Promise.reject(e);
         }
-
-        const connection: IConnection = await this.fetchConnection();
-        await this.sendSynthesisContext(connection);
-        await this.sendSsmlMessage(connection, ssml, requestId);
-        const synthesisStartEventArgs: SpeechSynthesisEventArgs = new SpeechSynthesisEventArgs(
-            new SpeechSynthesisResult(
-                requestId,
-                ResultReason.SynthesizingAudioStarted,
-            )
-        );
-
-        if (!!this.privSpeechSynthesizer.synthesisStarted) {
-            this.privSpeechSynthesizer.synthesisStarted(this.privSpeechSynthesizer, synthesisStartEventArgs);
-        }
-
-        const messageRetrievalPromise = this.receiveMessage();
     }
 
     // Cancels synthesis.

--- a/src/common.speech/SynthesisAdapterBase.ts
+++ b/src/common.speech/SynthesisAdapterBase.ts
@@ -79,8 +79,6 @@ export class SynthesisAdapterBase implements IDisposable {
 
     protected configConnectionOverride: (connection: IConnection) => any = undefined;
 
-    protected fetchConnectionOverride: () => any = undefined;
-
     public set audioOutputFormat(format: AudioOutputFormatImpl) {
         this.privAudioOutputFormat = format;
         this.privSynthesisTurn.audioOutputFormat = format;
@@ -146,9 +144,11 @@ export class SynthesisAdapterBase implements IDisposable {
         this.connectionEvents.attach((connectionEvent: ConnectionEvent): void => {
             if (connectionEvent.name === "ConnectionClosedEvent") {
                 const connectionClosedEvent = connectionEvent as ConnectionClosedEvent;
-                this.cancelSynthesisLocal(CancellationReason.Error,
-                    connectionClosedEvent.statusCode === 1007 ? CancellationErrorCode.BadRequestParameters : CancellationErrorCode.ConnectionFailure,
-                    connectionClosedEvent.reason + " websocket error code: " + connectionClosedEvent.statusCode);
+                if (connectionClosedEvent.statusCode !== 1000) {
+                    this.cancelSynthesisLocal(CancellationReason.Error,
+                        connectionClosedEvent.statusCode === 1007 ? CancellationErrorCode.BadRequestParameters : CancellationErrorCode.ConnectionFailure,
+                        connectionClosedEvent.reason + " websocket error code: " + connectionClosedEvent.statusCode);
+                }
             }
         });
     }
@@ -514,12 +514,25 @@ export class SynthesisAdapterBase implements IDisposable {
             ssml));
     }
 
-    private fetchConnection = (): Promise<IConnection> => {
-        if (this.fetchConnectionOverride !== undefined) {
-            return this.fetchConnectionOverride();
+    private async fetchConnection(): Promise<IConnection> {
+        if (this.privConnectionConfigurationPromise) {
+            return this.privConnectionConfigurationPromise.then((connection: IConnection): Promise<IConnection> => {
+                if (connection.state() === ConnectionState.Disconnected) {
+                    this.privConnectionId = null;
+                    this.privConnectionConfigurationPromise = null;
+                    this.privServiceHasSentMessage = false;
+                    return this.fetchConnection();
+                }
+                return this.privConnectionConfigurationPromise;
+            }, (error: string): Promise<IConnection> => {
+                this.privConnectionId = null;
+                this.privConnectionConfigurationPromise = null;
+                this.privServiceHasSentMessage = false;
+                return this.fetchConnection();
+            });
         }
-
-        return this.configureConnection();
+        this.privConnectionConfigurationPromise = this.configureConnection();
+        return await this.privConnectionConfigurationPromise;
     }
 
     // Takes an established websocket connection to the endpoint and sends speech configuration information.

--- a/src/common.speech/SynthesisTurn.ts
+++ b/src/common.speech/SynthesisTurn.ts
@@ -236,6 +236,7 @@ export class SynthesisTurn {
             this.privIsSynthesizing = false;
             this.privIsSynthesisEnded = true;
             this.privAudioOutputStream.close();
+            this.privInTurn = false;
             if (this.privTurnAudioDestination !== undefined) {
                 this.privTurnAudioDestination.close();
                 this.privTurnAudioDestination = undefined;

--- a/tests/PronunciationAssessmentTests.ts
+++ b/tests/PronunciationAssessmentTests.ts
@@ -87,10 +87,10 @@ test("testPronunciationAssessmentConfig::normal", (done: jest.DoneCallback) => {
     console.info("Name: testPronunciationAssessmentConfig:::normal");
     let pronConfig: sdk.PronunciationAssessmentConfig = new sdk.PronunciationAssessmentConfig("reference");
     let j = JSON.parse(pronConfig.toJSON());
-    expect(j.referenceText === "reference");
-    expect(j.gradingSystem === "FivePoint");
-    expect(j.granularity === "Phoneme");
-    expect(j.dimension === "Comprehensive");
+    expect(j.referenceText).toEqual("reference");
+    expect(j.gradingSystem).toEqual("FivePoint");
+    expect(j.granularity).toEqual("Phoneme");
+    expect(j.dimension).toEqual("Comprehensive");
     expect(j.scenarioId).toBeUndefined();
 
     pronConfig = new sdk.PronunciationAssessmentConfig("reference",
@@ -98,11 +98,11 @@ test("testPronunciationAssessmentConfig::normal", (done: jest.DoneCallback) => {
         PronunciationAssessmentGranularity.Word, true);
     pronConfig.referenceText = "new reference";
     j = JSON.parse(pronConfig.toJSON());
-    expect(j.referenceText === "new reference");
-    expect(j.gradingSystem === "HundredMark");
-    expect(j.granularity === "Word");
-    expect(j.dimension === "Comprehensive");
-    expect(j.enableMiscue === true);
+    expect(j.referenceText).toEqual("new reference");
+    expect(j.gradingSystem).toEqual("HundredMark");
+    expect(j.granularity).toEqual("Word");
+    expect(j.dimension).toEqual("Comprehensive");
+    expect(j.enableMiscue).toBeTruthy();
     done();
 });
 
@@ -111,7 +111,7 @@ test("testPronunciationAssessmentConfig::fromJson", (done: jest.DoneCallback) =>
     console.info("Name: testPronunciationAssessmentConfig::fromJson");
     const jsonString = `{"dimension": "Comprehensive", "enableMiscue": false, "key": "value"}`;
     const pronConfig = sdk.PronunciationAssessmentConfig.fromJSON(jsonString);
-    expect(JSON.parse(pronConfig.toJSON()) === JSON.parse(jsonString));
+    expect(JSON.parse(pronConfig.toJSON())).toEqual(JSON.parse(jsonString));
     done();
 });
 


### PR DESCRIPTION
Currently, the SDK sends `speech.config` before every audio chunk. This PR fixes this issue.