### PR TITLE
Add node-only tests, update file read to accomodate node

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,34 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 module.exports = {
-    transform: {
-        "^.+\\.ts$": "ts-jest",
-    },
-    testRegex: "tests/.*Tests\\.ts$",
-    testPathIgnorePatterns: ["/lib/", "/es2015/", "/node_modules/", "/src/"],
-    moduleFileExtensions: ["ts", "js", "jsx", "json", "node"],
-    collectCoverage: false,
-    "reporters": ["default", "jest-junit"],
-    setupFilesAfterEnv: ["./secrets/TestConfiguration.ts"],
-    testTimeout : 20000
+    projects: [
+        {
+            displayName: "jsdom",
+            transform: {
+                "^.+\\.ts$": "ts-jest",
+            },
+            testRegex: "tests/.*Tests\\.ts$",
+            testPathIgnorePatterns: ["/lib/", "/es2015/", "/node_modules/", "/src/"],
+            moduleFileExtensions: ["ts", "js", "jsx", "json", "node"],
+            testEnvironment: "jsdom",
+            collectCoverage: false,
+            "reporters": ["default", "jest-junit"],
+            setupFilesAfterEnv: ["./secrets/TestConfiguration.ts"],
+            testTimeout : 20000
+        },
+        {
+            displayName: "node",
+            transform: {
+                "^.+\\.ts$": "ts-jest",
+            },
+            testRegex: "tests/.*Tests\\.ts$",
+            testPathIgnorePatterns: ["/lib/", "/es2015/", "/node_modules/", "/src/"],
+            moduleFileExtensions: ["ts", "js", "jsx", "json", "node"],
+            testEnvironment: "node",
+            collectCoverage: false,
+            "reporters": ["default", "jest-junit"],
+            setupFilesAfterEnv: ["./secrets/TestConfiguration.ts"],
+            testTimeout : 30000
+        }
+    ]
 };

--- a/src/common.speech/Transcription/ConversationUtils.ts
+++ b/src/common.speech/Transcription/ConversationUtils.ts
@@ -6,6 +6,9 @@ import { IResponse } from "./ConversationTranslatorInterfaces";
 import { IRequestOptions, RestConfigBase } from "../../common.browser/RestConfigBase";
 import { Callback } from "../../sdk/Transcription/IConversation";
 
+// Node.JS specific xmlhttprequest / browser support.
+import * as XHR from "xmlhttprequest-ts";
+
 /**
  * Config settings for Conversation Translator
  */
@@ -24,7 +27,7 @@ function withQuery(url: string, params: any = {}): any {
     return queryString ? url + (url.indexOf("?") === -1 ? "?" : "&") + queryString : url;
 }
 
-function parseXHRResult(xhr: XMLHttpRequest): IResponse {
+function parseXHRResult(xhr: XMLHttpRequest | XHR.XMLHttpRequest): IResponse {
     return {
         data: xhr.responseText,
         headers: xhr.getAllResponseHeaders(),
@@ -35,7 +38,7 @@ function parseXHRResult(xhr: XMLHttpRequest): IResponse {
     };
 }
 
-function errorResponse(xhr: XMLHttpRequest, message: string | null = null): IResponse {
+function errorResponse(xhr: XMLHttpRequest | XHR.XMLHttpRequest, message: string | null = null): IResponse {
     return {
         data: message || xhr.statusText,
         headers: xhr.getAllResponseHeaders(),
@@ -82,7 +85,13 @@ export function request(
     const headers = options.headers || defaultRequestOptions.headers;
     const timeout = options.timeout || defaultRequestOptions.timeout;
 
-    const xhr = new XMLHttpRequest();
+    let xhr: XMLHttpRequest | XHR.XMLHttpRequest;
+    if (typeof window === "undefined") { // Node
+        xhr = new XHR.XMLHttpRequest();
+
+    } else {
+        xhr = new XMLHttpRequest();
+    }
     xhr.open(method, withQuery(url, queryParams), true);
 
     if (headers) {

--- a/tests/AutoSourceLangDetectionTests.ts
+++ b/tests/AutoSourceLangDetectionTests.ts
@@ -47,8 +47,7 @@ export const BuildRecognizer: (speechConfig?: sdk.SpeechConfig, autoConfig?: sdk
         objsToClose.push(a);
     }
 
-    const f: File = WaveFileAudioInput.LoadFile(fileName === undefined ? Settings.WaveFile : fileName);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(fileName === undefined ? Settings.WaveFile : fileName);
 
     const r: sdk.SpeechRecognizer = sdk.SpeechRecognizer.FromConfig(s, a, config);
     expect(r).not.toBeUndefined();

--- a/tests/ConnectionTests.ts
+++ b/tests/ConnectionTests.ts
@@ -20,7 +20,6 @@ import {
 
 import * as fs from "fs";
 import { allowedNodeEnvironmentFlags } from "process";
-import { PropertyId } from "../src/sdk/Exports";
 
 let objsToClose: any[];
 
@@ -54,8 +53,7 @@ export const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechConfig, file
         objsToClose.push(s);
     }
 
-    const f: File = WaveFileAudioInput.LoadFile(fileName === undefined ? Settings.WaveFile : fileName);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(fileName === undefined ? Settings.WaveFile : fileName);
 
     const language: string = Settings.WaveFileLanguage;
     if (s.speechRecognitionLanguage === undefined) {
@@ -631,7 +629,7 @@ test.skip("Switch RecoModes during a connection (single->cont)", (done: jest.Don
     });
 }, 20000);
 
-test("testAudioMessagesSent", (done: jest.DoneCallback) => {
+Settings.testIfDOMCondition("testAudioMessagesSent", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
     console.info("Name: testAudioMessagesSent");
 

--- a/tests/ConversationTranscriberTests.ts
+++ b/tests/ConversationTranscriberTests.ts
@@ -65,8 +65,7 @@ const BuildSpeechConfig: () => sdk.SpeechTranslationConfig = (): sdk.SpeechTrans
 
 const BuildTranscriber: () => sdk.ConversationTranscriber = (): sdk.ConversationTranscriber => {
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile8ch);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile8ch);
 
     const t: sdk.ConversationTranscriber = new sdk.ConversationTranscriber(config);
     expect(t).not.toBeUndefined();
@@ -76,8 +75,7 @@ const BuildTranscriber: () => sdk.ConversationTranscriber = (): sdk.Conversation
 
 const BuildMonoWaveTranscriber: () => sdk.ConversationTranscriber = (): sdk.ConversationTranscriber => {
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.DependentVerificationWaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.DependentVerificationWaveFile);
 
     const t: sdk.ConversationTranscriber = new sdk.ConversationTranscriber(config);
     expect(t).not.toBeUndefined();
@@ -152,7 +150,7 @@ test("Create Conversation and join to Transcriber", (done: jest.DoneCallback) =>
         });
 });
 
-test("Create Conversation and add participants", (done: jest.DoneCallback) => {
+Settings.testIfDOMCondition("Create Conversation and add participants", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
     console.info("Name: Create Conversation and join to Transcriber");
     const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
@@ -228,9 +226,9 @@ test("Create Conversation and add participants", (done: jest.DoneCallback) => {
         (error: string) => {
             done.fail(error);
         });
-}, 40000);
+}, 400000);
 
-test("Leave Conversation", (done: jest.DoneCallback) => {
+Settings.testIfDOMCondition("Leave Conversation", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
     console.info("Name: Leave Conversation");
     const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
@@ -306,7 +304,7 @@ test("Leave Conversation", (done: jest.DoneCallback) => {
             done.fail(error);
         });
 });
-test("Create Conversation with one channel audio (aligned)", (done: jest.DoneCallback) => {
+Settings.testIfDOMCondition("Create Conversation with one channel audio (aligned)", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
     console.info("Name: Create Conversation with one channel audio (aligned)");
     const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
@@ -385,7 +383,7 @@ test("Create Conversation with one channel audio (aligned)", (done: jest.DoneCal
             done.fail(error);
         });
 });
-test("Create Conversation and force disconnect", (done: jest.DoneCallback) => {
+Settings.testIfDOMCondition("Create Conversation and force disconnect", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
     console.info("Name: Create Conversation and force disconnect");
     const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();

--- a/tests/ConversationTranslatorTests.ts
+++ b/tests/ConversationTranslatorTests.ts
@@ -204,7 +204,7 @@ describe("conversation service tests", () => {
 
         WaitForCondition(() => (c.conversationId !== "" && c.conversationId.length === 5), done);
 
-    }, 20000);
+    }, 80000);
 
     test("Start Conversation, invalid language [400003]", (done: jest.DoneCallback) => {
 
@@ -226,9 +226,9 @@ describe("conversation service tests", () => {
 
         WaitForCondition(() => (errorMessage !== undefined), done);
 
-    }, 20000);
+    }, 80000);
 
-    test("Start Conversation, invalid nickname [400025]", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Start Conversation, invalid nickname [400025]", (done: jest.DoneCallback) => {
 
         let errorMessage: string;
 
@@ -250,9 +250,9 @@ describe("conversation service tests", () => {
 
         WaitForCondition(() => (errorMessage !== undefined), done);
 
-    }, 20000);
+    }, 80000);
 
-    test("Start Conversation, invalid subscription key or region [401000]", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Start Conversation, invalid subscription key or region [401000]", (done: jest.DoneCallback) => {
 
         let errorMessage: string;
 
@@ -273,9 +273,9 @@ describe("conversation service tests", () => {
 
         WaitForCondition(() => (errorMessage !== undefined), done);
 
-    }, 20000);
+    }, 80000);
 
-    test("Start Conversation, join as host and mute participants", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Start Conversation, join as host and mute participants", (done: jest.DoneCallback) => {
 
         // tslint:disable-next-line:no-console
         console.info("Start Conversation, join as host, mute participants");
@@ -356,9 +356,9 @@ describe("conversation service tests", () => {
                 }));
         }
 
-    }, 20000);
+    }, 40000);
 
-    test("Start Conversation, join as host and send message", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Start Conversation, join as host and send message", (done: jest.DoneCallback) => {
 
         // tslint:disable-next-line:no-console
         console.info("Start Conversation, join as host and send message");
@@ -418,9 +418,9 @@ describe("conversation service tests", () => {
 
         WaitForCondition(() => (textMessage.includes("Hello")), done);
 
-    }, 20000);
+    }, 60000);
 
-    test("Start Conversation, join as host and eject participant", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Start Conversation, join as host and eject participant", (done: jest.DoneCallback) => {
 
         // tslint:disable-next-line:no-console
         console.info("Start Conversation, join as host and eject participant");
@@ -504,7 +504,7 @@ describe("conversation service tests", () => {
 
         WaitForCondition(() => (ejected > 0), done);
 
-    }, 30000);
+    }, 60000);
 
 });
 
@@ -543,7 +543,7 @@ describe("conversation translator config tests", () => {
 
 describe("conversation translator service tests", () => {
 
-    test("Join Conversation Translator, invalid conversation code [400027]", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Join Conversation Translator, invalid conversation code [400027]", (done: jest.DoneCallback) => {
 
         // tslint:disable-next-line:no-console
         console.info("Join Conversation Translator, invalid conversation code [400027]");
@@ -575,7 +575,7 @@ describe("conversation translator service tests", () => {
 
     });
 
-    test("Join Conversation Translator, duplicate nickname [400028]", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Join Conversation Translator, duplicate nickname [400028]", (done: jest.DoneCallback) => {
 
         // tslint:disable-next-line:no-console
         console.info("Join Conversation Translator, duplicate nickname [400028]");
@@ -627,9 +627,9 @@ describe("conversation translator service tests", () => {
 
         WaitForCondition(() => (errorMessage !== ""), done);
 
-    }, 20000);
+    }, 80000);
 
-    test("Join Conversation Translator, locked conversation [400044]", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Join Conversation Translator, locked conversation [400044]", (done: jest.DoneCallback) => {
 
         // tslint:disable-next-line:no-console
         console.info("Join Conversation Translator, locked conversation [400044]");
@@ -670,16 +670,15 @@ describe("conversation translator service tests", () => {
 
             WaitForCondition(() => (errorMessage !== ""), done);
         }));
-    }, 20000);
+    }, 80000);
 
-    test("Start Conversation Translator, join as host with speech language and speak", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Start Conversation Translator, join as host with speech language and speak", (done: jest.DoneCallback) => {
 
         // tslint:disable-next-line:no-console
         console.info("Start Conversation, join as host with speech language and speak");
 
         // audio config
-        const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-        const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+        const audioConfig: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
         let final: string = "";
 
         // start a conversation
@@ -724,6 +723,6 @@ describe("conversation translator service tests", () => {
 
         WaitForCondition(() => (final !== ""), done);
 
-    }, 30000);
+    }, 90000);
 
 });

--- a/tests/DialogServiceConnectorTests.ts
+++ b/tests/DialogServiceConnectorTests.ts
@@ -100,8 +100,7 @@ function BuildConnectorFromWaveFile(dialogServiceConfig?: sdk.DialogServiceConfi
         objsToClose.push(connectorConfig);
     }
 
-    const f: File = WaveFileAudioInput.LoadFile(audioFileName === undefined ? Settings.WaveFile : audioFileName);
-    const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const audioConfig: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(audioFileName === undefined ? Settings.WaveFile : audioFileName);
 
     const language: string = Settings.WaveFileLanguage;
     if (connectorConfig.speechRecognitionLanguage === undefined) {
@@ -157,8 +156,7 @@ test("Create DialogServiceConnector, BotFrameworkConfig.fromSubscription", () =>
     const connectorConfig: sdk.BotFrameworkConfig = sdk.BotFrameworkConfig.fromSubscription(Settings.BotSubscription, Settings.BotRegion);
     expect(connectorConfig).not.toBeUndefined();
 
-    const file: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(file);
+    const audioConfig: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const connector: sdk.DialogServiceConnector = new sdk.DialogServiceConnector(connectorConfig, audioConfig);
     objsToClose.push(connector);
@@ -177,930 +175,919 @@ test("Output format, default", () => {
     expect(dialogConfig.outputFormat === sdk.OutputFormat.Simple);
 });
 
-describe.each([true, false])("Service-based tests", (forceNodeWebSocket: boolean) => {
+test("Create BotFrameworkConfig, invalid optional botId", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Create BotFrameworkConfig, invalid optional botId");
 
-    beforeAll(() => {
-        WebsocketMessageAdapter.forceNpmWebSocket = forceNodeWebSocket;
+    const botConfig: sdk.BotFrameworkConfig = sdk.BotFrameworkConfig.fromSubscription(Settings.BotSubscription, Settings.BotRegion, "potato");
+    objsToClose.push(botConfig);
+
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(botConfig);
+
+    // the service should return an error if an invalid botId was specified, even though the subscription is valid
+    connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        done.fail();
+    },
+        (error: string) => {
+            try {
+                expect(error).toContain("1006");
+                done();
+            } catch (error) {
+                done.fail(error);
+            }
+        });
+}, 15000);
+
+test("Connect / Disconnect", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Connect / Disconnect");
+
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    objsToClose.push(dialogConfig);
+
+    const connector: sdk.DialogServiceConnector = new sdk.DialogServiceConnector(dialogConfig);
+    objsToClose.push(connector);
+
+    let connected: boolean = false;
+    let disconnected: boolean = false;
+    const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
+
+    expect(connector).not.toBeUndefined();
+
+    connector.canceled = (sender: sdk.DialogServiceConnector, args: sdk.SpeechRecognitionCanceledEventArgs) => {
+        // tslint:disable-next-line:no-console
+        console.info("Error code: %d, error details: %s, error reason: %d", args.errorCode, args.errorDetails, args.reason);
+    };
+
+    connection.connected = (args: sdk.ConnectionEventArgs) => {
+        connected = true;
+    };
+
+    connection.disconnected = (args: sdk.ConnectionEventArgs) => {
+        disconnected = true;
+    };
+
+    connection.openConnection(undefined, (error: string): void => {
+        done.fail(error);
     });
 
-    afterAll(() => {
-        WebsocketMessageAdapter.forceNpmWebSocket = false;
+    WaitForCondition(() => {
+        return connected;
+    }, () => {
+        connection.closeConnection(() => {
+            if (!!disconnected) {
+                done();
+            } else {
+                done.fail("Did not disconnect before returning");
+            }
+        });
     });
+});
 
-    test("Create BotFrameworkConfig, invalid optional botId", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Create BotFrameworkConfig, invalid optional botId");
+test("GetDetailedOutputFormat", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: GetDetailedOutputFormat");
 
-        const botConfig: sdk.BotFrameworkConfig = sdk.BotFrameworkConfig.fromSubscription(Settings.BotSubscription, Settings.BotRegion, "potato");
-        objsToClose.push(botConfig);
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    dialogConfig.outputFormat = OutputFormat.Detailed;
+    objsToClose.push(dialogConfig);
 
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(botConfig);
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
+    objsToClose.push(connector);
 
-        // the service should return an error if an invalid botId was specified, even though the subscription is valid
-        connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-            done.fail();
-        },
-            (error: string) => {
-                try {
-                    expect(error).toContain("1006");
-                    done();
-                } catch (error) {
-                    done.fail(error);
-                }
-            });
-    }, 15000);
+    let recoCounter: number = 0;
+    connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        expect(result).not.toBeUndefined();
 
-    test("Connect / Disconnect", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: Connect / Disconnect");
-
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        objsToClose.push(dialogConfig);
-
-        const connector: sdk.DialogServiceConnector = new sdk.DialogServiceConnector(dialogConfig);
-        objsToClose.push(connector);
-
-        let connected: boolean = false;
-        let disconnected: boolean = false;
-        const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
-
-        expect(connector).not.toBeUndefined();
-
-        connector.canceled = (sender: sdk.DialogServiceConnector, args: sdk.SpeechRecognitionCanceledEventArgs) => {
-            // tslint:disable-next-line:no-console
-            console.info("Error code: %d, error details: %s, error reason: %d", args.errorCode, args.errorDetails, args.reason);
-        };
-
-        connection.connected = (args: sdk.ConnectionEventArgs) => {
-            connected = true;
-        };
-
-        connection.disconnected = (args: sdk.ConnectionEventArgs) => {
-            disconnected = true;
-        };
-
-        connection.openConnection(undefined, (error: string): void => {
+        const resultProps = result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult);
+        (expect(resultProps).toContain("NBest"));
+        recoCounter++;
+    },
+        (error: string) => {
             done.fail(error);
         });
 
-        WaitForCondition(() => {
-            return connected;
-        }, () => {
-            connection.closeConnection(() => {
-                if (!!disconnected) {
-                    done();
-                } else {
-                    done.fail("Did not disconnect before returning");
-                }
-            });
-        });
-    });
-
-    test("GetDetailedOutputFormat", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: GetDetailedOutputFormat");
-
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        dialogConfig.outputFormat = OutputFormat.Detailed;
-        objsToClose.push(dialogConfig);
-
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
-        objsToClose.push(connector);
-
-        let recoCounter: number = 0;
-        connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-            expect(result).not.toBeUndefined();
-
-            const resultProps = result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult);
-            (expect(resultProps).toContain("NBest"));
-            recoCounter++;
-        },
-            (error: string) => {
-                done.fail(error);
-            });
-
-        WaitForCondition(() => (recoCounter === 1), done);
-    });
-
-    test("ListenOnceAsync", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: ListenOnceAsync");
-
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        objsToClose.push(dialogConfig);
-
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
-        objsToClose.push(connector);
-
-        let sessionId: string;
-        let hypoCounter: number = 0;
-        let recoCounter: number = 0;
-
-        connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-            sessionId = e.sessionId;
-        };
-
-        connector.recognizing = (s: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionEventArgs): void => {
-            hypoCounter++;
-        };
-
-        connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
-            try {
-                expect(e.activity).not.toBeNull();
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.recognized = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionEventArgs) => {
-            recoCounter++;
-        };
-
-        connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-            try {
-                expect(e.errorDetails).toBeUndefined();
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-            expect(e.sessionId).toEqual(sessionId);
-        };
-
-        connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-            expect(result).not.toBeUndefined();
-            expect(result.errorDetails).toBeUndefined();
-            expect(result.text).not.toBeUndefined();
-            expect(hypoCounter).toBeGreaterThanOrEqual(1);
-            expect(recoCounter).toEqual(1);
-            recoCounter++;
-        },
-            (error: string) => {
-                done.fail(error);
-            });
-
-        WaitForCondition(() => (recoCounter === 2), done);
-    });
-
-    test("ListenOnceAsync with audio response", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: ListenOnceAsync with audio response");
-
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        objsToClose.push(dialogConfig);
-
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig, Settings.InputDir + "weatherinthemountain.wav");
-        objsToClose.push(connector);
-
-        let sessionId: string;
-        let hypoCounter: number = 0;
-
-        connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-            sessionId = e.sessionId;
-        };
-
-        connector.recognizing = (s: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionEventArgs): void => {
-            hypoCounter++;
-        };
-
-        // ServiceRecognizerBase.telemetryData = (json: string): void => {
-        //     // Only record telemetry events from this session.
-        //     if (json !== undefined &&
-        //         sessionId !== undefined &&
-        //         json.indexOf(sessionId) > 0) {
-        //         try {
-        //             expect(hypoCounter).toBeGreaterThanOrEqual(1);
-        //             validateTelemetry(json, 1, hypoCounter);
-        //         } catch (error) {
-        //             done.fail(error);
-        //         }
-        //         telemetryEvents++;
-        //     }
-        // };
-
-        const audioBuffer = new ArrayBuffer(320);
-        const audioReadLoop = (audioStream: PullAudioOutputStream, done: jest.DoneCallback) => {
-            audioStream.read(audioBuffer).then((bytesRead: number) => {
-                try {
-                    if (bytesRead === 0) {
-                        PostDoneTest(done, 2000);
-                    }
-
-                } catch (error) {
-                    done.fail(error);
-                }
-
-                if (bytesRead > 0) {
-                    audioReadLoop(audioStream, done);
-                }
-            }, (error: string) => {
-                done.fail(error);
-            });
-        };
-
-        connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
-            try {
-                expect(e.activity).not.toBeNull();
-                if (e.activity.type === "message") {
-                    if (e.activity.speak && (e.activity.speak !== "")) {
-                        expect(e.audioStream).not.toBeNull();
-                        audioReadLoop(e.audioStream, done);
-                    }
-                }
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-            try {
-                // done.fail(e.errorDetails);
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-            expect(e.sessionId).toEqual(sessionId);
-        };
-
-        connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-            expect(result).not.toBeUndefined();
-            expect(result.errorDetails).toBeUndefined();
-            expect(result.text).not.toBeUndefined();
-        },
-            (error: string) => {
-                done.fail(error);
-            });
-    }, 15000);
-
-    test("Successive ListenOnceAsync with audio response", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: Successive ListenOnceAsync with audio response");
-
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        objsToClose.push(dialogConfig);
-
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig, Settings.InputDir + "weatherinthemountain.wav");
-        objsToClose.push(connector);
-
-        let sessionId: string;
-        let hypoCounter: number = 0;
-        let firstReco: boolean = false;
-
-        connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-            sessionId = e.sessionId;
-        };
-
-        connector.recognizing = (s: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionEventArgs): void => {
-            hypoCounter++;
-        };
-
-        const audioBuffer = new ArrayBuffer(320);
-        const audioReadLoop = (audioStream: PullAudioOutputStream, done: jest.DoneCallback) => {
-            audioStream.read(audioBuffer).then((bytesRead: number) => {
-                try {
-                    if (bytesRead === 0) {
-                        PostDoneTest(done, 2000);
-                    }
-                } catch (error) {
-                    done.fail(error);
-                }
-
-                if (bytesRead > 0) {
-                    audioReadLoop(audioStream, done);
-                }
-            }, (error: string) => {
-                done.fail(error);
-            });
-        };
-
-        connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
-            try {
-                expect(e.activity).not.toBeNull();
-                if (e.activity.type === "message") {
-                    if (e.activity.speak && (e.activity.speak !== "")) {
-                        expect(e.audioStream).not.toBeNull();
-                        audioReadLoop(e.audioStream, done);
-                    }
-                }
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-            try {
-                // done.fail(e.errorDetails);
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-            expect(e.sessionId).toEqual(sessionId);
-        };
-
-        connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-            expect(result).not.toBeUndefined();
-            expect(result.errorDetails).toBeUndefined();
-            expect(result.text).not.toBeUndefined();
-            firstReco = true;
-        },
-            (error: string) => {
-                done.fail(error);
-            });
-
-        WaitForCondition(() => {
-            return firstReco;
-        }, () => {
-            connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-                expect(result).not.toBeUndefined();
-                expect(result.errorDetails).toBeUndefined();
-                expect(result.text).not.toBeUndefined();
-            },
-                (error: string) => {
-                    done.fail(error);
-                });
-        });
-    }, 15000);
-
-    test("Successive ListenOnceAsync calls", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: Successive ListenOnceAsync calls");
-
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        objsToClose.push(dialogConfig);
-
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
-        objsToClose.push(connector);
-
-        let sessionId: string;
-
-        let firstReco: boolean = false;
-        let connected: number = 0;
-
-        const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
-
-        connection.connected = (e: sdk.ConnectionEventArgs): void => {
-            connected++;
-        };
-
-        connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-            sessionId = e.sessionId;
-        };
-
-        connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
-            try {
-                expect(e.activity).not.toBeNull();
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-            try {
-                expect(e.errorDetails).toBeUndefined();
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-            expect(e.sessionId).toEqual(sessionId);
-        };
-
-        connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-            expect(result).not.toBeUndefined();
-            expect(result.errorDetails).toBeUndefined();
-            expect(result.text).not.toBeUndefined();
-            firstReco = true;
-        },
-            (error: string) => {
-                done.fail(error);
-            });
-
-        WaitForCondition(() => {
-            return firstReco;
-        }, () => {
-            connector.listenOnceAsync((result2: sdk.SpeechRecognitionResult) => {
-                try {
-                    const recoResult: sdk.SpeechRecognitionResult = result2;
-                    expect(recoResult).not.toBeUndefined();
-                    expect(connected).toEqual(1);
-                    done();
-                } catch (error) {
-                    done.fail(error);
-                }
-            },
-                (error: string) => {
-                    done.fail(error);
-                });
-        });
-    }, 15000);
-
-    test("ListenOnceAsync with silence returned", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: ListenOnceAsync with silence returned");
-
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        objsToClose.push(dialogConfig);
-
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig, Settings.InputDir + "initialSilence5s.wav");
-        objsToClose.push(connector);
-
-        let sessionId: string;
-
-        let firstReco: boolean = false;
-        let connected: number = 0;
-
-        const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
-
-        connection.connected = (e: sdk.ConnectionEventArgs): void => {
-            connected++;
-        };
-
-        connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-            sessionId = e.sessionId;
-        };
-
-        connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
-            try {
-                expect(e.activity).not.toBeNull();
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-            try {
-                expect(e.errorDetails).toBeUndefined();
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-            expect(e.sessionId).toEqual(sessionId);
-        };
-
-        connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-            expect(result.reason).not.toBeUndefined();
-            expect(result.errorDetails).toBeUndefined();
-            firstReco = true;
-        },
-            (error: string) => {
-                done.fail(error);
-            });
-
-        WaitForCondition(() => {
-            return firstReco;
-        }, () => {
-            connector.listenOnceAsync((result2: sdk.SpeechRecognitionResult) => {
-                try {
-                    expect(connected).toEqual(1);
-                    done();
-                } catch (error) {
-                    done.fail(error);
-                }
-            },
-                (error: string) => {
-                    done.fail(error);
-                });
-        });
-    }, 15000);
-
-    // test("ListenOnce succeeds after reconnect", (done: jest.DoneCallback) => {
-    //     // tslint:disable-next-line:no-console
-    //     console.info("Name: ListenOnce succeeds after reconnect");
-
-    //     const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-    //     objsToClose.push(dialogConfig);
-
-    //     // dialogConfig.setProxy("localhost", 8888);
-    //     // dialogConfig.setProperty("Conversation_Communication_Type", "AutoReply");
-
-    //     const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
-    //     objsToClose.push(connector);
-
-    //     let sessionId: string;
-
-    //     let firstReco: boolean = false;
-    //     let connected: number = 0;
-
-    //     const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
-
-    //     connection.connected = (e: sdk.ConnectionEventArgs): void => {
-    //         connected++;
-    //     };
-
-    //     connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-    //         sessionId = e.sessionId;
-    //     };
-
-    //     connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
-    //         try {
-    //             expect(e.activity).not.toBeNull();
-    //         } catch (error) {
-    //             done.fail(error);
-    //         }
-    //     };
-
-    //     connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-    //         try {
-    //             expect(e.errorDetails).toBeUndefined();
-    //         } catch (error) {
-    //             done.fail(error);
-    //         }
-    //     };
-
-    //     connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-    //         expect(e.sessionId).toEqual(sessionId);
-    //     };
-
-    //     connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-    //         expect(result).not.toBeUndefined();
-    //         expect(result.errorDetails).toBeUndefined();
-    //         expect(result.text).not.toBeUndefined();
-    //         firstReco = true;
-    //     },
-    //     (error: string) => {
-    //         done.fail(error);
-    //     });
-
-    //     WaitForCondition(() => {
-    //         return firstReco;
-    //     }, () => {
-    //         connector.listenOnceAsync((result2: sdk.SpeechRecognitionResult) => {
-    //             try {
-    //                 const recoResult: sdk.SpeechRecognitionResult = result2;
-    //                 expect(recoResult).not.toBeUndefined();
-    //                 expect(recoResult.text).toEqual("What's the weather like?");
-    //                 expect(connected).toEqual(1);
-    //                 done();
-    //             } catch (error) {
-    //                 done.fail(error);
-    //             }
-    //         },
-    //         (error: string) => {
-    //             done.fail(error);
-    //         });
-    //     });
-    // }, 360000);
-
-    // test("Multiple ListenOnce", (done: jest.DoneCallback) => {
-    //     // tslint:disable-next-line:no-console
-    //     console.info("Name: Multiple ListenOnce");
-    //     const dialogConfig: sdk.DialogServiceConfig = BuildDialogServiceConfig();
-    //     objsToClose.push(dialogConfig);
-
-    //     // dialogConfig.setProxy("localhost", 8888);
-    //     // dialogConfig.setProperty("Conversation_Communication_Type", "AutoReply");
-
-    //     const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
-    //     objsToClose.push(connector);
-
-    //     const recoAttempts: number = 5;
-    //     let sessionId: string;
-    //     let connected: number = 0;
-    //     let recognized: number = 0;
-
-    //     const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
-
-    //     connection.connected = (e: sdk.ConnectionEventArgs): void => {
-    //         connected++;
-    //     };
-
-    //     connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-    //         sessionId = e.sessionId;
-    //     };
-
-    //     connector.recognized = (s: sdk.DialogServiceConnector, e: SpeechRecognitionEventArgs): void => {
-    //         recognized++;
-    //     };
-
-    //     connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
-    //         try {
-    //             expect(e.activity).not.toBeNull();
-    //         } catch (error) {
-    //             done.fail(error);
-    //         }
-    //     };
-
-    //     connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-    //         try {
-    //             expect(e.errorDetails).toBeUndefined();
-    //         } catch (error) {
-    //             done.fail(error);
-    //         }
-    //     };
-
-    //     connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-    //         expect(e.sessionId).toEqual(sessionId);
-    //     };
-
-    //     let recoDone: boolean = true;
-    //     let recoCall = 0;
-    //     for (; recoCall < recoAttempts; recoCall++) {
-
-    //         connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-    //             expect(result).not.toBeUndefined();
-    //             expect(result.errorDetails).toBeUndefined();
-    //             expect(result.text).not.toBeUndefined();
-    //             recoDone = true;
-    //         },
-    //         (error: string) => {
-    //             done.fail(error);
-    //         });
-
-    //         WaitForCondition(() => {
-    //             return recoDone === true;
-    //         }, () => { recoDone = false; });
-    //     }
-
-    //     WaitForCondition(() => (recoAttempts === recoCall), () => {
-    //         expect(recoCall).toEqual(recoAttempts);
-    //         expect(recognized).toEqual(recoAttempts);
-    //         expect(connected).toEqual(1);
-    //         done();
-    //     });
-    // }, 15000);
-
-    // test("Successive ListenOnce with timeout", (done: jest.DoneCallback) => {
-    //     // tslint:disable-next-line:no-console
-    //     console.info("Name: Successive ListenOnce with timeout");
-    //     const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-    //     objsToClose.push(dialogConfig);
-
-    //     //dialogConfig.setProxy("localhost", 8888);
-    //     // dialogConfig.setProperty("Conversation_Communication_Type", "AutoReply");
-
-    //     const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
-    //     objsToClose.push(connector);
-
-    //     const recoAttempts: number = 5;
-    //     let sessionId: string;
-    //     let connected: number = 0;
-    //     let recognized: number = 0;
-
-    //     const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
-
-    //     connection.connected = (e: sdk.ConnectionEventArgs): void => {
-    //         connected++;
-    //     };
-
-    //     connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-    //         sessionId = e.sessionId;
-    //     };
-
-    //     connector.recognized = (s: sdk.DialogServiceConnector, e: SpeechRecognitionEventArgs): void => {
-    //         recognized++;
-    //     };
-
-    //     connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
-    //         try {
-    //             expect(e.activity).not.toBeNull();
-    //         } catch (error) {
-    //             done.fail(error);
-    //         }
-    //     };
-
-    //     connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-    //         try {
-    //             expect(e.errorDetails).toBeUndefined();
-    //         } catch (error) {
-    //             done.fail(error);
-    //         }
-    //     };
-
-    //     connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-    //         expect(e.sessionId).toEqual(sessionId);
-    //     };
-
-    //     let recoDone: boolean = false;
-
-    //     // tslint:disable-next-line:no-console
-    //     console.info("Starting first reco");
-
-    //     connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-    //         expect(result).not.toBeUndefined();
-    //         expect(result.errorDetails).toBeUndefined();
-    //         expect(result.text).not.toBeUndefined();
-    //         recoDone = true;
-
-    //         // tslint:disable-next-line:no-console
-    //         console.info("First reco done, received result");
-    //     },
-    //     (error: string) => {
-    //         done.fail(error);
-    //     });
-
-    //     WaitForCondition(() => {
-    //         return recoDone;
-    //     }, () => {
-
-    //         // tslint:disable-next-line:no-console
-    //         console.info("Beginning 5 minute sleep to cause websocket timeout");
-
-    //         // Wait for 5+ minutes
-    //         sleep(310000).then( () => {
-
-    //             // tslint:disable-next-line:no-console
-    //             console.info("Websocket timeout complete, starting second reco");
-
-    //             recoDone = false;
-    //             connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
-    //                 expect(result).not.toBeUndefined();
-    //                 expect(result.errorDetails).toBeUndefined();
-    //                 expect(result.text).not.toBeUndefined();
-    //                 recoDone = true;
-
-    //                 // tslint:disable-next-line:no-console
-    //                 console.info("Second reco done");
-    //             },
-    //             (error: string) => {
-    //                 done.fail(error);
-    //             });
-
-    //             WaitForCondition(() => {
-    //                 return recoDone;
-    //             }, () => {
-    //                 done();
-    //             });
-    //         });
-    //     });
-
-    // }, 360000);
-
-    test("Send/Receive messages", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: Send/Receive messages");
-
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        objsToClose.push(dialogConfig);
-
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
-        objsToClose.push(connector);
-
-        let sessionId: string;
-
-        connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-            sessionId = e.sessionId;
-        };
-
-        let activityCount: number = 0;
-        connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
-            try {
-                expect(e.activity).not.toBeNull();
-                activityCount++;
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-            try {
-                expect(e.errorDetails).toBeUndefined();
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-            expect(e.sessionId).toEqual(sessionId);
-        };
-
-        const message: string = JSON.stringify(simpleMessageObj);
-        connector.sendActivityAsync(message);
-
-        WaitForCondition(() => (activityCount >= 1), done);
-    });
-
-    test("Send multiple messages", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: Send multiple messages");
-
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        objsToClose.push(dialogConfig);
-
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
-        objsToClose.push(connector);
-
-        let sessionId: string;
-
-        connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-            sessionId = e.sessionId;
-        };
-
-        let activityCount: number = 0;
-        connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
-            try {
-                expect(e.activity).not.toBeNull();
-                activityCount++;
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-            try {
-                expect(e.errorDetails).toBeUndefined();
-            } catch (error) {
-                done.fail(error);
-            }
-        };
-
-        connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-            expect(e.sessionId).toEqual(sessionId);
-        };
-
-        for (let j = 0; j < 5; j++) {
-            const numberedMessage: any = { speak: "This is speech", text: `"Message ${j}`, type: "message" };
-            const message: string = JSON.stringify(numberedMessage);
-            connector.sendActivityAsync(message);
-            sleep(100).catch();
+    WaitForCondition(() => (recoCounter === 1), done);
+});
+
+test("ListenOnceAsync", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: ListenOnceAsync");
+
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    objsToClose.push(dialogConfig);
+
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
+    objsToClose.push(connector);
+
+    let sessionId: string;
+    let hypoCounter: number = 0;
+    let recoCounter: number = 0;
+
+    connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+        sessionId = e.sessionId;
+    };
+
+    connector.recognizing = (s: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionEventArgs): void => {
+        hypoCounter++;
+    };
+
+    connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+        try {
+            expect(e.activity).not.toBeNull();
+        } catch (error) {
+            done.fail(error);
         }
+    };
 
-        // TODO improve, needs a more accurate verification
-        WaitForCondition(() => (activityCount >= 4), done);
-    });
+    connector.recognized = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionEventArgs) => {
+        recoCounter++;
+    };
 
-    test("Send/Receive messages during ListenOnce", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: Send/Receive messages during ListenOnce");
+    connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
 
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        objsToClose.push(dialogConfig);
+    connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+        expect(e.sessionId).toEqual(sessionId);
+    };
 
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
-        objsToClose.push(connector);
+    connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        expect(result).not.toBeUndefined();
+        expect(result.errorDetails).toBeUndefined();
+        expect(result.text).not.toBeUndefined();
+        expect(hypoCounter).toBeGreaterThanOrEqual(1);
+        expect(recoCounter).toEqual(1);
+        recoCounter++;
+    },
+        (error: string) => {
+            done.fail(error);
+        });
 
-        let sessionId: string;
-        let recoDone: boolean = false;
+    WaitForCondition(() => (recoCounter === 2), done);
+});
 
-        connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
-            sessionId = e.sessionId;
-        };
+Settings.testIfDOMCondition("ListenOnceAsync with audio response", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: ListenOnceAsync with audio response");
 
-        let activityCount: number = 0;
-        connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    objsToClose.push(dialogConfig);
+
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig, Settings.InputDir + "weatherinthemountain.wav");
+    objsToClose.push(connector);
+
+    let sessionId: string;
+    let hypoCounter: number = 0;
+
+    connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+        sessionId = e.sessionId;
+    };
+
+    connector.recognizing = (s: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionEventArgs): void => {
+        hypoCounter++;
+    };
+
+    // ServiceRecognizerBase.telemetryData = (json: string): void => {
+    //     // Only record telemetry events from this session.
+    //     if (json !== undefined &&
+    //         sessionId !== undefined &&
+    //         json.indexOf(sessionId) > 0) {
+    //         try {
+    //             expect(hypoCounter).toBeGreaterThanOrEqual(1);
+    //             validateTelemetry(json, 1, hypoCounter);
+    //         } catch (error) {
+    //             done.fail(error);
+    //         }
+    //         telemetryEvents++;
+    //     }
+    // };
+
+    const audioBuffer = new ArrayBuffer(320);
+    const audioReadLoop = (audioStream: PullAudioOutputStream, done: jest.DoneCallback) => {
+        audioStream.read(audioBuffer).then((bytesRead: number) => {
             try {
-                expect(e.activity).not.toBeNull();
-                activityCount++;
+                if (bytesRead === 0) {
+                    PostDoneTest(done, 2000);
+                }
+
             } catch (error) {
                 done.fail(error);
             }
-        };
 
-        connector.speechStartDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs): void => {
+            if (bytesRead > 0) {
+                audioReadLoop(audioStream, done);
+            }
+        }, (error: string) => {
+            done.fail(error);
+        });
+    };
+
+    connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+        try {
+            expect(e.activity).not.toBeNull();
+            if (e.activity.type === "message") {
+                if (e.activity.speak && (e.activity.speak !== "")) {
+                    expect(e.audioStream).not.toBeNull();
+                    audioReadLoop(e.audioStream, done);
+                }
+            }
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        try {
+            // done.fail(e.errorDetails);
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+        expect(e.sessionId).toEqual(sessionId);
+    };
+
+    connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        expect(result).not.toBeUndefined();
+        expect(result.errorDetails).toBeUndefined();
+        expect(result.text).not.toBeUndefined();
+    },
+        (error: string) => {
+            done.fail(error);
+        });
+}, 15000);
+
+Settings.testIfDOMCondition("Successive ListenOnceAsync with audio response", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Successive ListenOnceAsync with audio response");
+
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    objsToClose.push(dialogConfig);
+
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig, Settings.InputDir + "weatherinthemountain.wav");
+    objsToClose.push(connector);
+
+    let sessionId: string;
+    let hypoCounter: number = 0;
+    let firstReco: boolean = false;
+
+    connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+        sessionId = e.sessionId;
+    };
+
+    connector.recognizing = (s: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionEventArgs): void => {
+        hypoCounter++;
+    };
+
+    const audioBuffer = new ArrayBuffer(320);
+    const audioReadLoop = (audioStream: PullAudioOutputStream, done: jest.DoneCallback) => {
+        audioStream.read(audioBuffer).then((bytesRead: number) => {
             try {
-                const message: string = JSON.stringify(simpleMessageObj);
-                connector.sendActivityAsync(message);
+                if (bytesRead === 0) {
+                    PostDoneTest(done, 2000);
+                }
             } catch (error) {
                 done.fail(error);
             }
-        };
 
-        connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
-            try {
-                expect(e.errorDetails).toBeUndefined();
-            } catch (error) {
-                done.fail(error);
+            if (bytesRead > 0) {
+                audioReadLoop(audioStream, done);
             }
-        };
+        }, (error: string) => {
+            done.fail(error);
+        });
+    };
 
-        connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
-            expect(e.sessionId).toEqual(sessionId);
-        };
+    connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+        try {
+            expect(e.activity).not.toBeNull();
+            if (e.activity.type === "message") {
+                if (e.activity.speak && (e.activity.speak !== "")) {
+                    expect(e.audioStream).not.toBeNull();
+                    audioReadLoop(e.audioStream, done);
+                }
+            }
+        } catch (error) {
+            done.fail(error);
+        }
+    };
 
+    connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        try {
+            // done.fail(e.errorDetails);
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+        expect(e.sessionId).toEqual(sessionId);
+    };
+
+    connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        expect(result).not.toBeUndefined();
+        expect(result.errorDetails).toBeUndefined();
+        expect(result.text).not.toBeUndefined();
+        firstReco = true;
+    },
+        (error: string) => {
+            done.fail(error);
+        });
+
+    WaitForCondition(() => {
+        return firstReco;
+    }, () => {
         connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
             expect(result).not.toBeUndefined();
             expect(result.errorDetails).toBeUndefined();
             expect(result.text).not.toBeUndefined();
-            recoDone = true;
         },
             (error: string) => {
                 done.fail(error);
             });
-
-        WaitForCondition(() => (activityCount > 1 && recoDone), done);
     });
+}, 15000);
 
-    test("SendActivity fails with invalid JSON object", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: SendActivity fails with invalid JSON object");
+Settings.testIfDOMCondition("Successive ListenOnceAsync calls", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Successive ListenOnceAsync calls");
 
-        const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
-        objsToClose.push(dialogConfig);
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    objsToClose.push(dialogConfig);
 
-        const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
-        objsToClose.push(connector);
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
+    objsToClose.push(connector);
 
-        const malformedJSON: string = '{speak: "This is speech", "text" : "This is JSON is malformed", "type": "message" };';
-        connector.sendActivityAsync(malformedJSON, () => { done.fail("Should have failed"); }, (error: string) => {
-            expect(error).toContain("Unexpected token");
-            done();
+    let sessionId: string;
+
+    let firstReco: boolean = false;
+    let connected: number = 0;
+
+    const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
+
+    connection.connected = (e: sdk.ConnectionEventArgs): void => {
+        connected++;
+    };
+
+    connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+        sessionId = e.sessionId;
+    };
+
+    connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+        try {
+            expect(e.activity).not.toBeNull();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+        expect(e.sessionId).toEqual(sessionId);
+    };
+
+    connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        expect(result).not.toBeUndefined();
+        expect(result.errorDetails).toBeUndefined();
+        expect(result.text).not.toBeUndefined();
+        firstReco = true;
+    },
+        (error: string) => {
+            done.fail(error);
         });
+
+    WaitForCondition(() => {
+        return firstReco;
+    }, () => {
+        connector.listenOnceAsync((result2: sdk.SpeechRecognitionResult) => {
+            try {
+                const recoResult: sdk.SpeechRecognitionResult = result2;
+                expect(recoResult).not.toBeUndefined();
+                expect(connected).toEqual(1);
+                done();
+            } catch (error) {
+                done.fail(error);
+            }
+        },
+            (error: string) => {
+                done.fail(error);
+            });
+    });
+}, 15000);
+
+Settings.testIfDOMCondition("ListenOnceAsync with silence returned", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: ListenOnceAsync with silence returned");
+
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    objsToClose.push(dialogConfig);
+
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig, Settings.InputDir + "initialSilence5s.wav");
+    objsToClose.push(connector);
+
+    let sessionId: string;
+
+    let firstReco: boolean = false;
+    let connected: number = 0;
+
+    const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
+
+    connection.connected = (e: sdk.ConnectionEventArgs): void => {
+        connected++;
+    };
+
+    connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+        sessionId = e.sessionId;
+    };
+
+    connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+        try {
+            expect(e.activity).not.toBeNull();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+        expect(e.sessionId).toEqual(sessionId);
+    };
+
+    connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        expect(result.reason).not.toBeUndefined();
+        expect(result.errorDetails).toBeUndefined();
+        firstReco = true;
+    },
+        (error: string) => {
+            done.fail(error);
+        });
+
+    WaitForCondition(() => {
+        return firstReco;
+    }, () => {
+        connector.listenOnceAsync((result2: sdk.SpeechRecognitionResult) => {
+            try {
+                expect(connected).toEqual(1);
+                done();
+            } catch (error) {
+                done.fail(error);
+            }
+        },
+            (error: string) => {
+                done.fail(error);
+            });
+    });
+}, 15000);
+
+// test("ListenOnce succeeds after reconnect", (done: jest.DoneCallback) => {
+//     // tslint:disable-next-line:no-console
+//     console.info("Name: ListenOnce succeeds after reconnect");
+
+//     const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+//     objsToClose.push(dialogConfig);
+
+//     // dialogConfig.setProxy("localhost", 8888);
+//     // dialogConfig.setProperty("Conversation_Communication_Type", "AutoReply");
+
+//     const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
+//     objsToClose.push(connector);
+
+//     let sessionId: string;
+
+//     let firstReco: boolean = false;
+//     let connected: number = 0;
+
+//     const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
+
+//     connection.connected = (e: sdk.ConnectionEventArgs): void => {
+//         connected++;
+//     };
+
+//     connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+//         sessionId = e.sessionId;
+//     };
+
+//     connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+//         try {
+//             expect(e.activity).not.toBeNull();
+//         } catch (error) {
+//             done.fail(error);
+//         }
+//     };
+
+//     connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+//         try {
+//             expect(e.errorDetails).toBeUndefined();
+//         } catch (error) {
+//             done.fail(error);
+//         }
+//     };
+
+//     connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+//         expect(e.sessionId).toEqual(sessionId);
+//     };
+
+//     connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+//         expect(result).not.toBeUndefined();
+//         expect(result.errorDetails).toBeUndefined();
+//         expect(result.text).not.toBeUndefined();
+//         firstReco = true;
+//     },
+//     (error: string) => {
+//         done.fail(error);
+//     });
+
+//     WaitForCondition(() => {
+//         return firstReco;
+//     }, () => {
+//         connector.listenOnceAsync((result2: sdk.SpeechRecognitionResult) => {
+//             try {
+//                 const recoResult: sdk.SpeechRecognitionResult = result2;
+//                 expect(recoResult).not.toBeUndefined();
+//                 expect(recoResult.text).toEqual("What's the weather like?");
+//                 expect(connected).toEqual(1);
+//                 done();
+//             } catch (error) {
+//                 done.fail(error);
+//             }
+//         },
+//         (error: string) => {
+//             done.fail(error);
+//         });
+//     });
+// }, 360000);
+
+// test("Multiple ListenOnce", (done: jest.DoneCallback) => {
+//     // tslint:disable-next-line:no-console
+//     console.info("Name: Multiple ListenOnce");
+//     const dialogConfig: sdk.DialogServiceConfig = BuildDialogServiceConfig();
+//     objsToClose.push(dialogConfig);
+
+//     // dialogConfig.setProxy("localhost", 8888);
+//     // dialogConfig.setProperty("Conversation_Communication_Type", "AutoReply");
+
+//     const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
+//     objsToClose.push(connector);
+
+//     const recoAttempts: number = 5;
+//     let sessionId: string;
+//     let connected: number = 0;
+//     let recognized: number = 0;
+
+//     const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
+
+//     connection.connected = (e: sdk.ConnectionEventArgs): void => {
+//         connected++;
+//     };
+
+//     connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+//         sessionId = e.sessionId;
+//     };
+
+//     connector.recognized = (s: sdk.DialogServiceConnector, e: SpeechRecognitionEventArgs): void => {
+//         recognized++;
+//     };
+
+//     connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+//         try {
+//             expect(e.activity).not.toBeNull();
+//         } catch (error) {
+//             done.fail(error);
+//         }
+//     };
+
+//     connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+//         try {
+//             expect(e.errorDetails).toBeUndefined();
+//         } catch (error) {
+//             done.fail(error);
+//         }
+//     };
+
+//     connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+//         expect(e.sessionId).toEqual(sessionId);
+//     };
+
+//     let recoDone: boolean = true;
+//     let recoCall = 0;
+//     for (; recoCall < recoAttempts; recoCall++) {
+
+//         connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+//             expect(result).not.toBeUndefined();
+//             expect(result.errorDetails).toBeUndefined();
+//             expect(result.text).not.toBeUndefined();
+//             recoDone = true;
+//         },
+//         (error: string) => {
+//             done.fail(error);
+//         });
+
+//         WaitForCondition(() => {
+//             return recoDone === true;
+//         }, () => { recoDone = false; });
+//     }
+
+//     WaitForCondition(() => (recoAttempts === recoCall), () => {
+//         expect(recoCall).toEqual(recoAttempts);
+//         expect(recognized).toEqual(recoAttempts);
+//         expect(connected).toEqual(1);
+//         done();
+//     });
+// }, 15000);
+
+// test("Successive ListenOnce with timeout", (done: jest.DoneCallback) => {
+//     // tslint:disable-next-line:no-console
+//     console.info("Name: Successive ListenOnce with timeout");
+//     const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+//     objsToClose.push(dialogConfig);
+
+//     //dialogConfig.setProxy("localhost", 8888);
+//     // dialogConfig.setProperty("Conversation_Communication_Type", "AutoReply");
+
+//     const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
+//     objsToClose.push(connector);
+
+//     const recoAttempts: number = 5;
+//     let sessionId: string;
+//     let connected: number = 0;
+//     let recognized: number = 0;
+
+//     const connection: sdk.Connection = sdk.Connection.fromRecognizer(connector);
+
+//     connection.connected = (e: sdk.ConnectionEventArgs): void => {
+//         connected++;
+//     };
+
+//     connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+//         sessionId = e.sessionId;
+//     };
+
+//     connector.recognized = (s: sdk.DialogServiceConnector, e: SpeechRecognitionEventArgs): void => {
+//         recognized++;
+//     };
+
+//     connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+//         try {
+//             expect(e.activity).not.toBeNull();
+//         } catch (error) {
+//             done.fail(error);
+//         }
+//     };
+
+//     connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+//         try {
+//             expect(e.errorDetails).toBeUndefined();
+//         } catch (error) {
+//             done.fail(error);
+//         }
+//     };
+
+//     connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+//         expect(e.sessionId).toEqual(sessionId);
+//     };
+
+//     let recoDone: boolean = false;
+
+//     // tslint:disable-next-line:no-console
+//     console.info("Starting first reco");
+
+//     connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+//         expect(result).not.toBeUndefined();
+//         expect(result.errorDetails).toBeUndefined();
+//         expect(result.text).not.toBeUndefined();
+//         recoDone = true;
+
+//         // tslint:disable-next-line:no-console
+//         console.info("First reco done, received result");
+//     },
+//     (error: string) => {
+//         done.fail(error);
+//     });
+
+//     WaitForCondition(() => {
+//         return recoDone;
+//     }, () => {
+
+//         // tslint:disable-next-line:no-console
+//         console.info("Beginning 5 minute sleep to cause websocket timeout");
+
+//         // Wait for 5+ minutes
+//         sleep(310000).then( () => {
+
+//             // tslint:disable-next-line:no-console
+//             console.info("Websocket timeout complete, starting second reco");
+
+//             recoDone = false;
+//             connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+//                 expect(result).not.toBeUndefined();
+//                 expect(result.errorDetails).toBeUndefined();
+//                 expect(result.text).not.toBeUndefined();
+//                 recoDone = true;
+
+//                 // tslint:disable-next-line:no-console
+//                 console.info("Second reco done");
+//             },
+//             (error: string) => {
+//                 done.fail(error);
+//             });
+
+//             WaitForCondition(() => {
+//                 return recoDone;
+//             }, () => {
+//                 done();
+//             });
+//         });
+//     });
+
+// }, 360000);
+
+test("Send/Receive messages", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Send/Receive messages");
+
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    objsToClose.push(dialogConfig);
+
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
+    objsToClose.push(connector);
+
+    let sessionId: string;
+
+    connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+        sessionId = e.sessionId;
+    };
+
+    let activityCount: number = 0;
+    connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+        try {
+            expect(e.activity).not.toBeNull();
+            activityCount++;
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+        expect(e.sessionId).toEqual(sessionId);
+    };
+
+    const message: string = JSON.stringify(simpleMessageObj);
+    connector.sendActivityAsync(message);
+
+    WaitForCondition(() => (activityCount >= 1), done);
+});
+
+test("Send multiple messages", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Send multiple messages");
+
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    objsToClose.push(dialogConfig);
+
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
+    objsToClose.push(connector);
+
+    let sessionId: string;
+
+    connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+        sessionId = e.sessionId;
+    };
+
+    let activityCount: number = 0;
+    connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+        try {
+            expect(e.activity).not.toBeNull();
+            activityCount++;
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+        expect(e.sessionId).toEqual(sessionId);
+    };
+
+    for (let j = 0; j < 5; j++) {
+        const numberedMessage: any = { speak: "This is speech", text: `"Message ${j}`, type: "message" };
+        const message: string = JSON.stringify(numberedMessage);
+        connector.sendActivityAsync(message);
+        sleep(100).catch();
+    }
+
+    // TODO improve, needs a more accurate verification
+    WaitForCondition(() => (activityCount >= 4), done);
+});
+
+test("Send/Receive messages during ListenOnce", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Send/Receive messages during ListenOnce");
+
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    objsToClose.push(dialogConfig);
+
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
+    objsToClose.push(connector);
+
+    let sessionId: string;
+    let recoDone: boolean = false;
+
+    connector.sessionStarted = (s: sdk.DialogServiceConnector, e: sdk.SessionEventArgs): void => {
+        sessionId = e.sessionId;
+    };
+
+    let activityCount: number = 0;
+    connector.activityReceived = (sender: sdk.DialogServiceConnector, e: sdk.ActivityReceivedEventArgs) => {
+        try {
+            expect(e.activity).not.toBeNull();
+            activityCount++;
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.speechStartDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs): void => {
+        try {
+            const message: string = JSON.stringify(simpleMessageObj);
+            connector.sendActivityAsync(message);
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.canceled = (sender: sdk.DialogServiceConnector, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        try {
+            expect(e.errorDetails).toBeUndefined();
+        } catch (error) {
+            done.fail(error);
+        }
+    };
+
+    connector.speechEndDetected = (sender: sdk.DialogServiceConnector, e: sdk.RecognitionEventArgs) => {
+        expect(e.sessionId).toEqual(sessionId);
+    };
+
+    connector.listenOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        expect(result).not.toBeUndefined();
+        expect(result.errorDetails).toBeUndefined();
+        expect(result.text).not.toBeUndefined();
+        recoDone = true;
+    },
+        (error: string) => {
+            done.fail(error);
+        });
+
+    WaitForCondition(() => (activityCount > 1 && recoDone), done);
+});
+
+test("SendActivity fails with invalid JSON object", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: SendActivity fails with invalid JSON object");
+
+    const dialogConfig: sdk.BotFrameworkConfig = BuildBotFrameworkConfig();
+    objsToClose.push(dialogConfig);
+
+    const connector: sdk.DialogServiceConnector = BuildConnectorFromWaveFile(dialogConfig);
+    objsToClose.push(connector);
+
+    const malformedJSON: string = '{speak: "This is speech", "text" : "This is JSON is malformed", "type": "message" };';
+    connector.sendActivityAsync(malformedJSON, () => { done.fail("Should have failed"); }, (error: string) => {
+        expect(error).toContain("Unexpected token");
+        done();
     });
 });

--- a/tests/GeneralRecognizerTests.ts
+++ b/tests/GeneralRecognizerTests.ts
@@ -16,8 +16,7 @@ test("testRecognizer1", () => {
     const s = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
     expect(s).not.toBeUndefined();
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const r = new sdk.IntentRecognizer(s, config);
     expect(r).not.toBeUndefined();
@@ -31,8 +30,7 @@ test("testRecognizer2", () => {
     const s = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
     expect(s).not.toBeUndefined();
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const r = new sdk.SpeechRecognizer(s, config);
     expect(r).not.toBeUndefined();
@@ -46,8 +44,7 @@ test("testRecognizer3", () => {
     const s = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
     expect(s).not.toBeUndefined();
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const r = new sdk.SpeakerRecognizer(s, config);
     expect(r).not.toBeUndefined();

--- a/tests/IntentRecognizerTests.ts
+++ b/tests/IntentRecognizerTests.ts
@@ -56,8 +56,7 @@ const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechConfig, audioFileNa
     }
 
     const fileName: string = undefined === audioFileName ? Settings.LuisWaveFile : audioFileName;
-    const f: File = WaveFileAudioInput.LoadFile(fileName);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(fileName);
 
     const language: string = Settings.WaveFileLanguage;
     if (s.speechRecognitionLanguage === undefined) {
@@ -236,7 +235,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
         testInitialSilenceTimeout(config, done);
     }, 20000);
 
-    test("InitialSilenceTimeout (File)", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("InitialSilenceTimeout (File)", (done: jest.DoneCallback) => {
         // tslint:disable-next-line:no-console
         console.info("Name: InitialSilenceTimeout (File)");
         const audioFormat: AudioStreamFormatImpl = sdk.AudioStreamFormat.getDefaultInputFormat() as AudioStreamFormatImpl;

--- a/tests/PronunciationAssessmentTests.ts
+++ b/tests/PronunciationAssessmentTests.ts
@@ -51,8 +51,7 @@ const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechConfig, audioFileNa
     }
 
     const fileName: string = undefined === audioFileName ? Settings.LuisWaveFile : audioFileName;
-    const f: File = WaveFileAudioInput.LoadFile(fileName);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(fileName);
 
     const language: string = Settings.WaveFileLanguage;
     if (s.speechRecognitionLanguage === undefined) {

--- a/tests/PushInputStreamTests.ts
+++ b/tests/PushInputStreamTests.ts
@@ -187,7 +187,7 @@ test("Stream blocks when not closed", (done: jest.DoneCallback) => {
 
         readLoop();
     }, (error: string) => done.fail(error));
-});
+}, 15000);
 
 test("nonAligned data is fine", (done: jest.DoneCallback) => {
     const ps: PushAudioInputStreamImpl = new PushAudioInputStreamImpl();

--- a/tests/Settings.ts
+++ b/tests/Settings.ts
@@ -92,6 +92,7 @@ export class Settings {
 
     public static CustomVoiceEndpointId: string = "6b231818-6b8c-4452-9a69-2009355d5d7a";
     public static CustomVoiceVoiceName: string = "sdk-test";
+    public static testIfDOMCondition: jest.It = (typeof window === "undefined") ? test.skip : test;
 
     public static initialize(): void {
         Settings.SettingsClassLock = new Settings();

--- a/tests/SpeechConfigTests.ts
+++ b/tests/SpeechConfigTests.ts
@@ -41,9 +41,7 @@ afterEach(async (done: jest.DoneCallback) => {
 
 const BuildSpeechRecognizerFromWaveFile: (speechConfig: sdk.SpeechConfig, fileName?: string) => sdk.SpeechRecognizer = (speechConfig?: sdk.SpeechConfig, fileName?: string): sdk.SpeechRecognizer => {
 
-    const f: File = WaveFileAudioInput.LoadFile(fileName === undefined ? Settings.WaveFile : fileName);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
-
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(fileName === undefined ? Settings.WaveFile : fileName);
     const language: string = Settings.WaveFileLanguage;
     if (speechConfig.speechRecognitionLanguage === undefined) {
         speechConfig.speechRecognitionLanguage = language;
@@ -57,8 +55,7 @@ const BuildSpeechRecognizerFromWaveFile: (speechConfig: sdk.SpeechConfig, fileNa
 
 const BuildIntentRecognizerFromWaveFile: (speechConfig: sdk.SpeechConfig, fileName?: string) => sdk.IntentRecognizer = (speechConfig?: sdk.SpeechConfig, fileName?: string): sdk.IntentRecognizer => {
 
-    const f: File = WaveFileAudioInput.LoadFile(fileName === undefined ? Settings.WaveFile : fileName);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(fileName === undefined ? Settings.WaveFile : fileName);
 
     const language: string = Settings.WaveFileLanguage;
     if (speechConfig.speechRecognitionLanguage === undefined) {
@@ -73,8 +70,7 @@ const BuildIntentRecognizerFromWaveFile: (speechConfig: sdk.SpeechConfig, fileNa
 
 const BuildTranslationRecognizerFromWaveFile: (speechConfig: sdk.SpeechTranslationConfig, fileName?: string) => sdk.TranslationRecognizer = (speechConfig?: sdk.SpeechTranslationConfig, fileName?: string): sdk.TranslationRecognizer => {
 
-    const f: File = WaveFileAudioInput.LoadFile(fileName === undefined ? Settings.WaveFile : fileName);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(fileName === undefined ? Settings.WaveFile : fileName);
 
     const language: string = Settings.WaveFileLanguage;
     if (speechConfig.speechRecognitionLanguage === undefined) {
@@ -205,8 +201,7 @@ test("Properties are passed to recognizer", () => {
 test("Create SR from AudioConfig", () => {
     const s: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s, config);
 
@@ -230,8 +225,7 @@ test("Create recognizer with language and audioConfig", () => {
     const s: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
     s.speechRecognitionLanguage = "en-EN";
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s, config);
 
@@ -275,8 +269,7 @@ test("Intent Recognizer with Wave File.", () => {
     const s: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
     s.speechRecognitionLanguage = "en-US";
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const r: sdk.IntentRecognizer = new sdk.IntentRecognizer(s, config);
 
@@ -430,8 +423,7 @@ test("Translation Recog success", () => {
     s.speechRecognitionLanguage = "en-US";
     s.setProperty(sdk.PropertyId[sdk.PropertyId.SpeechServiceConnection_TranslationVoice], "en-US");
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const r: sdk.TranslationRecognizer = new sdk.TranslationRecognizer(s);
     expect(r).not.toBeUndefined();
@@ -463,7 +455,7 @@ describe("NPM proxy test", () => {
         // Fiddler default port
         s.setProxy("localhost", 8888);
         WebsocketMessageAdapter.forceNpmWebSocket = true;
-        const a: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(WaveFileAudioInput.LoadFile(Settings.WaveFile));
+        const a: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
         const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s, a);
         objsToClose.push(r);
@@ -486,7 +478,7 @@ describe("NPM proxy test", () => {
 
         s.setProxy("localhost", 8880);
         WebsocketMessageAdapter.forceNpmWebSocket = true;
-        const a: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(WaveFileAudioInput.LoadFile(Settings.WaveFile));
+        const a: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
         const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s, a);
         objsToClose.push(r);
@@ -504,13 +496,13 @@ describe("NPM proxy test", () => {
     });
 });
 
-test("Proxy has no effect on browser WebSocket", (done: jest.DoneCallback) => {
+Settings.testIfDOMCondition("Proxy has no effect on browser WebSocket", (done: jest.DoneCallback) => {
     const s: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
     objsToClose.push(s);
 
     // Fiddler default port
     s.setProxy("localhost", 8880);
-    const a: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(WaveFileAudioInput.LoadFile(Settings.WaveFile));
+    const a: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s, a);
     objsToClose.push(r);

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -58,9 +58,7 @@ export const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechConfig, file
         objsToClose.push(s);
     }
 
-    const f: File = WaveFileAudioInput.LoadFile(fileName === undefined ? Settings.WaveFile : fileName);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
-
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(fileName === undefined ? Settings.WaveFile : fileName);
     const language: string = Settings.WaveFileLanguage;
     if (s.speechRecognitionLanguage === undefined) {
         s.speechRecognitionLanguage = language;
@@ -179,8 +177,7 @@ test("testSpeechRecognizer1", () => {
     const speechConfig: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
     expect(speechConfig).not.toBeUndefined();
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(speechConfig, config);
     objsToClose.push(r);
@@ -237,7 +234,7 @@ test("testGetParameters", () => {
     expect(r.endpointId === r.properties.getProperty(sdk.PropertyId.SpeechServiceConnection_EndpointId, null)); // todo: is this really the correct mapping?
 });
 
-test("BadWavFileProducesError", (done: jest.DoneCallback) => {
+Settings.testIfDOMCondition("BadWavFileProducesError", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
     console.info("Name: BadWavFileProducesError");
     const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1362,7 +1359,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             testInitialSilenceTimeout(config, done);
         }, 15000);
 
-        test("InitialSilenceTimeout (File)", (done: jest.DoneCallback) => {
+        Settings.testIfDOMCondition("InitialSilenceTimeout (File)", (done: jest.DoneCallback) => {
             // tslint:disable-next-line:no-console
             console.info("Name: InitialSilenceTimeout (File)");
             const audioFormat: AudioStreamFormatImpl = sdk.AudioStreamFormat.getDefaultInputFormat() as AudioStreamFormatImpl;
@@ -1453,8 +1450,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
             s.speechRecognitionLanguage = "es-MX";
 
-            const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-            const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+            const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
             const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s, config);
             expect(r).not.toBeUndefined();
@@ -1671,8 +1667,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         s.speechRecognitionLanguage = "en-US";
 
-        const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-        const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+        const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
         const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s, config);
         objsToClose.push(r);
@@ -2218,7 +2213,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
     }, 35000);
 });
 
-test("Push Stream Async", (done: jest.DoneCallback) => {
+Settings.testIfDOMCondition("Push Stream Async", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
     console.info("Name: Push Stream Async");
 

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -129,7 +129,7 @@ class PushAudioOutputStreamTestCallback extends sdk.PushAudioOutputStreamCallbac
     }
 }
 
-test("testSpeechSynthesizer1", () => {
+Settings.testIfDOMCondition("testSpeechSynthesizer1", () => {
     // tslint:disable-next-line:no-console
     console.info("Name: testSpeechSynthesizer1");
     const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
@@ -163,15 +163,7 @@ test("testSetAndGetParameters", () => {
         .toEqual(sdk.SpeechSynthesisOutputFormat[sdk.SpeechSynthesisOutputFormat.Audio16Khz128KBitRateMonoMp3]);
 });
 
-describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean) => {
-
-    beforeAll(() => {
-        WebsocketMessageAdapter.forceNpmWebSocket = forceNodeWebSocket;
-    });
-
-    afterAll(() => {
-        WebsocketMessageAdapter.forceNpmWebSocket = false;
-    });
+describe("Service based tests", () => {
 
     test("testSpeechSynthesizerEvent1", (done: jest.DoneCallback) => {
         // tslint:disable-next-line:no-console
@@ -410,7 +402,7 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         });
     });
 
-    test("testSpeechSynthesizer: synthesis with invalid key.", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("testSpeechSynthesizer: synthesis with invalid key.", (done: jest.DoneCallback) => {
         // tslint:disable-next-line:no-console
         console.info("Name: testSpeechSynthesizer synthesis with invalid key.");
         const speechConfig: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription("invalidKey", Settings.SpeechRegion);
@@ -424,10 +416,6 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         s.SynthesisCanceled = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
             try {
                 CheckSynthesisResult(e.result, sdk.ResultReason.Canceled);
-                // only node websocket will contains the status code 401
-                if (forceNodeWebSocket) {
-                    expect(e.result.errorDetails).toContain("401");
-                }
                 const cancellationDetail: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(e.result);
                 expect(cancellationDetail.ErrorCode).toEqual(sdk.CancellationErrorCode.ConnectionFailure);
                 expect(cancellationDetail.reason).toEqual(sdk.CancellationReason.Error);
@@ -439,10 +427,6 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
 
         s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
             CheckSynthesisResult(result, sdk.ResultReason.Canceled);
-            // only node websocket will contains the status code 401
-            if (forceNodeWebSocket) {
-                expect(result.errorDetails).toContain("401");
-            }
             const cancellationDetail: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(result);
             expect(cancellationDetail.ErrorCode).toEqual(sdk.CancellationErrorCode.ConnectionFailure);
             expect(cancellationDetail.reason).toEqual(sdk.CancellationReason.Error);
@@ -553,7 +537,7 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         });
     });
 
-    test("testSpeechSynthesizer: synthesis to push audio output stream.", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("testSpeechSynthesizer: synthesis to push audio output stream.", (done: jest.DoneCallback) => {
         // tslint:disable-next-line:no-console
         console.info("Name: testSpeechSynthesizer synthesis to push audio output stream.");
         const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();

--- a/tests/TranslationRecognizerTests.ts
+++ b/tests/TranslationRecognizerTests.ts
@@ -55,8 +55,7 @@ const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechTranslationConfig) 
         objsToClose.push(s);
     }
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const language: string = Settings.WaveFileLanguage;
     if (s.getProperty(sdk.PropertyId[sdk.PropertyId.SpeechServiceConnection_RecoLanguage]) === undefined) {
@@ -522,7 +521,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
         testInitialSilenceTimeout(config, done);
     }, 15000);
 
-    test("InitialSilenceTimeout (File)", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("InitialSilenceTimeout (File)", (done: jest.DoneCallback) => {
         // tslint:disable-next-line:no-console
         console.info("Name: InitialSilenceTimeout (File)");
         const audioFormat: AudioStreamFormatImpl = sdk.AudioStreamFormat.getDefaultInputFormat() as AudioStreamFormatImpl;
@@ -700,7 +699,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
 
     });
 
-    test("Default mic is used when audio config is not specified. (once)", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Default mic is used when audio config is not specified. (once)", (done: jest.DoneCallback) => {
         // tslint:disable-next-line:no-console
         console.info("Name: Default mic is used when audio config is not specified. (once)");
         const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
@@ -723,7 +722,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
             });
     });
 
-    test("Default mic is used when audio config is not specified. (Cont)", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Default mic is used when audio config is not specified. (Cont)", (done: jest.DoneCallback) => {
         // tslint:disable-next-line:no-console
         console.info("Name: Default mic is used when audio config is not specified. (Cont)");
         const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);

--- a/tests/TranslationSynthTests.ts
+++ b/tests/TranslationSynthTests.ts
@@ -50,8 +50,7 @@ const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechTranslationConfig) 
         objsToClose.push(s);
     }
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const language: string = Settings.WaveFileLanguage;
     if (s.getProperty(sdk.PropertyId[sdk.PropertyId.SpeechServiceConnection_RecoLanguage]) === undefined) {
@@ -86,7 +85,7 @@ test("GetOutputVoiceName", () => {
     expect(r.voiceName).toEqual(voice);
 });
 
-test("TranslateVoiceRoundTrip", (done: jest.DoneCallback) => {
+Settings.testIfDOMCondition("TranslateVoiceRoundTrip", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
     console.info("Name: TranslateVoiceRoundTrip");
     const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
@@ -521,8 +520,7 @@ test("Config is copied on construction", () => {
     s.setProperty("RandomProperty", ranVal);
     s.voiceName = "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)";
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.WaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.WaveFile);
 
     const r: sdk.TranslationRecognizer = new sdk.TranslationRecognizer(s, config);
     expect(r).not.toBeUndefined();

--- a/tests/VoiceProfileClientTests.ts
+++ b/tests/VoiceProfileClientTests.ts
@@ -66,9 +66,7 @@ const BuildRecognizer: (speechConfig?: sdk.SpeechConfig) => sdk.SpeakerRecognize
         objsToClose.push(s);
     }
 
-    const f: File = WaveFileAudioInput.LoadFile(Settings.DependentVerificationWaveFile);
-    const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
-
+    const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.DependentVerificationWaveFile);
     const r: sdk.SpeakerRecognizer = new sdk.SpeakerRecognizer(s, config);
     expect(r).not.toBeUndefined();
 
@@ -91,255 +89,252 @@ test("GetParameters", () => {
     expect(r.properties).not.toBeUndefined();
 });
 
-describe.each([true, false])("Service based tests", () => {
+test("Create and Delete Voice Profile using push stream - Independent Identification", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Create and Delete Voice Profile using push stream - Independent Identification");
+    const s: sdk.SpeechConfig = BuildSpeechConfig();
+    objsToClose.push(s);
 
-    test("Create and Delete Voice Profile using push stream - Independent Identification", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: Create and Delete Voice Profile using push stream - Independent Identification");
-        const s: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(s);
+    const r: sdk.VoiceProfileClient = BuildClient(s);
+    objsToClose.push(r);
 
-        const r: sdk.VoiceProfileClient = BuildClient(s);
-        objsToClose.push(r);
+    const type: sdk.VoiceProfileType = sdk.VoiceProfileType.TextIndependentIdentification;
+    r.createProfileAsync(
+        type,
+        "en-us",
+        (res: sdk.VoiceProfile) => {
+            expect(res).not.toBeUndefined();
+            expect(res.profileId).not.toBeUndefined();
+            expect(res.profileType).not.toBeUndefined();
+            expect(res.profileType).toEqual(type);
+            // Create the push stream we need for the speech sdk.
+            const pushStream: sdk.PushAudioInputStream = sdk.AudioInputStream.createPushStream();
 
-        const type: sdk.VoiceProfileType = sdk.VoiceProfileType.TextIndependentIdentification;
-        r.createProfileAsync(
-            type,
-            "en-us",
-            (res: sdk.VoiceProfile) => {
-                expect(res).not.toBeUndefined();
-                expect(res.profileId).not.toBeUndefined();
-                expect(res.profileType).not.toBeUndefined();
-                expect(res.profileType).toEqual(type);
-                // Create the push stream we need for the speech sdk.
-                const pushStream: sdk.PushAudioInputStream = sdk.AudioInputStream.createPushStream();
-
-                // Open the file and push it to the push stream.
-                fs.createReadStream(Settings.IndependentIdentificationWaveFile).on("data", (arrayBuffer: { buffer: ArrayBuffer }) => {
-                    pushStream.write(arrayBuffer.buffer);
-                }).on("end", () => {
-                    pushStream.close();
+            // Open the file and push it to the push stream.
+            fs.createReadStream(Settings.IndependentIdentificationWaveFile).on("data", (arrayBuffer: { buffer: ArrayBuffer }) => {
+                pushStream.write(arrayBuffer.buffer);
+            }).on("end", () => {
+                pushStream.close();
+            });
+            const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(pushStream);
+            r.enrollProfileAsync(
+                res,
+                config,
+                (enrollResult: sdk.VoiceProfileEnrollmentResult) => {
+                    expect(enrollResult).not.toBeUndefined();
+                    expect(enrollResult.reason).not.toBeUndefined();
+                    expect(enrollResult.reason).toEqual(sdk.ResultReason.EnrolledVoiceProfile);
+                    expect(enrollResult.enrollmentsCount).toEqual(1);
+                    expect(() => sdk.SpeakerVerificationModel.fromProfile(res)).toThrow();
+                    r.resetProfileAsync(
+                        res,
+                        (resetResult: sdk.VoiceProfileResult) => {
+                            expect(resetResult).not.toBeUndefined();
+                            expect(resetResult.reason).not.toBeUndefined();
+                            expect(resetResult.reason).toEqual(sdk.ResultReason.ResetVoiceProfile);
+                            r.deleteProfileAsync(
+                                res,
+                                (result: sdk.VoiceProfileResult) => {
+                                    expect(result).not.toBeUndefined();
+                                    expect(result.reason).toEqual(sdk.ResultReason.DeletedVoiceProfile);
+                                    done();
+                                },
+                                (error: string) => {
+                                    done.fail(error);
+                                });
+                        },
+                        (error: string) => {
+                            done.fail(error);
+                        });
+                },
+                (error: string) => {
+                    done.fail(error);
                 });
-                const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(pushStream);
-                r.enrollProfileAsync(
-                    res,
-                    config,
-                    (enrollResult: sdk.VoiceProfileEnrollmentResult) => {
-                        expect(enrollResult).not.toBeUndefined();
-                        expect(enrollResult.reason).not.toBeUndefined();
-                        expect(enrollResult.reason).toEqual(sdk.ResultReason.EnrolledVoiceProfile);
-                        expect(enrollResult.enrollmentsCount).toEqual(1);
-                        expect(() => sdk.SpeakerVerificationModel.fromProfile(res)).toThrow();
-                        r.resetProfileAsync(
-                            res,
-                            (resetResult: sdk.VoiceProfileResult) => {
-                                expect(resetResult).not.toBeUndefined();
-                                expect(resetResult.reason).not.toBeUndefined();
-                                expect(resetResult.reason).toEqual(sdk.ResultReason.ResetVoiceProfile);
-                                r.deleteProfileAsync(
-                                    res,
-                                    (result: sdk.VoiceProfileResult) => {
-                                        expect(result).not.toBeUndefined();
-                                        expect(result.reason).toEqual(sdk.ResultReason.DeletedVoiceProfile);
-                                        done();
-                                    },
-                                    (error: string) => {
-                                        done.fail(error);
-                                    });
-                            },
-                            (error: string) => {
-                                done.fail(error);
-                            });
-                    },
-                    (error: string) => {
-                        done.fail(error);
-                    });
 
-            },
-            (error: string) => {
-                done.fail(error);
-            });
-    });
+        },
+        (error: string) => {
+            done.fail(error);
+        });
+}, 15000);
 
-    test("Create and Delete Voice Profile - Independent Identification", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: Create and Delete Voice Profile - Independent Identification");
-        const s: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(s);
+test("Create and Delete Voice Profile - Independent Identification", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Create and Delete Voice Profile - Independent Identification");
+    const s: sdk.SpeechConfig = BuildSpeechConfig();
+    objsToClose.push(s);
 
-        const r: sdk.VoiceProfileClient = BuildClient(s);
-        objsToClose.push(r);
+    const r: sdk.VoiceProfileClient = BuildClient(s);
+    objsToClose.push(r);
 
-        const type: sdk.VoiceProfileType = sdk.VoiceProfileType.TextIndependentIdentification;
-        r.createProfileAsync(
-            type,
-            "en-us",
-            (res: sdk.VoiceProfile) => {
-                expect(res).not.toBeUndefined();
-                expect(res.profileId).not.toBeUndefined();
-                expect(res.profileType).not.toBeUndefined();
-                expect(res.profileType).toEqual(type);
-                const f: File = WaveFileAudioInput.LoadFile(Settings.IndependentIdentificationWaveFile);
-                const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(f);
-                r.enrollProfileAsync(
-                    res,
-                    config,
-                    (enrollResult: sdk.VoiceProfileEnrollmentResult) => {
-                        expect(enrollResult).not.toBeUndefined();
-                        expect(enrollResult.reason).not.toBeUndefined();
-                        expect(enrollResult.reason).toEqual(sdk.ResultReason.EnrolledVoiceProfile);
-                        expect(enrollResult.enrollmentsCount).toEqual(1);
-                        expect(() => sdk.SpeakerVerificationModel.fromProfile(res)).toThrow();
-                        r.resetProfileAsync(
-                            res,
-                            (resetResult: sdk.VoiceProfileResult) => {
-                                expect(resetResult).not.toBeUndefined();
-                                expect(resetResult.reason).not.toBeUndefined();
-                                expect(resetResult.reason).toEqual(sdk.ResultReason.ResetVoiceProfile);
-                                r.deleteProfileAsync(
-                                    res,
-                                    (result: sdk.VoiceProfileResult) => {
-                                        expect(result).not.toBeUndefined();
-                                        expect(result.reason).toEqual(sdk.ResultReason.DeletedVoiceProfile);
-                                        done();
-                                    },
-                                    (error: string) => {
-                                        done.fail(error);
-                                    });
-                            },
-                            (error: string) => {
-                                done.fail(error);
-                            });
-                    },
-                    (error: string) => {
-                        done.fail(error);
-                    });
+    const type: sdk.VoiceProfileType = sdk.VoiceProfileType.TextIndependentIdentification;
+    r.createProfileAsync(
+        type,
+        "en-us",
+        (res: sdk.VoiceProfile) => {
+            expect(res).not.toBeUndefined();
+            expect(res.profileId).not.toBeUndefined();
+            expect(res.profileType).not.toBeUndefined();
+            expect(res.profileType).toEqual(type);
 
-            },
-            (error: string) => {
-                done.fail(error);
-            });
-    });
-
-    test("Create and Delete Voice Profile - Independent Verification", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: Create and Delete Voice Profile - Independent Verification");
-        const s: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(s);
-
-        const r: sdk.VoiceProfileClient = BuildClient(s);
-        objsToClose.push(r);
-
-        const type: sdk.VoiceProfileType = sdk.VoiceProfileType.TextIndependentVerification;
-        r.createProfileAsync(
-            type,
-            "en-us",
-            (res: sdk.VoiceProfile) => {
-                expect(res).not.toBeUndefined();
-                expect(res.profileId).not.toBeUndefined();
-                expect(res.profileType).not.toBeUndefined();
-                expect(res.profileType).toEqual(type);
-                expect(() => sdk.SpeakerIdentificationModel.fromProfiles([res])).toThrow();
-                r.deleteProfileAsync(
-                    res,
-                    (result: sdk.VoiceProfileResult) => {
-                        expect(result).not.toBeUndefined();
-                        expect(result.reason).toEqual(sdk.ResultReason.DeletedVoiceProfile);
-                        done();
-                    },
-                    (error: string) => {
-                        done.fail(error);
-                    });
-            },
-            (error: string) => {
-                done.fail(error);
-            });
-    });
-
-    test("Create and Delete Voice Profile - Dependent Verification", (done: jest.DoneCallback) => {
-        // tslint:disable-next-line:no-console
-        console.info("Name: Create and Delete Voice Profile - Dependent Verification");
-        const s: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(s);
-
-        const r: sdk.VoiceProfileClient = BuildClient(s);
-        objsToClose.push(r);
-
-        const type: sdk.VoiceProfileType = sdk.VoiceProfileType.TextDependentVerification;
-        r.createProfileAsync(
-            type,
-            "en-us",
-            (res: sdk.VoiceProfile) => {
-                expect(res).not.toBeUndefined();
-                expect(res.profileId).not.toBeUndefined();
-                expect(res.profileType).not.toBeUndefined();
-                expect(res.profileType).toEqual(type);
-                const configs: sdk.AudioConfig[] = [];
-                Settings.VerificationWaveFiles.forEach((file: string) => {
-                    configs.push(sdk.AudioConfig.fromWavFileInput(WaveFileAudioInput.LoadFile(file)));
+            const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.IndependentIdentificationWaveFile);
+            r.enrollProfileAsync(
+                res,
+                config,
+                (enrollResult: sdk.VoiceProfileEnrollmentResult) => {
+                    expect(enrollResult).not.toBeUndefined();
+                    expect(enrollResult.reason).not.toBeUndefined();
+                    expect(enrollResult.reason).toEqual(sdk.ResultReason.EnrolledVoiceProfile);
+                    expect(enrollResult.enrollmentsCount).toEqual(1);
+                    expect(() => sdk.SpeakerVerificationModel.fromProfile(res)).toThrow();
+                    r.resetProfileAsync(
+                        res,
+                        (resetResult: sdk.VoiceProfileResult) => {
+                            expect(resetResult).not.toBeUndefined();
+                            expect(resetResult.reason).not.toBeUndefined();
+                            expect(resetResult.reason).toEqual(sdk.ResultReason.ResetVoiceProfile);
+                            r.deleteProfileAsync(
+                                res,
+                                (result: sdk.VoiceProfileResult) => {
+                                    expect(result).not.toBeUndefined();
+                                    expect(result.reason).toEqual(sdk.ResultReason.DeletedVoiceProfile);
+                                    done();
+                                },
+                                (error: string) => {
+                                    done.fail(error);
+                                });
+                        },
+                        (error: string) => {
+                            done.fail(error);
+                        });
+                },
+                (error: string) => {
+                    done.fail(error);
                 });
-                r.enrollProfileAsync(
-                    res,
-                    configs[0],
-                    (enrollResult1: sdk.VoiceProfileEnrollmentResult) => {
-                        expect(enrollResult1).not.toBeUndefined();
-                        expect(enrollResult1.reason).not.toBeUndefined();
-                        expect(enrollResult1.reason).toEqual(sdk.ResultReason.EnrollingVoiceProfile);
-                        expect(enrollResult1.enrollmentsCount).toEqual(1);
-                        r.enrollProfileAsync(
-                            res,
-                            configs[1],
-                            (enrollResult2: sdk.VoiceProfileEnrollmentResult) => {
-                                expect(enrollResult2).not.toBeUndefined();
-                                expect(enrollResult2.reason).not.toBeUndefined();
-                                expect(enrollResult2.reason).toEqual(sdk.ResultReason.EnrollingVoiceProfile);
-                                expect(enrollResult2.enrollmentsCount).toEqual(2);
-                                r.enrollProfileAsync(
-                                    res,
-                                    configs[2],
-                                    (enrollResult3: sdk.VoiceProfileEnrollmentResult) => {
-                                        expect(enrollResult3).not.toBeUndefined();
-                                        expect(enrollResult3.reason).not.toBeUndefined();
-                                        expect(enrollResult3.reason).toEqual(sdk.ResultReason.EnrolledVoiceProfile);
-                                        expect(enrollResult3.enrollmentsCount).toEqual(3);
-                                        const reco: sdk.SpeakerRecognizer = BuildRecognizer();
-                                        const m: sdk.SpeakerVerificationModel = sdk.SpeakerVerificationModel.fromProfile(res);
-                                        reco.recognizeOnceAsync(
-                                            m,
-                                            (recognizeResult: sdk.SpeakerRecognitionResult) => {
-                                                expect(recognizeResult).not.toBeUndefined();
-                                                expect(recognizeResult.reason).not.toBeUndefined();
-                                                expect(recognizeResult.reason).toEqual(sdk.ResultReason.RecognizedSpeaker);
-                                                expect(recognizeResult.profileId).toEqual(res.profileId);
-                                                r.deleteProfileAsync(
-                                                    res,
-                                                    (result: sdk.VoiceProfileResult) => {
-                                                        expect(result).not.toBeUndefined();
-                                                        expect(result.reason).toEqual(sdk.ResultReason.DeletedVoiceProfile);
-                                                        done();
-                                                    },
-                                                    (error: string) => {
-                                                        done.fail(error);
-                                                    });
-                                            },
-                                            (error: string) => {
-                                                done.fail(error);
-                                            });
-                                    },
-                                    (error: string) => {
-                                        done.fail(error);
-                                    });
-                            },
-                            (error: string) => {
-                                done.fail(error);
-                            });
-                    },
-                    (error: string) => {
-                        done.fail(error);
-                    });
-            },
-            (error: string) => {
-                done.fail(error);
+
+        },
+        (error: string) => {
+            done.fail(error);
+        });
+}, 15000);
+
+test("Create and Delete Voice Profile - Independent Verification", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Create and Delete Voice Profile - Independent Verification");
+    const s: sdk.SpeechConfig = BuildSpeechConfig();
+    objsToClose.push(s);
+
+    const r: sdk.VoiceProfileClient = BuildClient(s);
+    objsToClose.push(r);
+
+    const type: sdk.VoiceProfileType = sdk.VoiceProfileType.TextIndependentVerification;
+    r.createProfileAsync(
+        type,
+        "en-us",
+        (res: sdk.VoiceProfile) => {
+            expect(res).not.toBeUndefined();
+            expect(res.profileId).not.toBeUndefined();
+            expect(res.profileType).not.toBeUndefined();
+            expect(res.profileType).toEqual(type);
+            expect(() => sdk.SpeakerIdentificationModel.fromProfiles([res])).toThrow();
+            r.deleteProfileAsync(
+                res,
+                (result: sdk.VoiceProfileResult) => {
+                    expect(result).not.toBeUndefined();
+                    expect(result.reason).toEqual(sdk.ResultReason.DeletedVoiceProfile);
+                    done();
+                },
+                (error: string) => {
+                    done.fail(error);
+                });
+        },
+        (error: string) => {
+            done.fail(error);
+        });
+}, 15000);
+
+test("Create and Delete Voice Profile - Dependent Verification", (done: jest.DoneCallback) => {
+    // tslint:disable-next-line:no-console
+    console.info("Name: Create and Delete Voice Profile - Dependent Verification");
+    const s: sdk.SpeechConfig = BuildSpeechConfig();
+    objsToClose.push(s);
+
+    const r: sdk.VoiceProfileClient = BuildClient(s);
+    objsToClose.push(r);
+
+    const type: sdk.VoiceProfileType = sdk.VoiceProfileType.TextDependentVerification;
+    r.createProfileAsync(
+        type,
+        "en-us",
+        (res: sdk.VoiceProfile) => {
+            expect(res).not.toBeUndefined();
+            expect(res.profileId).not.toBeUndefined();
+            expect(res.profileType).not.toBeUndefined();
+            expect(res.profileType).toEqual(type);
+            const configs: sdk.AudioConfig[] = [];
+            Settings.VerificationWaveFiles.forEach((file: string) => {
+                configs.push(WaveFileAudioInput.getAudioConfigFromFile(file));
             });
-    });
-});
+            r.enrollProfileAsync(
+                res,
+                configs[0],
+                (enrollResult1: sdk.VoiceProfileEnrollmentResult) => {
+                    expect(enrollResult1).not.toBeUndefined();
+                    expect(enrollResult1.reason).not.toBeUndefined();
+                    expect(enrollResult1.reason).toEqual(sdk.ResultReason.EnrollingVoiceProfile);
+                    expect(enrollResult1.enrollmentsCount).toEqual(1);
+                    r.enrollProfileAsync(
+                        res,
+                        configs[1],
+                        (enrollResult2: sdk.VoiceProfileEnrollmentResult) => {
+                            expect(enrollResult2).not.toBeUndefined();
+                            expect(enrollResult2.reason).not.toBeUndefined();
+                            expect(enrollResult2.reason).toEqual(sdk.ResultReason.EnrollingVoiceProfile);
+                            expect(enrollResult2.enrollmentsCount).toEqual(2);
+                            r.enrollProfileAsync(
+                                res,
+                                configs[2],
+                                (enrollResult3: sdk.VoiceProfileEnrollmentResult) => {
+                                    expect(enrollResult3).not.toBeUndefined();
+                                    expect(enrollResult3.reason).not.toBeUndefined();
+                                    expect(enrollResult3.reason).toEqual(sdk.ResultReason.EnrolledVoiceProfile);
+                                    expect(enrollResult3.enrollmentsCount).toEqual(3);
+                                    const reco: sdk.SpeakerRecognizer = BuildRecognizer();
+                                    const m: sdk.SpeakerVerificationModel = sdk.SpeakerVerificationModel.fromProfile(res);
+                                    reco.recognizeOnceAsync(
+                                        m,
+                                        (recognizeResult: sdk.SpeakerRecognitionResult) => {
+                                            expect(recognizeResult).not.toBeUndefined();
+                                            expect(recognizeResult.reason).not.toBeUndefined();
+                                            expect(recognizeResult.reason).toEqual(sdk.ResultReason.RecognizedSpeaker);
+                                            expect(recognizeResult.profileId).toEqual(res.profileId);
+                                            r.deleteProfileAsync(
+                                                res,
+                                                (result: sdk.VoiceProfileResult) => {
+                                                    expect(result).not.toBeUndefined();
+                                                    expect(result.reason).toEqual(sdk.ResultReason.DeletedVoiceProfile);
+                                                    done();
+                                                },
+                                                (error: string) => {
+                                                    done.fail(error);
+                                                });
+                                        },
+                                        (error: string) => {
+                                            done.fail(error);
+                                        });
+                                },
+                                (error: string) => {
+                                    done.fail(error);
+                                });
+                        },
+                        (error: string) => {
+                            done.fail(error);
+                        });
+                },
+                (error: string) => {
+                    done.fail(error);
+                });
+        },
+        (error: string) => {
+            done.fail(error);
+        });
+}, 15000);

--- a/tests/WaveFileAudioInputStream.ts
+++ b/tests/WaveFileAudioInputStream.ts
@@ -2,8 +2,31 @@
 // Licensed under the MIT license.
 
 import * as fs from "fs";
+import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
+import { Settings } from "./Settings";
 
 export class WaveFileAudioInput {
+
+    public static getAudioConfigFromFile(filename: string): sdk.AudioConfig {
+        if (typeof File === "undefined") {
+            let pushStream: sdk.PushAudioInputStream = sdk.AudioInputStream.createPushStream();
+            if (filename === Settings.WaveFile44k) {
+                const f: sdk.AudioStreamFormat = sdk.AudioStreamFormat.getWaveFormatPCM(44100, 16, 1);
+                pushStream = sdk.AudioInputStream.createPushStream(f);
+            } else {
+                pushStream = sdk.AudioInputStream.createPushStream();
+            }
+            fs.createReadStream(filename).on("data", (arrayBuffer: Buffer): void => {
+                pushStream.write(arrayBuffer.slice());
+            }).on("end", (): void => {
+                pushStream.close();
+            });
+            return sdk.AudioConfig.fromStreamInput(pushStream);
+        } else {
+            const f: File = WaveFileAudioInput.LoadFile(filename);
+            return sdk.AudioConfig.fromWavFileInput(f);
+        }
+    }
 
     public static LoadFile(filename: string): File {
         // obtain and open the line.


### PR DESCRIPTION
On the node side, there is an issue where PushInputAudioStream does not do wav header checking like FileAudioSource, and there may be performance issues as well. For now, tests affected have been conditionally disabled for Node test runs, as have browser specific tests.