### PR TITLE
BotFrameworkConfig: add 'fromHost' and 'fromEndpoint' factories

### DIFF
--- a/src/common.browser/WebsocketMessageAdapter.ts
+++ b/src/common.browser/WebsocketMessageAdapter.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { HeaderNames } from "../common.speech/HeaderNames";
 import {
     ArgumentNullError,
     BackgroundEvent,
@@ -80,7 +81,7 @@ export class WebsocketMessageAdapter {
         this.privEnableCompression = enableCompression;
 
         // Add the connection ID to the headers
-        this.privHeaders["X-ConnectionId"] = this.privConnectionId;
+        this.privHeaders[HeaderNames.ConnectionId] = this.privConnectionId;
 
         this.privLastErrorReceived = "";
     }

--- a/src/common.speech/CognitiveSubscriptionKeyAuthentication.ts
+++ b/src/common.speech/CognitiveSubscriptionKeyAuthentication.ts
@@ -4,12 +4,11 @@
 import {
     ArgumentNullError,
 } from "../common/Exports";
+import { HeaderNames } from "./HeaderNames";
 import {
     AuthInfo,
     IAuthentication
 } from "./IAuthentication";
-
-const AuthHeader: string = "Ocp-Apim-Subscription-Key";
 
 /**
  * @class
@@ -27,7 +26,7 @@ export class CognitiveSubscriptionKeyAuthentication implements IAuthentication {
             throw new ArgumentNullError("subscriptionKey");
         }
 
-        this.privAuthInfo = new AuthInfo(AuthHeader, subscriptionKey);
+        this.privAuthInfo = new AuthInfo(HeaderNames.AuthKey, subscriptionKey);
     }
 
     /**

--- a/src/common.speech/ConnectionFactoryBase.ts
+++ b/src/common.speech/ConnectionFactoryBase.ts
@@ -33,7 +33,7 @@ export abstract class ConnectionFactoryBase implements IConnectionFactory {
             endpoint);
 
         this.setUrlParameter(PropertyId.SpeechServiceResponse_ProfanityOption,
-            QueryParameterNames.Profanify,
+            QueryParameterNames.Profanity,
             config,
             queryParams,
             endpoint);

--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -7,45 +7,16 @@ import {
 } from "../common.browser/Exports";
 import { OutputFormatPropertyName } from "../common.speech/Exports";
 import { IConnection, IStringDictionary } from "../common/Exports";
-import { OutputFormat, PropertyId } from "../sdk/Exports";
+import { DialogServiceConfig, OutputFormat, PropertyId } from "../sdk/Exports";
 import { ConnectionFactoryBase } from "./ConnectionFactoryBase";
 import { AuthInfo, RecognizerConfig, WebsocketMessageFormatter } from "./Exports";
+import { HeaderNames } from "./HeaderNames";
 import { QueryParameterNames } from "./QueryParameterNames";
 
 const baseUrl: string = "convai.speech";
 
-interface IBackendValues {
-    authHeader: string;
-    resourcePath: string;
-    version: string;
-}
-
-const botFramework: IBackendValues = {
-    authHeader: "X-DLS-Secret",
-    resourcePath: "",
-    version: "v3"
-};
-
-const customCommands: IBackendValues = {
-    authHeader: "X-CommandsAppId",
-    resourcePath: "commands",
-    version: "v1"
-};
-
 const pathSuffix: string = "api";
 const connectionID: string = "connectionId";
-
-function getDialogSpecificValues(dialogType: string): IBackendValues {
-    switch (dialogType) {
-        case "custom_commands": {
-            return customCommands;
-        }
-        case "bot_framework": {
-            return botFramework;
-        }
-    }
-    throw new Error(`Invalid dialog type '${dialogType}'`);
-}
 
 export class DialogConnectionFactory extends ConnectionFactoryBase {
 
@@ -61,12 +32,24 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         const requestTurnStatus: string = config.parameters.getProperty(PropertyId.Conversation_Request_Bot_Status_Messages, "true");
 
         const queryParams: IStringDictionary<string> = {};
-        queryParams[QueryParameterNames.LanguageParamName] = language;
-        queryParams[QueryParameterNames.FormatParamName] = config.parameters.getProperty(OutputFormatPropertyName, OutputFormat[OutputFormat.Simple]).toLowerCase();
-        queryParams[QueryParameterNames.RequestBotStatusMessagesParamName] = requestTurnStatus;
-        queryParams[connectionID] = connectionId;
+        queryParams[QueryParameterNames.ConnectionId] = connectionId;
+        queryParams[QueryParameterNames.Format] = config.parameters.getProperty(OutputFormatPropertyName, OutputFormat[OutputFormat.Simple]).toLowerCase();
+        queryParams[QueryParameterNames.Language] = language;
+        queryParams[QueryParameterNames.RequestBotStatusMessages] = requestTurnStatus;
+        if (applicationId) {
+            queryParams[QueryParameterNames.BotId] = applicationId;
+            if (dialogType === DialogServiceConfig.DialogTypes.CustomCommands) {
+                queryParams[HeaderNames.CustomCommandsAppId] = applicationId;
+            }
+        }
 
-        const {resourcePath, version, authHeader} = getDialogSpecificValues(dialogType);
+        const resourceInfix: string =
+            dialogType === DialogServiceConfig.DialogTypes.CustomCommands ? "/commands"
+            : "";
+        const version: string =
+            dialogType === DialogServiceConfig.DialogTypes.CustomCommands ? "v1"
+            : dialogType === DialogServiceConfig.DialogTypes.BotFramework ? "v3"
+            : "v0";
 
         const headers: IStringDictionary<string> = {};
 
@@ -74,23 +57,17 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
             headers[authInfo.headerName] = authInfo.token;
         }
 
-        if (applicationId !== "") {
-            headers[authHeader] = applicationId;
-        }
-
         // The URL used for connection is chosen in a priority order of specification:
         //  1. If a custom endpoint is provided, that URL is used verbatim.
         //  2. If a custom host is provided (e.g. "wss://my.custom.endpoint.com:1123"), a URL is constructed from it.
         //  3. If no custom connection details are provided, a URL is constructed from default values.
         let endpoint: string = config.parameters.getProperty(PropertyId.SpeechServiceConnection_Endpoint, "");
-        if (endpoint === "") {
+        if (!endpoint) {
             const hostSuffix = (region && region.toLowerCase().startsWith("china")) ? ".azure.cn" : ".microsoft.com";
             const host: string = config.parameters.getProperty(
                 PropertyId.SpeechServiceConnection_Host,
                 `wss://${region}.${baseUrl}${hostSuffix}`);
-            endpoint = `${host}`
-                + (resourcePath ? `/${resourcePath}` : "")
-                + `/${pathSuffix}/${version}`;
+            endpoint = `${host}${resourceInfix}/api/${version}`;
         }
 
         this.setCommonUrlParams(config, queryParams, endpoint);

--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -13,12 +13,12 @@ import { AuthInfo, RecognizerConfig, WebsocketMessageFormatter } from "./Exports
 import { HeaderNames } from "./HeaderNames";
 import { QueryParameterNames } from "./QueryParameterNames";
 
-const baseUrl: string = "convai.speech";
-
-const pathSuffix: string = "api";
-const connectionID: string = "connectionId";
-
 export class DialogConnectionFactory extends ConnectionFactoryBase {
+
+    private Constants: any = class {
+        private ApiKey: string = "api";
+        private BaseUrl: string = "convai.speech";
+    };
 
     public create = (
         config: RecognizerConfig,
@@ -66,8 +66,8 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
             const hostSuffix = (region && region.toLowerCase().startsWith("china")) ? ".azure.cn" : ".microsoft.com";
             const host: string = config.parameters.getProperty(
                 PropertyId.SpeechServiceConnection_Host,
-                `wss://${region}.${baseUrl}${hostSuffix}`);
-            endpoint = `${host}${resourceInfix}/api/${version}`;
+                `wss://${region}.${this.Constants.BaseUrl}${hostSuffix}`);
+            endpoint = `${host}${resourceInfix}/${this.Constants.ApiKey}/${version}`;
         }
 
         this.setCommonUrlParams(config, queryParams, endpoint);

--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -15,9 +15,9 @@ import { QueryParameterNames } from "./QueryParameterNames";
 
 export class DialogConnectionFactory extends ConnectionFactoryBase {
 
-    private Constants: any = class {
-        private ApiKey: string = "api";
-        private BaseUrl: string = "convai.speech";
+    private static Constants: any = class {
+        private static ApiKey: string = "api";
+        private static BaseUrl: string = "convai.speech";
     };
 
     public create = (
@@ -66,8 +66,8 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
             const hostSuffix = (region && region.toLowerCase().startsWith("china")) ? ".azure.cn" : ".microsoft.com";
             const host: string = config.parameters.getProperty(
                 PropertyId.SpeechServiceConnection_Host,
-                `wss://${region}.${this.Constants.BaseUrl}${hostSuffix}`);
-            endpoint = `${host}${resourceInfix}/${this.Constants.ApiKey}/${version}`;
+                `wss://${region}.${DialogConnectionFactory.Constants.BaseUrl}${hostSuffix}`);
+            endpoint = `${host}${resourceInfix}/${DialogConnectionFactory.Constants.ApiKey}/${version}`;
         }
 
         this.setCommonUrlParams(config, queryParams, endpoint);

--- a/src/common.speech/DialogServiceAdapter.ts
+++ b/src/common.speech/DialogServiceAdapter.ts
@@ -615,11 +615,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
 
             default:
                 Events.instance.onEvent(
-<<<<<<< HEAD
-                    new BackgroundEvent("Unexpected response of type `${responsePayload.messageType}`. Ignoring."));
-=======
                     new BackgroundEvent(`Unexpected response of type ${responsePayload.messageType}. Ignoring.`));
->>>>>>> user/travisw/turnstatus
                 break;
         }
     }

--- a/src/common.speech/DialogServiceAdapter.ts
+++ b/src/common.speech/DialogServiceAdapter.ts
@@ -22,6 +22,7 @@ import {
     ActivityReceivedEventArgs,
     CancellationErrorCode,
     CancellationReason,
+    DialogServiceConfig,
     DialogServiceConnector,
     PropertyCollection,
     PropertyId,
@@ -500,7 +501,9 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
     private sendAgentConfig = (connection: IConnection): Promise<void> => {
         if (this.agentConfig && !this.agentConfigSent) {
 
-            if (this.privRecognizerConfig.parameters.getProperty(PropertyId.Conversation_DialogType) === "custom_commands") {
+            if (this.privRecognizerConfig
+                .parameters
+                .getProperty(PropertyId.Conversation_DialogType) === DialogServiceConfig.DialogTypes.CustomCommands) {
                 const config = this.agentConfig.get();
                 config.botInfo.commandsCulture = this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceConnection_RecoLanguage, "en-us");
                 this.agentConfig.set(config);

--- a/src/common.speech/HeaderNames.ts
+++ b/src/common.speech/HeaderNames.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+export class HeaderNames {
+    public static AuthKey: string = "Ocp-Apim-Subscription-Key";
+    public static ConnectionId: string = "X-ConnectionId";
+    public static ContentType: string = "Content-Type";
+    public static CustomCommandsAppId: string = "X-CommandsAppId";
+    public static Path: string = "Path";
+    public static RequestId: string = "X-RequestId";
+    public static RequestStreamId: string = "x-streamid";
+    public static RequestTimestamp: string = "X-Timestamp";
+}

--- a/src/common.speech/HeaderNames.ts
+++ b/src/common.speech/HeaderNames.ts
@@ -8,6 +8,6 @@ export class HeaderNames {
     public static CustomCommandsAppId: string = "X-CommandsAppId";
     public static Path: string = "Path";
     public static RequestId: string = "X-RequestId";
-    public static RequestStreamId: string = "x-streamid";
+    public static RequestStreamId: string = "X-StreamId";
     public static RequestTimestamp: string = "X-Timestamp";
 }

--- a/src/common.speech/IntentConnectionFactory.ts
+++ b/src/common.speech/IntentConnectionFactory.ts
@@ -20,9 +20,7 @@ import {
     RecognizerConfig,
     WebsocketMessageFormatter,
 } from "./Exports";
-
-const TestHooksParamName: string = "testhooks";
-const ConnectionIdHeader: string = "X-ConnectionId";
+import { HeaderNames } from "./HeaderNames";
 
 export class IntentConnectionFactory extends ConnectionFactoryBase {
 
@@ -50,7 +48,7 @@ export class IntentConnectionFactory extends ConnectionFactoryBase {
         if (authInfo.token !== undefined && authInfo.token !== "") {
             headers[authInfo.headerName] = authInfo.token;
         }
-        headers[ConnectionIdHeader] = connectionId;
+        headers[HeaderNames.ConnectionId] = connectionId;
 
         config.parameters.setProperty(PropertyId.SpeechServiceConnection_Url, endpoint);
 

--- a/src/common.speech/QueryParameterNames.ts
+++ b/src/common.speech/QueryParameterNames.ts
@@ -2,55 +2,20 @@
 // Licensed under the MIT license.
 
 export class QueryParameterNames {
-    public static get TestHooksParamName(): string {
-        return "testhooks";
-    }
-    public static get ConnectionIdHeader(): string {
-        return "X-ConnectionId";
-    }
-    public static get DeploymentIdParamName(): string {
-        return "cid";
-    }
-    public static get FormatParamName(): string {
-        return "format";
-    }
-    public static get LanguageParamName(): string {
-        return "language";
-    }
-    public static get TranslationFromParamName(): string {
-        return "from";
-    }
-    public static get TranslationToParamName(): string {
-        return "to";
-    }
-    public static get CustomVoiceDeploymentIdParamName(): string {
-        return "deploymentId";
-    }
-    public static get Profanify(): string {
-        return "profanity";
-    }
-    public static get EnableAudioLogging(): string {
-        return "storeAudio";
-    }
-    public static get EnableWordLevelTimestamps(): string {
-        return "wordLevelTimestamps";
-    }
-    public static get InitialSilenceTimeoutMs(): string {
-        return "initialSilenceTimeoutMs";
-    }
-    public static get EndSilenceTimeoutMs(): string {
-        return "endSilenceTimeoutMs";
-    }
-    public static get StableIntermediateThreshold(): string {
-        return "stableIntermediateThreshold";
-    }
-    public static get StableTranslation(): string {
-        return "stableTranslation";
-    }
-    public static get EnableLanguageID(): string {
-        return "lidEnabled";
-    }
-    public static get RequestBotStatusMessagesParamName(): string {
-        return "enableBotMessageStatus";
-    }
+    public static BotId: string = "botid";
+    public static ConnectionId: string = "connectionid";
+    public static CustomSpeechDeploymentId: string = "cid";
+    public static CustomVoiceDeploymentId: string = "deploymentId";
+    public static EnableAudioLogging: string = "storeAudio";
+    public static EnableLanguageId: string = "lidEnabled";
+    public static EnableWordLevelTimestamps: string = "wordLevelTimestamps";
+    public static EndSilenceTimeoutMs: string = "endSilenceTimeoutMs";
+    public static Format: string = "format";
+    public static InitialSilenceTimeoutMs: string = "initialSilenceTimeoutMs";
+    public static Language: string = "language";
+    public static Profanity: string = "profanity";
+    public static RequestBotStatusMessages: string = "enableBotMessageStatus";
+    public static StableIntermediateThreshold: string = "stableIntermediateThreshold";
+    public static StableTranslation: string = "stableTranslation";
+    public static TestHooks: string = "testhooks";
 }

--- a/src/common.speech/RecognitionEvents.ts
+++ b/src/common.speech/RecognitionEvents.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import { EventType, PlatformEvent } from "../common/Exports";
 
 export class SpeechRecognitionEvent extends PlatformEvent {
@@ -23,7 +25,6 @@ export class SpeechRecognitionEvent extends PlatformEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class RecognitionTriggeredEvent extends SpeechRecognitionEvent {
     private privAudioSourceId: string;
     private privAudioNodeId: string;
@@ -44,7 +45,6 @@ export class RecognitionTriggeredEvent extends SpeechRecognitionEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ListeningStartedEvent extends SpeechRecognitionEvent {
     private privAudioSourceId: string;
     private privAudioNodeId: string;
@@ -64,7 +64,6 @@ export class ListeningStartedEvent extends SpeechRecognitionEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ConnectingToServiceEvent extends SpeechRecognitionEvent {
     private privAuthFetchEventid: string;
 
@@ -78,7 +77,6 @@ export class ConnectingToServiceEvent extends SpeechRecognitionEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class RecognitionStartedEvent extends SpeechRecognitionEvent {
     private privAudioSourceId: string;
     private privAudioNodeId: string;
@@ -118,7 +116,6 @@ export enum RecognitionCompletionStatus {
     UnknownError,
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class RecognitionEndedEvent extends SpeechRecognitionEvent {
     private privAudioSourceId: string;
     private privAudioNodeId: string;

--- a/src/common.speech/RecognizerConfig.ts
+++ b/src/common.speech/RecognizerConfig.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import { PropertyCollection, PropertyId } from "../sdk/Exports";
 
 export enum RecognitionMode {
@@ -59,7 +61,6 @@ export class RecognizerConfig {
 }
 
 // The config is serialized and sent as the Speech.Config
-// tslint:disable-next-line:max-classes-per-file
 export class SpeechServiceConfig {
     private context: Context;
     private recognition: string;
@@ -96,7 +97,6 @@ export class SpeechServiceConfig {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class Context {
     public system: System;
     public os: OS;
@@ -108,7 +108,6 @@ export class Context {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class System {
     public name: string;
     public version: string;
@@ -126,7 +125,6 @@ export class System {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OS {
     public platform: string;
     public name: string;
@@ -139,7 +137,6 @@ export class OS {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class Device {
     public manufacturer: string;
     public model: string;

--- a/src/common.speech/ServiceTelemetryListener.Internal.ts
+++ b/src/common.speech/ServiceTelemetryListener.Internal.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import {
     AudioSourceErrorEvent,
     AudioStreamNodeAttachedEvent,
@@ -22,7 +24,6 @@ export interface ITelemetry {
     ReceivedMessages: IStringDictionary<string[]>;
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export interface IMetric {
     End?: string;
     Error?: string;
@@ -33,7 +34,6 @@ export interface IMetric {
     FirstHypothesisLatencyMs?: number[];
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ServiceTelemetryListener implements IEventListener<PlatformEvent> {
     private privIsDisposed: boolean = false;
 

--- a/src/common.speech/SpeechConnectionFactory.ts
+++ b/src/common.speech/SpeechConnectionFactory.ts
@@ -26,6 +26,7 @@ import {
     RecognizerConfig,
     WebsocketMessageFormatter
 } from "./Exports";
+import { HeaderNames } from "./HeaderNames";
 import {
     QueryParameterNames
 } from "./QueryParameterNames";
@@ -52,21 +53,21 @@ export class SpeechConnectionFactory extends ConnectionFactoryBase {
         const language: string = config.parameters.getProperty(PropertyId.SpeechServiceConnection_RecoLanguage, undefined);
 
         if (endpointId) {
-            if (!endpoint || endpoint.search(QueryParameterNames.DeploymentIdParamName) === -1) {
-                queryParams[QueryParameterNames.DeploymentIdParamName] = endpointId;
+            if (!endpoint || endpoint.search(QueryParameterNames.CustomSpeechDeploymentId) === -1) {
+                queryParams[QueryParameterNames.CustomSpeechDeploymentId] = endpointId;
             }
         } else if (language) {
-            if (!endpoint || endpoint.search(QueryParameterNames.LanguageParamName) === -1) {
-                queryParams[QueryParameterNames.LanguageParamName] = language;
+            if (!endpoint || endpoint.search(QueryParameterNames.Language) === -1) {
+                queryParams[QueryParameterNames.Language] = language;
             }
         }
 
-        if (!endpoint || endpoint.search(QueryParameterNames.FormatParamName) === -1) {
-            queryParams[QueryParameterNames.FormatParamName] = config.parameters.getProperty(OutputFormatPropertyName, OutputFormat[OutputFormat.Simple]).toLowerCase();
+        if (!endpoint || endpoint.search(QueryParameterNames.Format) === -1) {
+            queryParams[QueryParameterNames.Format] = config.parameters.getProperty(OutputFormatPropertyName, OutputFormat[OutputFormat.Simple]).toLowerCase();
         }
 
         if (config.autoDetectSourceLanguages !== undefined) {
-            queryParams[QueryParameterNames.EnableLanguageID] = "true";
+            queryParams[QueryParameterNames.EnableLanguageId] = "true";
         }
 
         this.setCommonUrlParams(config, queryParams, endpoint);
@@ -93,7 +94,7 @@ export class SpeechConnectionFactory extends ConnectionFactoryBase {
         if (authInfo.token !== undefined && authInfo.token !== "") {
             headers[authInfo.headerName] = authInfo.token;
         }
-        headers[QueryParameterNames.ConnectionIdHeader] = connectionId;
+        headers[HeaderNames.ConnectionId] = connectionId;
 
         config.parameters.setProperty(PropertyId.SpeechServiceConnection_Url, endpoint);
 

--- a/src/common.speech/SpeechConnectionMessage.Internal.ts
+++ b/src/common.speech/SpeechConnectionMessage.Internal.ts
@@ -2,12 +2,7 @@
 // Licensed under the MIT license.
 
 import { ArgumentNullError, ConnectionMessage, IStringDictionary, MessageType } from "../common/Exports";
-
-const PathHeaderName: string = "Path";
-const ContentTypeHeaderName: string = "Content-Type";
-const RequestIdHeaderName: string = "X-RequestId";
-const RequestTimestampHeaderName: string = "X-Timestamp";
-const RequestStreamIdHeaderName: string = "x-streamid";
+import { HeaderNames } from "./HeaderNames";
 
 export class SpeechConnectionMessage extends ConnectionMessage {
 
@@ -36,15 +31,15 @@ export class SpeechConnectionMessage extends ConnectionMessage {
         }
 
         const headers: IStringDictionary<string> = {};
-        headers[PathHeaderName] = path;
-        headers[RequestIdHeaderName] = requestId;
-        headers[RequestTimestampHeaderName] = new Date().toISOString();
+        headers[HeaderNames.Path] = path;
+        headers[HeaderNames.RequestId] = requestId;
+        headers[HeaderNames.RequestTimestamp] = new Date().toISOString();
         if (contentType) {
-            headers[ContentTypeHeaderName] = contentType;
+            headers[HeaderNames.ContentType] = contentType;
         }
 
         if (streamId) {
-            headers[RequestStreamIdHeaderName] = streamId;
+            headers[HeaderNames.RequestStreamId] = streamId;
         }
 
         if (additionalHeaders) {
@@ -100,15 +95,15 @@ export class SpeechConnectionMessage extends ConnectionMessage {
         if (message.headers) {
             for (const headerName in message.headers) {
                 if (headerName) {
-                    if (headerName.toLowerCase() === PathHeaderName.toLowerCase()) {
+                    if (headerName.toLowerCase() === HeaderNames.Path.toLowerCase()) {
                         path = message.headers[headerName];
-                    } else if (headerName.toLowerCase() === RequestIdHeaderName.toLowerCase()) {
+                    } else if (headerName.toLowerCase() === HeaderNames.RequestId.toLowerCase()) {
                         requestId = message.headers[headerName];
-                    } else if (headerName.toLowerCase() === RequestTimestampHeaderName.toLowerCase()) {
+                    } else if (headerName.toLowerCase() === HeaderNames.RequestTimestamp.toLowerCase()) {
                         requestTimestamp = message.headers[headerName];
-                    } else if (headerName.toLowerCase() === ContentTypeHeaderName.toLowerCase()) {
+                    } else if (headerName.toLowerCase() === HeaderNames.ContentType.toLowerCase()) {
                         contentType = message.headers[headerName];
-                    } else if (headerName.toLowerCase() === RequestStreamIdHeaderName.toLowerCase()) {
+                    } else if (headerName.toLowerCase() === HeaderNames.RequestStreamId.toLowerCase()) {
                         streamId = message.headers[headerName];
                     } else {
                         additionalHeaders[headerName] = message.headers[headerName];

--- a/src/common.speech/SpeechSynthesisConnectionFactory.ts
+++ b/src/common.speech/SpeechSynthesisConnectionFactory.ts
@@ -15,6 +15,7 @@ import {
     SynthesizerConfig,
     WebsocketMessageFormatter
 } from "./Exports";
+import { HeaderNames } from "./HeaderNames";
 import { ISynthesisConnectionFactory } from "./ISynthesisConnectionFactory";
 import {
     QueryParameterNames
@@ -46,9 +47,9 @@ export class SpeechSynthesisConnectionFactory implements ISynthesisConnectionFac
         if (authInfo.token !== undefined && authInfo.token !== "") {
             headers[authInfo.headerName] = authInfo.token;
         }
-        headers[QueryParameterNames.ConnectionIdHeader] = connectionId;
+        headers[HeaderNames.ConnectionId] = connectionId;
         if (endpointId !== undefined) {
-            headers[QueryParameterNames.CustomVoiceDeploymentIdParamName] = endpointId;
+            headers[QueryParameterNames.CustomVoiceDeploymentId] = endpointId;
         }
 
         config.parameters.setProperty(PropertyId.SpeechServiceConnection_Url, endpoint);

--- a/src/common.speech/SynthesisEvents.ts
+++ b/src/common.speech/SynthesisEvents.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import { EventType, PlatformEvent } from "../common/Exports";
 
 export class SpeechSynthesisEvent extends PlatformEvent {
@@ -17,7 +19,6 @@ export class SpeechSynthesisEvent extends PlatformEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class SynthesisTriggeredEvent extends SpeechSynthesisEvent {
     private privSessionAudioDestinationId: string;
     private privTurnAudioDestinationId: string;
@@ -38,7 +39,6 @@ export class SynthesisTriggeredEvent extends SpeechSynthesisEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ConnectingToSynthesisServiceEvent extends SpeechSynthesisEvent {
     private privAuthFetchEventId: string;
 
@@ -52,7 +52,6 @@ export class ConnectingToSynthesisServiceEvent extends SpeechSynthesisEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class SynthesisStartedEvent extends SpeechSynthesisEvent {
     private privAuthFetchEventId: string;
 

--- a/src/common.speech/TranscriberConnectionFactory.ts
+++ b/src/common.speech/TranscriberConnectionFactory.ts
@@ -24,6 +24,7 @@ import {
     RecognizerConfig,
     WebsocketMessageFormatter
 } from "./Exports";
+import { HeaderNames } from "./HeaderNames";
 import {
     QueryParameterNames
 } from "./QueryParameterNames";
@@ -49,12 +50,12 @@ export class TranscriberConnectionFactory extends ConnectionFactoryBase {
         const language: string = config.parameters.getProperty(PropertyId.SpeechServiceConnection_RecoLanguage, undefined);
 
         if (endpointId) {
-            if (!endpoint || endpoint.search(QueryParameterNames.DeploymentIdParamName) === -1) {
-                queryParams[QueryParameterNames.DeploymentIdParamName] = endpointId;
+            if (!endpoint || endpoint.search(QueryParameterNames.CustomSpeechDeploymentId) === -1) {
+                queryParams[QueryParameterNames.CustomSpeechDeploymentId] = endpointId;
             }
         } else if (language) {
-            if (!endpoint || endpoint.search(QueryParameterNames.LanguageParamName) === -1) {
-                queryParams[QueryParameterNames.LanguageParamName] = language;
+            if (!endpoint || endpoint.search(QueryParameterNames.Language) === -1) {
+                queryParams[QueryParameterNames.Language] = language;
             }
         }
 
@@ -67,7 +68,7 @@ export class TranscriberConnectionFactory extends ConnectionFactoryBase {
         if (authInfo.token !== undefined && authInfo.token !== "") {
             headers[authInfo.headerName] = authInfo.token;
         }
-        headers[QueryParameterNames.ConnectionIdHeader] = connectionId;
+        headers[HeaderNames.ConnectionId] = connectionId;
 
         config.parameters.setProperty(PropertyId.SpeechServiceConnection_Url, endpoint);
 

--- a/src/common.speech/TranslationConnectionFactory.ts
+++ b/src/common.speech/TranslationConnectionFactory.ts
@@ -21,10 +21,8 @@ import {
     RecognizerConfig,
     WebsocketMessageFormatter,
 } from "./Exports";
+import { HeaderNames } from "./HeaderNames";
 import { QueryParameterNames } from "./QueryParameterNames";
-
-const TestHooksParamName: string = "testhooks";
-const ConnectionIdHeader: string = "X-ConnectionId";
 
 export class TranslationConnectionFactory extends ConnectionFactoryBase {
 
@@ -67,7 +65,7 @@ export class TranslationConnectionFactory extends ConnectionFactoryBase {
         if (authInfo.token !== undefined && authInfo.token !== "") {
             headers[authInfo.headerName] = authInfo.token;
         }
-        headers[ConnectionIdHeader] = connectionId;
+        headers[HeaderNames.ConnectionId] = connectionId;
 
         config.parameters.setProperty(PropertyId.SpeechServiceConnection_Url, endpoint);
 

--- a/src/common/AudioSourceEvents.ts
+++ b/src/common/AudioSourceEvents.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import { EventType, PlatformEvent } from "./PlatformEvent";
 
 export class AudioSourceEvent extends PlatformEvent {
@@ -16,28 +18,24 @@ export class AudioSourceEvent extends PlatformEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class AudioSourceInitializingEvent extends AudioSourceEvent {
     constructor(audioSourceId: string) {
         super("AudioSourceInitializingEvent", audioSourceId);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class AudioSourceReadyEvent extends AudioSourceEvent {
     constructor(audioSourceId: string) {
         super("AudioSourceReadyEvent", audioSourceId);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class AudioSourceOffEvent extends AudioSourceEvent {
     constructor(audioSourceId: string) {
         super("AudioSourceOffEvent", audioSourceId);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class AudioSourceErrorEvent extends AudioSourceEvent {
     private privError: string;
 
@@ -51,7 +49,6 @@ export class AudioSourceErrorEvent extends AudioSourceEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class AudioStreamNodeEvent extends AudioSourceEvent {
     private privAudioNodeId: string;
 
@@ -65,28 +62,24 @@ export class AudioStreamNodeEvent extends AudioSourceEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class AudioStreamNodeAttachingEvent extends AudioStreamNodeEvent {
     constructor(audioSourceId: string, audioNodeId: string) {
         super("AudioStreamNodeAttachingEvent", audioSourceId, audioNodeId);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class AudioStreamNodeAttachedEvent extends AudioStreamNodeEvent {
     constructor(audioSourceId: string, audioNodeId: string) {
         super("AudioStreamNodeAttachedEvent", audioSourceId, audioNodeId);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class AudioStreamNodeDetachedEvent extends AudioStreamNodeEvent {
     constructor(audioSourceId: string, audioNodeId: string) {
         super("AudioStreamNodeDetachedEvent", audioSourceId, audioNodeId);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class AudioStreamNodeErrorEvent extends AudioStreamNodeEvent {
     private privError: string;
 

--- a/src/common/ConnectionEvents.ts
+++ b/src/common/ConnectionEvents.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import { ConnectionMessage } from "./ConnectionMessage";
 import { IStringDictionary } from "./IDictionary";
 import { EventType, PlatformEvent } from "./PlatformEvent";
@@ -18,7 +20,6 @@ export class ServiceEvent extends PlatformEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ConnectionEvent extends PlatformEvent {
     private privConnectionId: string;
 
@@ -32,7 +33,6 @@ export class ConnectionEvent extends PlatformEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ConnectionStartEvent extends ConnectionEvent {
     private privUri: string;
     private privHeaders: IStringDictionary<string>;
@@ -52,14 +52,12 @@ export class ConnectionStartEvent extends ConnectionEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ConnectionEstablishedEvent extends ConnectionEvent {
     constructor(connectionId: string, metadata?: IStringDictionary<string>) {
         super("ConnectionEstablishedEvent", connectionId);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ConnectionClosedEvent extends ConnectionEvent {
     private privRreason: string;
     private privStatusCode: number;
@@ -79,7 +77,6 @@ export class ConnectionClosedEvent extends ConnectionEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ConnectionErrorEvent extends ConnectionEvent {
     private readonly privMessage: string;
     private readonly privType: string;
@@ -99,7 +96,6 @@ export class ConnectionErrorEvent extends ConnectionEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ConnectionEstablishErrorEvent extends ConnectionEvent {
     private privStatusCode: number;
     private privReason: string;
@@ -119,7 +115,6 @@ export class ConnectionEstablishErrorEvent extends ConnectionEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ConnectionMessageReceivedEvent extends ConnectionEvent {
     private privNetworkReceivedTime: string;
     private privMessage: ConnectionMessage;
@@ -139,7 +134,6 @@ export class ConnectionMessageReceivedEvent extends ConnectionEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class ConnectionMessageSentEvent extends ConnectionEvent {
     private privNetworkSentTime: string;
     private privMessage: ConnectionMessage;

--- a/src/common/Error.ts
+++ b/src/common/Error.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 /**
  * The error that is thrown when an argument passed in is null.
  *
@@ -31,7 +33,6 @@ export class ArgumentNullError extends Error {
  * @class InvalidOperationError
  * @extends {Error}
  */
-// tslint:disable-next-line:max-classes-per-file
 export class InvalidOperationError extends Error {
 
     /**

--- a/src/common/OCSPEvents.ts
+++ b/src/common/OCSPEvents.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import { EventType, PlatformEvent } from "./PlatformEvent";
 
 export class OCSPEvent extends PlatformEvent {
@@ -13,70 +15,60 @@ export class OCSPEvent extends PlatformEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPMemoryCacheHitEvent extends OCSPEvent {
     constructor(signature: string) {
         super("OCSPMemoryCacheHitEvent", EventType.Debug, signature);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPCacheMissEvent extends OCSPEvent {
     constructor(signature: string) {
         super("OCSPCacheMissEvent", EventType.Debug, signature);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPDiskCacheHitEvent extends OCSPEvent {
     constructor(signature: string) {
         super("OCSPDiskCacheHitEvent", EventType.Debug, signature);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPCacheUpdateNeededEvent extends OCSPEvent {
     constructor(signature: string) {
         super("OCSPCacheUpdateNeededEvent", EventType.Debug, signature);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPMemoryCacheStoreEvent extends OCSPEvent {
     constructor(signature: string) {
         super("OCSPMemoryCacheStoreEvent", EventType.Debug, signature);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPDiskCacheStoreEvent extends OCSPEvent {
     constructor(signature: string) {
         super("OCSPDiskCacheStoreEvent", EventType.Debug, signature);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPCacheUpdatehCompleteEvent extends OCSPEvent {
     constructor(signature: string) {
         super("OCSPCacheUpdatehCompleteEvent", EventType.Debug, signature);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPStapleReceivedEvent extends OCSPEvent {
     constructor() {
         super("OCSPStapleReceivedEvent", EventType.Debug, "");
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPWSUpgradeStartedEvent extends OCSPEvent {
     constructor(serialNumber: string) {
         super("OCSPWSUpgradeStartedEvent", EventType.Debug, serialNumber);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPCacheEntryExpiredEvent extends OCSPEvent {
     private privExpireTime: number;
 
@@ -86,7 +78,6 @@ export class OCSPCacheEntryExpiredEvent extends OCSPEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPCacheEntryNeedsRefreshEvent extends OCSPEvent {
     private privExpireTime: number;
     private privStartTime: number;
@@ -98,7 +89,6 @@ export class OCSPCacheEntryNeedsRefreshEvent extends OCSPEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPCacheHitEvent extends OCSPEvent {
     private privExpireTime: number;
     private privStartTime: number;
@@ -114,7 +104,6 @@ export class OCSPCacheHitEvent extends OCSPEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPVerificationFailedEvent extends OCSPEvent {
     private privError: string;
 
@@ -124,7 +113,6 @@ export class OCSPVerificationFailedEvent extends OCSPEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPCacheFetchErrorEvent extends OCSPEvent {
     private privError: string;
 
@@ -134,14 +122,12 @@ export class OCSPCacheFetchErrorEvent extends OCSPEvent {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPResponseRetrievedEvent extends OCSPEvent {
     constructor(serialNumber: string) {
         super("OCSPResponseRetrievedEvent", EventType.Debug, serialNumber);
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class OCSPCacheUpdateErrorEvent extends OCSPEvent {
     private privError: string;
 

--- a/src/common/Promise.ts
+++ b/src/common/Promise.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import { ArgumentNullError } from "./Error";
 
 export enum PromiseState {
@@ -62,7 +64,6 @@ export class PromiseResult<T> {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class PromiseResultEventSource<T>  {
 
     private privOnSetResult: (result: T) => void;
@@ -82,7 +83,6 @@ export class PromiseResultEventSource<T>  {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class Deferred<T> implements IDeferred<T> {
     private privPromise: Promise<T>;
     private privResolve: (value?: T | PromiseLike<T>) => void;
@@ -110,7 +110,6 @@ export class Deferred<T> implements IDeferred<T> {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class Sink<T> {
     private privState: PromiseState = PromiseState.None;
     private privPromiseResult: PromiseResult<T> = null;

--- a/src/sdk/Audio/AudioConfig.ts
+++ b/src/sdk/Audio/AudioConfig.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import { PathLike } from "fs";
 import {
     FileAudioSource,
@@ -213,7 +215,6 @@ export abstract class AudioConfig {
  * @private
  * @class AudioConfigImpl
  */
-// tslint:disable-next-line:max-classes-per-file
 export class AudioConfigImpl extends AudioConfig implements IAudioSource {
     private privSource: IAudioSource;
 
@@ -346,7 +347,6 @@ export class AudioConfigImpl extends AudioConfig implements IAudioSource {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class AudioOutputConfigImpl extends AudioConfig implements IAudioDestination {
     private privDestination: IAudioDestination;
 

--- a/src/sdk/Audio/AudioInputStream.ts
+++ b/src/sdk/Audio/AudioInputStream.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import {
     connectivity,
     ISpeechConfigAudioDevice,
@@ -81,7 +83,6 @@ export abstract class AudioInputStream {
  * Represents memory backed push audio input stream used for custom audio input configurations.
  * @class PushAudioInputStream
  */
-// tslint:disable-next-line:max-classes-per-file
 export abstract class PushAudioInputStream extends AudioInputStream {
 
     /**
@@ -120,7 +121,6 @@ export abstract class PushAudioInputStream extends AudioInputStream {
  * @private
  * @class PushAudioInputStreamImpl
  */
-// tslint:disable-next-line:max-classes-per-file
 export class PushAudioInputStreamImpl extends PushAudioInputStream implements IAudioSource {
 
     private privFormat: AudioStreamFormatImpl;
@@ -277,7 +277,6 @@ export class PushAudioInputStreamImpl extends PushAudioInputStream implements IA
  * Represents audio input stream used for custom audio input configurations.
  * @class PullAudioInputStream
  */
-// tslint:disable-next-line:max-classes-per-file
 export abstract class PullAudioInputStream extends AudioInputStream {
     /**
      * Creates and initializes and instance.
@@ -316,7 +315,6 @@ export abstract class PullAudioInputStream extends AudioInputStream {
  * @private
  * @class PullAudioInputStreamImpl
  */
-// tslint:disable-next-line:max-classes-per-file
 export class PullAudioInputStreamImpl extends PullAudioInputStream implements IAudioSource {
 
     private privCallback: PullAudioInputStreamCallback;

--- a/src/sdk/Audio/AudioOutputStream.ts
+++ b/src/sdk/Audio/AudioOutputStream.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+// tslint:disable:max-classes-per-file
+
 import {
     createNoDashGuid,
     Deferred,
@@ -58,7 +60,6 @@ export abstract class AudioOutputStream {
  * Represents memory backed push audio output stream used for custom audio output configurations.
  * @class PullAudioOutputStream
  */
-// tslint:disable-next-line:max-classes-per-file
 export abstract class PullAudioOutputStream extends AudioOutputStream {
 
     /**
@@ -96,7 +97,6 @@ export abstract class PullAudioOutputStream extends AudioOutputStream {
  * @private
  * @class PullAudioOutputStreamImpl
  */
-// tslint:disable-next-line:max-classes-per-file
 export class PullAudioOutputStreamImpl extends PullAudioOutputStream implements IAudioDestination {
     private privFormat: AudioOutputFormatImpl;
     private privId: string;
@@ -225,7 +225,6 @@ export class PullAudioOutputStreamImpl extends PullAudioOutputStream implements 
  * Represents audio output stream used for custom audio output configurations.
  * @class PushAudioOutputStream
  */
-// tslint:disable-next-line:max-classes-per-file
 export abstract class PushAudioOutputStream extends AudioOutputStream {
     /**
      * Creates and initializes and instance.
@@ -262,7 +261,6 @@ export abstract class PushAudioOutputStream extends AudioOutputStream {
  * @private
  * @class PushAudioOutputStreamImpl
  */
-// tslint:disable-next-line:max-classes-per-file
 export class PushAudioOutputStreamImpl extends PushAudioOutputStream implements IAudioDestination {
     private readonly privId: string;
     private privCallback: PushAudioOutputStreamCallback;

--- a/src/sdk/BotFrameworkConfig.ts
+++ b/src/sdk/BotFrameworkConfig.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Contracts } from "./Contracts";
-import { DialogServiceConfigImpl } from "./DialogServiceConfig";
+import { DialogServiceConfig, DialogServiceConfigImpl } from "./DialogServiceConfig";
 import { PropertyId } from "./Exports";
 
 /**
@@ -33,7 +33,7 @@ export class BotFrameworkConfig extends DialogServiceConfigImpl {
         Contracts.throwIfNullOrWhitespace(region, "region");
 
         const botFrameworkConfig: BotFrameworkConfig = new DialogServiceConfigImpl();
-        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, "bot_framework");
+        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, DialogServiceConfig.DialogTypes.BotFramework);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceConnection_Key, subscription);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceConnection_Region, region);
 
@@ -64,7 +64,7 @@ export class BotFrameworkConfig extends DialogServiceConfigImpl {
         Contracts.throwIfNullOrWhitespace(region, "region");
 
         const botFrameworkConfig: BotFrameworkConfig = new DialogServiceConfigImpl();
-        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, "bot_framework");
+        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, DialogServiceConfig.DialogTypes.BotFramework);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceAuthorization_Token, authorizationToken);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceConnection_Region, region);
 
@@ -102,7 +102,7 @@ export class BotFrameworkConfig extends DialogServiceConfigImpl {
         Contracts.throwIfNullOrUndefined(resolvedHost, "resolvedHost");
 
         const botFrameworkConfig: BotFrameworkConfig = new DialogServiceConfigImpl();
-        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, "bot_framework");
+        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, DialogServiceConfig.DialogTypes.BotFramework);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceConnection_Host, resolvedHost.toString());
 
         if (undefined !== subscriptionKey) {
@@ -130,7 +130,7 @@ export class BotFrameworkConfig extends DialogServiceConfigImpl {
         Contracts.throwIfNull(endpoint, "endpoint");
 
         const botFrameworkConfig: BotFrameworkConfig = new DialogServiceConfigImpl();
-        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, "bot_framework");
+        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, DialogServiceConfig.DialogTypes.BotFramework);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceConnection_Endpoint, endpoint.toString());
 
         if (undefined !== subscriptionKey) {

--- a/src/sdk/BotFrameworkConfig.ts
+++ b/src/sdk/BotFrameworkConfig.ts
@@ -19,21 +19,24 @@ export class BotFrameworkConfig extends DialogServiceConfigImpl {
     }
 
     /**
-     * Creates an instance of the bot framework config with the specified subscription and region.
+     * Creates a bot framework configuration instance with the provided subscription information.
      * @member BotFrameworkConfig.fromSubscription
      * @function
      * @public
      * @param subscription Subscription key associated with the bot
      * @param region The region name (see the <a href="https://aka.ms/csspeech/region">region page</a>).
-     * @param botId Optional. Identifier for using a specific bot within an Azure resource group. Equivalent to the resource name.
-     * @returns {BotFrameworkConfig} A new bot framework config.
+     * @param botId Optional. Identifier for using a specific bot within an Azure resource group. Equivalent to the
+     *        resource name.
+     * @returns {BotFrameworkConfig} A new bot framework configuration instance.
      */
     public static fromSubscription(subscription: string, region: string, botId?: string): BotFrameworkConfig {
         Contracts.throwIfNullOrWhitespace(subscription, "subscription");
         Contracts.throwIfNullOrWhitespace(region, "region");
 
         const botFrameworkConfig: BotFrameworkConfig = new DialogServiceConfigImpl();
-        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, DialogServiceConfig.DialogTypes.BotFramework);
+        botFrameworkConfig.setProperty(
+            PropertyId.Conversation_DialogType,
+            DialogServiceConfig.DialogTypes.BotFramework);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceConnection_Key, subscription);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceConnection_Region, region);
 
@@ -45,26 +48,33 @@ export class BotFrameworkConfig extends DialogServiceConfigImpl {
     }
 
     /**
-     * Creates an instance of the bot framework config with the specified authorization token and region.
-     * Note: The caller needs to ensure that the authorization token is valid. Before the authorization token
-     * expires, the caller needs to refresh it by calling this setter with a new valid token.
-     * As configuration values are copied when creating a new recognizer, the new token value will not apply to recognizers that have already been created.
-     * For recognizers that have been created before, you need to set authorization token of the corresponding recognizer
-     * to refresh the token. Otherwise, the recognizers will encounter errors during recognition.
+     * Creates a bot framework configuration instance for the specified authorization token and region.
+     * Note: The caller must ensure that an authorization token is valid. Before an authorization token expires, the
+     *       caller must refresh it by setting the authorizationToken property on the corresponding
+     *       DialogServiceConnector instance created with this config. The contents of configuration objects are copied
+     *       when connectors are created, so setting authorizationToken on a DialogServiceConnector will not update the
+     *       original configuration's authorization token. Create a new configuration instance or set the
+     *       SpeechServiceAuthorization_Token property to update an existing instance if it will be used to create
+     *       further DialogServiceConnectors.
      * @member BotFrameworkConfig.fromAuthorizationToken
      * @function
      * @public
      * @param authorizationToken The authorization token associated with the bot
      * @param region The region name (see the <a href="https://aka.ms/csspeech/region">region page</a>).
-     * @param botId Optional. Identifier for using a specific bot within an Azure resource group. Equivalent to the resource name.
-     * @returns {BotFrameworkConfig} A new bot framework config.
+     * @param botId Optional. Identifier for using a specific bot within an Azure resource group. Equivalent to the
+     *        resource name.
+     * @returns {BotFrameworkConfig} A new bot framework configuration instance.
      */
-    public static fromAuthorizationToken(authorizationToken: string, region: string, botId?: string): BotFrameworkConfig {
+    public static fromAuthorizationToken(
+        authorizationToken: string, region: string, botId?: string
+    ): BotFrameworkConfig {
         Contracts.throwIfNullOrWhitespace(authorizationToken, "authorizationToken");
         Contracts.throwIfNullOrWhitespace(region, "region");
 
         const botFrameworkConfig: BotFrameworkConfig = new DialogServiceConfigImpl();
-        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, DialogServiceConfig.DialogTypes.BotFramework);
+        botFrameworkConfig.setProperty(
+            PropertyId.Conversation_DialogType,
+            DialogServiceConfig.DialogTypes.BotFramework);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceAuthorization_Token, authorizationToken);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceConnection_Region, region);
 
@@ -77,20 +87,23 @@ export class BotFrameworkConfig extends DialogServiceConfigImpl {
 
     /**
      * Creates an instance of a BotFrameworkConfig.
-     * This method is intended only for users who use a non-default service host. The standard resource path will be assumed.
-     * For services with a non-standard resource path or no path at all, use fromEndpoint instead.
+     * This method is intended only for users who use a non-default service host. The standard resource path will be
+     * assumed. For services with a non-standard resource path or no path at all, use fromEndpoint instead.
      * Note: Query parameters are not allowed in the host URI and must be set by other APIs.
-     * Note: To use an authorization token with fromHost, use fromHost(URL),
-     * and then set the AuthorizationToken property on the created BotFrameworkConfig instance.
-     * Note: Added in version 1.9.0.
+     * Note: To use an authorization token with fromHost, use fromHost(URL) and then set the AuthorizationToken
+     *       property on the created BotFrameworkConfig instance.
+     * Note: Added in version 1.15.0.
      * @member BotFrameworkConfig.fromHost
      * @function
      * @public
-     * @param {URL | string} host - If a URL is provided, the fully-qualified host with protocol (e.g. wss://your.host.com:1234)
-     *  will be used. If a string is provided, it will be embedded in wss://{host}.convai.speech.azure.us.
-     * @param {string} subscriptionKey - The subscription key. If a subscription key is not specified, an authorization token must be set.
-     * @param botId Optional. Identifier for using a specific bot within an Azure resource group. Equivalent to the resource name.
-     * @returns {BotFrameworkConfig} A speech factory instance.
+     * @param {URL | string} host - If a URL is provided, the fully-qualified host with protocol (e.g.
+     *        wss://your.host.com:1234) will be used. If a string is provided, it will be embedded in
+     *        wss://{host}.convai.speech.azure.us.
+     * @param {string} subscriptionKey - The subscription key. If a subscription key is not specified, an authorization
+     *        token must be set.
+     * @param botId Optional. Identifier for using a specific bot within an Azure resource group. Equivalent to the
+     *        resource name.
+     * @returns {BotFrameworkConfig} A new bot framework configuration instance.
      */
     public static fromHost(
         host: URL | string,
@@ -102,7 +115,9 @@ export class BotFrameworkConfig extends DialogServiceConfigImpl {
         Contracts.throwIfNullOrUndefined(resolvedHost, "resolvedHost");
 
         const botFrameworkConfig: BotFrameworkConfig = new DialogServiceConfigImpl();
-        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, DialogServiceConfig.DialogTypes.BotFramework);
+        botFrameworkConfig.setProperty(
+            PropertyId.Conversation_DialogType,
+            DialogServiceConfig.DialogTypes.BotFramework);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceConnection_Host, resolvedHost.toString());
 
         if (undefined !== subscriptionKey) {
@@ -119,18 +134,22 @@ export class BotFrameworkConfig extends DialogServiceConfigImpl {
      * Note: To use authorization token with fromEndpoint, pass an empty string to the subscriptionKey in the
      *       fromEndpoint method, and then set authorizationToken="token" on the created BotFrameworkConfig instance to
      *       use the authorization token.
+     * Note: Added in version 1.15.0.
      * @member BotFrameworkConfig.fromEndpoint
      * @function
      * @public
      * @param {URL} endpoint - The service endpoint to connect to.
-     * @param {string} subscriptionKey - The subscription key. If a subscription key is not specified, an authorization token must be set.
-     * @returns {BotFrameworkConfig} - A new object configured to connect to the provided endpoint.
+     * @param {string} subscriptionKey - The subscription key. If a subscription key is not specified, an authorization
+     *        token must be set.
+     * @returns {BotFrameworkConfig} - A new bot framework configuration instance using the provided endpoint.
      */
     public static fromEndpoint(endpoint: URL, subscriptionKey?: string): BotFrameworkConfig {
         Contracts.throwIfNull(endpoint, "endpoint");
 
         const botFrameworkConfig: BotFrameworkConfig = new DialogServiceConfigImpl();
-        botFrameworkConfig.setProperty(PropertyId.Conversation_DialogType, DialogServiceConfig.DialogTypes.BotFramework);
+        botFrameworkConfig.setProperty(
+            PropertyId.Conversation_DialogType,
+            DialogServiceConfig.DialogTypes.BotFramework);
         botFrameworkConfig.setProperty(PropertyId.SpeechServiceConnection_Endpoint, endpoint.toString());
 
         if (undefined !== subscriptionKey) {

--- a/src/sdk/ConnectionMessage.ts
+++ b/src/sdk/ConnectionMessage.ts
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
 //
 
+import { HeaderNames } from "../common.speech/HeaderNames";
 import {
     ConnectionMessage as IntConnectionMessage,
     MessageType
@@ -71,8 +72,8 @@ export class ConnectionMessageImpl {
     constructor(message: IntConnectionMessage) {
         this.privConnectionMessage = message;
         this.privProperties = new PropertyCollection();
-        if (!!this.privConnectionMessage.headers["X-ConnectionId"]) {
-            this.privProperties.setProperty(PropertyId.Speech_SessionId, this.privConnectionMessage.headers["X-ConnectionId"]);
+        if (!!this.privConnectionMessage.headers[HeaderNames.ConnectionId]) {
+            this.privProperties.setProperty(PropertyId.Speech_SessionId, this.privConnectionMessage.headers[HeaderNames.ConnectionId]);
         }
 
         Object.keys(this.privConnectionMessage.headers).forEach((header: string, index: number, array: string[]): void => {

--- a/src/sdk/CustomCommandsConfig.ts
+++ b/src/sdk/CustomCommandsConfig.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Contracts } from "./Contracts";
-import { DialogServiceConfigImpl } from "./DialogServiceConfig";
+import { DialogServiceConfig, DialogServiceConfigImpl } from "./DialogServiceConfig";
 import { PropertyId } from "./Exports";
 
 /**
@@ -34,7 +34,7 @@ export class CustomCommandsConfig extends DialogServiceConfigImpl {
         Contracts.throwIfNullOrWhitespace(region, "region");
 
         const customCommandsConfig: CustomCommandsConfig = new DialogServiceConfigImpl();
-        customCommandsConfig.setProperty(PropertyId.Conversation_DialogType, "custom_commands");
+        customCommandsConfig.setProperty(PropertyId.Conversation_DialogType, DialogServiceConfig.DialogTypes.CustomCommands);
         customCommandsConfig.setProperty(PropertyId.Conversation_ApplicationId, applicationId);
         customCommandsConfig.setProperty(PropertyId.SpeechServiceConnection_Key, subscription);
         customCommandsConfig.setProperty(PropertyId.SpeechServiceConnection_Region, region);
@@ -62,7 +62,7 @@ export class CustomCommandsConfig extends DialogServiceConfigImpl {
         Contracts.throwIfNullOrWhitespace(region, "region");
 
         const customCommandsConfig: CustomCommandsConfig = new DialogServiceConfigImpl();
-        customCommandsConfig.setProperty(PropertyId.Conversation_DialogType, "custom_commands");
+        customCommandsConfig.setProperty(PropertyId.Conversation_DialogType, DialogServiceConfig.DialogTypes.CustomCommands);
         customCommandsConfig.setProperty(PropertyId.Conversation_ApplicationId, applicationId);
         customCommandsConfig.setProperty(PropertyId.SpeechServiceAuthorization_Token, authorizationToken);
         customCommandsConfig.setProperty(PropertyId.SpeechServiceConnection_Region, region);

--- a/src/sdk/DialogServiceConfig.ts
+++ b/src/sdk/DialogServiceConfig.ts
@@ -96,7 +96,6 @@ export abstract class DialogServiceConfig {
     // tslint:disable-next-line: no-empty
     public set applicationId(value: string) { }
 
-    // tslint:disable-next-line:max-classes-per-file
     public static DialogTypes: any = class {
         public static BotFramework: string = "bot_framework";
         public static CustomCommands: string = "custom_commands";

--- a/src/sdk/DialogServiceConfig.ts
+++ b/src/sdk/DialogServiceConfig.ts
@@ -95,6 +95,12 @@ export abstract class DialogServiceConfig {
      */
     // tslint:disable-next-line: no-empty
     public set applicationId(value: string) { }
+
+    // tslint:disable-next-line:max-classes-per-file
+    public static DialogTypes: any = class {
+        public static BotFramework: string = "bot_framework";
+        public static CustomCommands: string = "custom_commands";
+    };
 }
 
 /**

--- a/tests/DialogServiceConnectorTests.ts
+++ b/tests/DialogServiceConnectorTests.ts
@@ -180,8 +180,6 @@ test("Output format, default", () => {
     expect(dialogConfig.outputFormat === sdk.OutputFormat.Simple);
 });
 
-// Skip this test pending parity check with C++/C# -- 1006/404 is only returned when an unintended double-forwardslash
-// is present in the connection URL.
 test("Create BotFrameworkConfig, invalid optional botId", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
     console.info("Create BotFrameworkConfig, invalid optional botId");

--- a/tests/DialogServiceConnectorTests.ts
+++ b/tests/DialogServiceConnectorTests.ts
@@ -178,7 +178,9 @@ test("Output format, default", () => {
     expect(dialogConfig.outputFormat === sdk.OutputFormat.Simple);
 });
 
-test("Create BotFrameworkConfig, invalid optional botId", (done: jest.DoneCallback) => {
+// Skip this test pending parity check with C++/C# -- 1006/404 is only returned when an unintended double-forwardslash
+// is present in the connection URL.
+test.skip("Create BotFrameworkConfig, invalid optional botId", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
     console.info("Create BotFrameworkConfig, invalid optional botId");
 
@@ -191,7 +193,7 @@ test("Create BotFrameworkConfig, invalid optional botId", (done: jest.DoneCallba
     connector.listenOnceAsync(
         (successResult: sdk.SpeechRecognitionResult) => {
             if (successResult.reason !== sdk.ResultReason.Canceled) {
-                done.fail(`listenOnceAsync shouldn't have reason '${successResult.reason} with this config`);
+                done.fail(`listenOnceAsync shouldn't have reason '${successResult.reason}' with this config`);
             } else {
                 expect(successResult.errorDetails).toContain("1006");
             }

--- a/tests/LongRunning/SpeechRecoAuthTokenErrorMessageTests.ts
+++ b/tests/LongRunning/SpeechRecoAuthTokenErrorMessageTests.ts
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+import * as request from "request";
 import * as sdk from "../../microsoft.cognitiveservices.speech.sdk";
 import { ConsoleLoggingListener, WebsocketMessageAdapter } from "../../src/common.browser/Exports";
+import { HeaderNames } from "../../src/common.speech/HeaderNames";
 import { Events, EventType, PlatformEvent } from "../../src/common/Exports";
-
 import { Settings } from "../Settings";
-import { WaveFileAudioInput } from "../WaveFileAudioInputStream";
-
-import * as request from "request";
-
 import { WaitForCondition } from "../Utilities";
+import { WaveFileAudioInput } from "../WaveFileAudioInputStream";
 
 let objsToClose: any[];
 
@@ -51,7 +49,7 @@ test("Non-refreshed auth token has sensible error message", (done: jest.DoneCall
     const req = {
         headers: {
             "Content-Type": "application/json",
-            "Ocp-Apim-Subscription-Key": Settings.SpeechSubscriptionKey,
+            [HeaderNames.AuthKey]: Settings.SpeechSubscriptionKey,
         },
         url: "https://" + Settings.SpeechRegion + ".api.cognitive.microsoft.com/sts/v1.0/issueToken",
     };

--- a/tests/LongRunning/SpeechRecoAuthTokenRefreshTests.ts
+++ b/tests/LongRunning/SpeechRecoAuthTokenRefreshTests.ts
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+import * as request from "request";
 import * as sdk from "../../microsoft.cognitiveservices.speech.sdk";
 import { ConsoleLoggingListener, WebsocketMessageAdapter } from "../../src/common.browser/Exports";
+import { HeaderNames } from "../../src/common.speech/HeaderNames";
 import { Events, EventType, PlatformEvent } from "../../src/common/Exports";
-
 import { Settings } from "../Settings";
-import { WaveFileAudioInput } from "../WaveFileAudioInputStream";
-
-import * as request from "request";
-
 import { WaitForCondition } from "../Utilities";
+import { WaveFileAudioInput } from "../WaveFileAudioInputStream";
 
 let objsToClose: any[];
 
@@ -51,7 +49,7 @@ test("AuthToken refresh works correctly", (done: jest.DoneCallback) => {
     const req = {
         headers: {
             "Content-Type": "application/json",
-            "Ocp-Apim-Subscription-Key": Settings.SpeechSubscriptionKey,
+            [HeaderNames.AuthKey]: Settings.SpeechSubscriptionKey,
         },
         url: "https://" + Settings.SpeechRegion + ".api.cognitive.microsoft.com/sts/v1.0/issueToken",
     };

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -4,6 +4,7 @@
 import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
 import { ConsoleLoggingListener, WebsocketMessageAdapter } from "../src/common.browser/Exports";
 import { ServiceRecognizerBase } from "../src/common.speech/Exports";
+import { HeaderNames } from "../src/common.speech/HeaderNames";
 import { QueryParameterNames } from "../src/common.speech/QueryParameterNames";
 import { ConnectionStartEvent, IDetachable } from "../src/common/Exports";
 import { Events, EventType, PlatformEvent } from "../src/common/Exports";
@@ -354,7 +355,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         const req = {
             headers: {
                 "Content-Type": "application/json",
-                "Ocp-Apim-Subscription-Key": Settings.SpeechSubscriptionKey,
+                [HeaderNames.AuthKey]: Settings.SpeechSubscriptionKey,
             },
             url: "https://" + Settings.SpeechRegion + ".api.cognitive.microsoft.com/sts/v1.0/issueToken",
         };
@@ -1883,8 +1884,8 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                     expect("What's the weather like?").toEqual(res.text);
                     expect(uri).not.toBeUndefined();
-                    expect(uri.search(QueryParameterNames.DeploymentIdParamName + "=" + Settings.SpeechTestEndpointId)).not.toEqual(-1);
-                    expect(uri.search(QueryParameterNames.LanguageParamName)).toEqual(-1);
+                    expect(uri.search(QueryParameterNames.CustomSpeechDeploymentId + "=" + Settings.SpeechTestEndpointId)).not.toEqual(-1);
+                    expect(uri.search(QueryParameterNames.Language)).toEqual(-1);
 
                     done();
                 } catch (error) {

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import * as request from "request";
 import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
 import { ConsoleLoggingListener, WebsocketMessageAdapter } from "../src/common.browser/Exports";
+import { HeaderNames } from "../src/common.speech/HeaderNames";
 import { QueryParameterNames } from "../src/common.speech/QueryParameterNames";
 import {
     ConnectionStartEvent,
@@ -570,7 +571,7 @@ describe("Service based tests", () => {
         const req = {
             headers: {
                 "Content-Type": "application/json",
-                "Ocp-Apim-Subscription-Key": Settings.SpeechSubscriptionKey,
+                [HeaderNames.AuthKey]: Settings.SpeechSubscriptionKey,
             },
             url: "https://" + Settings.SpeechRegion + ".api.cognitive.microsoft.com/sts/v1.0/issueToken",
         };
@@ -686,7 +687,7 @@ describe("Service based tests", () => {
         s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
             CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
             expect(uri).not.toBeUndefined();
-            expect(uri.search(QueryParameterNames.CustomVoiceDeploymentIdParamName + "=" + Settings.CustomVoiceEndpointId)).not.toEqual(-1);
+            expect(uri.search(QueryParameterNames.CustomVoiceDeploymentId + "=" + Settings.CustomVoiceEndpointId)).not.toEqual(-1);
             done();
         }, (e: string): void => {
             done.fail(e);

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,8 @@
 
     "interface-name": [ false ],
 
+    "max-classes-per-file": [ true, 1, "exclude-class-expressions" ],
+
     "max-line-length": [ false ],
 
     "member-ordering": [


### PR DESCRIPTION
## The problem
BotFrameworkConfig lacks `fromEndpoint` and `fromHost` factories for use with custom service locations, including sovereign cloud deployments. A workaround exists to directly use the host and/or endpoint properties, but this is both cumbersome and error prone.

## The approach
Fairly straightforward: add the parity methods, using `SpeechConfig` as a basis for comparison.

One small edition is that `fromHost` supports two semantic meanings of its parameter depending on whether it's a string or URL:

* `fromHost(URL, ...)` requires a typed URL object that will include protocol and hostname information, e.g. `new URL("wss://my.custom.host")`
* `fromHost(string, ...)` accepts a *base hostname* that's pasted into a template of the form `wss://{basename}.convai.speech.azure.us`, e.g. `"my.custom.host"`. This is purely a convenience overload for an anticipated common pattern.

`fromEndpoint` behaves as expected and is identical to setting the endpoint property.

## Errata

* In the course of development, issues with the query string parameters used for Custom Commands application and Bot selection were noted and addressed. This is also accompanied by a refactor of header and query string parameter name constants, which is responsible for the somewhat large file count
* A typo from my previous PR in string interpolation (end of `DialogServiceAdapter`) is snuck in
* An optional `botId` parameter is added to `fromAuthorizationToken` for parity with `fromSubscription`
* Fairly comprehensive testing for URL contents is included (full disclosure: I had fun playing with the test framework for the first time)