### PR TITLE
DialogServiceConnector: Restore support for Direct Line tokens

### DIFF
--- a/src/common.speech/DialogConnectorFactory.ts
+++ b/src/common.speech/DialogConnectorFactory.ts
@@ -32,7 +32,7 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         const requestTurnStatus: string = config.parameters.getProperty(PropertyId.Conversation_Request_Bot_Status_Messages, "true");
 
         const queryParams: IStringDictionary<string> = {};
-        queryParams[QueryParameterNames.ConnectionId] = connectionId;
+        queryParams[HeaderNames.ConnectionId] = connectionId;
         queryParams[QueryParameterNames.Format] = config.parameters.getProperty(OutputFormatPropertyName, OutputFormat[OutputFormat.Simple]).toLowerCase();
         queryParams[QueryParameterNames.Language] = language;
         queryParams[QueryParameterNames.RequestBotStatusMessages] = requestTurnStatus;
@@ -44,7 +44,7 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
         }
 
         const resourceInfix: string =
-            dialogType === DialogServiceConfig.DialogTypes.CustomCommands ? "/commands"
+            dialogType === DialogServiceConfig.DialogTypes.CustomCommands ? "commands/"
             : "";
         const version: string =
             dialogType === DialogServiceConfig.DialogTypes.CustomCommands ? "v1"
@@ -67,7 +67,8 @@ export class DialogConnectionFactory extends ConnectionFactoryBase {
             const host: string = config.parameters.getProperty(
                 PropertyId.SpeechServiceConnection_Host,
                 `wss://${region}.${DialogConnectionFactory.Constants.BaseUrl}${hostSuffix}`);
-            endpoint = `${host}${resourceInfix}/${DialogConnectionFactory.Constants.ApiKey}/${version}`;
+            const standardizedHost: string = host.endsWith("/") ? host : host + "/";
+            endpoint = `${standardizedHost}${resourceInfix}${DialogConnectionFactory.Constants.ApiKey}/${version}`;
         }
 
         this.setCommonUrlParams(config, queryParams, endpoint);

--- a/src/common.speech/DialogServiceAdapter.ts
+++ b/src/common.speech/DialogServiceAdapter.ts
@@ -4,6 +4,7 @@
 import {
     ReplayableAudioNode
 } from "../common.browser/Exports";
+import { SendingAgentContextMessageEvent } from "../common/DialogEvents";
 import {
     BackgroundEvent,
     ConnectionEvent,
@@ -11,7 +12,9 @@ import {
     createGuid,
     createNoDashGuid,
     Deferred,
+    DialogEvent,
     Events,
+    EventSource,
     IAudioSource,
     IAudioStreamNode,
     IConnection,
@@ -63,6 +66,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
     private terminateMessageLoop: boolean;
     private agentConfigSent: boolean;
     private privLastResult: SpeechRecognitionResult;
+    private privEvents: EventSource<DialogEvent>;
 
     // Turns are of two kinds:
     // 1: SR turns, end when the SR result is returned and then turn end.
@@ -78,6 +82,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
 
         super(authentication, connectionFactory, audioSource, recognizerConfig, dialogServiceConnector);
 
+        this.privEvents = new EventSource<DialogEvent>();
         this.privDialogServiceConnector = dialogServiceConnector;
         this.receiveMessageOverride = this.receiveDialogMessageOverride;
         this.privTurnStateManager = new DialogServiceTurnStateManager();
@@ -515,6 +520,8 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
                 config.botInfo.commandsCulture = this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceConnection_RecoLanguage, "en-us");
                 this.agentConfig.set(config);
             }
+            this.onEvent(new SendingAgentContextMessageEvent(this.agentConfig));
+
             const agentConfigJson = this.agentConfig.toJsonString();
 
             // guard against sending this multiple times on one connection
@@ -628,5 +635,10 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
                     new BackgroundEvent(`Unexpected response of type ${responsePayload.messageType}. Ignoring.`));
                 break;
         }
+    }
+
+    private onEvent(event: DialogEvent): void {
+        this.privEvents.onEvent(event);
+        Events.instance.onEvent(event);
     }
 }

--- a/src/common.speech/QueryParameterNames.ts
+++ b/src/common.speech/QueryParameterNames.ts
@@ -3,7 +3,6 @@
 
 export class QueryParameterNames {
     public static BotId: string = "botid";
-    public static ConnectionId: string = "connectionid";
     public static CustomSpeechDeploymentId: string = "cid";
     public static CustomVoiceDeploymentId: string = "deploymentId";
     public static EnableAudioLogging: string = "storeAudio";

--- a/src/common/DialogEvents.ts
+++ b/src/common/DialogEvents.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+// tslint:disable:max-classes-per-file
+
+import { AgentConfig } from "../common.speech/Exports";
+import { EventType, PlatformEvent } from "./PlatformEvent";
+
+export class DialogEvent extends PlatformEvent {
+
+    constructor(eventName: string, eventType: EventType = EventType.Info) {
+        super(eventName, eventType);
+    }
+}
+
+export class SendingAgentContextMessageEvent extends DialogEvent {
+    private privAgentConfig: AgentConfig;
+
+    constructor(agentConfig: AgentConfig) {
+        super("SendingAgentContextMessageEvent");
+        this.privAgentConfig = agentConfig;
+    }
+
+    public get agentConfig(): AgentConfig {
+        return this.privAgentConfig;
+    }
+}

--- a/src/common/Exports.ts
+++ b/src/common/Exports.ts
@@ -5,6 +5,7 @@ export * from "./AudioSourceEvents";
 export * from "./ConnectionEvents";
 export * from "./ConnectionMessage";
 export * from "./ConnectionOpenResponse";
+export * from "./DialogEvents";
 export * from "./Error";
 export * from "./Events";
 export * from "./EventSource";

--- a/src/sdk/DialogServiceConnector.ts
+++ b/src/sdk/DialogServiceConnector.ts
@@ -267,7 +267,7 @@ export class DialogServiceConnector extends Recognizer {
             botInfo: {
                 commType: communicationType,
                 commandsCulture: undefined,
-                connectionId: this.properties.getProperty(PropertyId.Conversation_ApplicationId),
+                connectionId: this.properties.getProperty(PropertyId.Conversation_Agent_Connection_Id),
                 conversationId: this.properties.getProperty(PropertyId.Conversation_Conversation_Id, undefined),
                 fromId: this.properties.getProperty(PropertyId.Conversation_From_Id, undefined),
                 ttsAudioFormat: (SpeechSynthesisOutputFormat as any)[this.properties.getProperty(PropertyId.SpeechServiceConnection_SynthOutputFormat, undefined)]

--- a/src/sdk/PropertyId.ts
+++ b/src/sdk/PropertyId.ts
@@ -334,6 +334,13 @@ export enum PropertyId {
     Conversation_Request_Bot_Status_Messages,
 
     /**
+     * Specifies the connection ID to be provided in the Agent configuration message, e.g. a Direct Line token for
+     * channel authentication.
+     * Added in version 1.15.1.
+     */
+    Conversation_Agent_Connection_Id,
+
+    /**
      * The Cognitive Services Speech Service host (url). Under normal circumstances, you shouldn't have to use this property directly.
      * Instead, use [[SpeechConfig.fromHost]].
      */


### PR DESCRIPTION
## Problem
1.15 fixed support for `botid` by appropriately mapping `Conversation_ApplicationId` to the `botid` query string parameter. This unwittingly broke an overloaded use of `Conversation_ApplicationId`: Direct Line token passthrough.

To do channel authentication, the agent context message currently grabs the `Conversation_ApplicationId` value.

* But providing a `botid` that isn't valid (not the Azure resource name) will cause DLS to issue a 4xx error (can't find the bot!)
* And we just made that map to said key

The correct solution here is to demux the concept of the extra token and the concept of a botid. Here that's done by adding a new property, `Conversation_Application_Connection_Id`. This will map into the agent config's `connectionId` field and appropriately pass through as the authentication token -- without messing with the ability to select non-default bots for a subscription.

Fixes #317

## Extras
* A related problem was found where using a strongly-typed URL as the host (needed for more flexible suffix support) caused an extraneous extra `/` to end up in the final connection URL. That's addressed by standardizing whether or not the forward slash is present in this fragment.

Fixes #315 

* The use of "connectionId" as a key, although not regressed anywhere, isn't right and the proper "X-ConnectionId" value is now used instead.

* Test coverage is also added to check that this property goes to the right place. We didn't have any events/monitoring for agent config messages (or anything in dialog, actually), so there's a bit of plumbing added.