### PR TITLE
Correct microphone timing issue if mic stream ends occurs before stop…

### DIFF
--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -68,6 +68,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
     private privActivityTemplate: string;
     private privSetTimeout: (cb: () => void, delay: number) => number = setTimeout;
     private privAudioSource: IAudioSource;
+    private privDeviceType: string = null;
     protected privSpeechContext: SpeechContext;
     protected privRequestSession: RequestSession;
     protected privConnectionId: string;
@@ -208,6 +209,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
         const audioStreamNode: IAudioStreamNode = await this.audioSource.attach(this.privRequestSession.audioNodeId);
         const format: AudioStreamFormatImpl = await this.audioSource.format;
         const deviceInfo: ISpeechConfigAudioDevice = await this.audioSource.deviceInfo;
+        this.privDeviceType = deviceInfo.type;
 
         const audioNode = new ReplayableAudioNode(audioStreamNode, format.avgBytesPerSec);
         await this.privRequestSession.onAudioSourceAttachCompleted(audioNode, false);
@@ -692,7 +694,9 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                     } else {
                         // the audio stream has been closed, no need to schedule next
                         // read-upload cycle.
-                        this.privRequestSession.onSpeechEnded();
+                        if (!this.privDeviceType || this.privDeviceType !== "Microphones") {
+                            this.privRequestSession.onSpeechEnded();
+                        }
                     }
                 }
             }

--- a/src/common/IConnection.ts
+++ b/src/common/IConnection.ts
@@ -5,7 +5,6 @@ import { ConnectionEvent } from "./ConnectionEvents";
 import { ConnectionMessage } from "./ConnectionMessage";
 import { ConnectionOpenResponse } from "./ConnectionOpenResponse";
 import { EventSource } from "./EventSource";
-import { IDisposable } from "./IDisposable";
 
 export enum ConnectionState {
     None,


### PR DESCRIPTION
…Recognizer.

From https://portal.microsofticm.com/imp/v3/incidents/details/228051095/home.

Essentially the new FireFox is getting to the end of the mic stream (when close() is called on it) before stopRecognizing has been called. This accounts for that possibility.