### PR TITLE
increase header slice to 512 bytes

### DIFF
--- a/src/common.browser/FileAudioSource.ts
+++ b/src/common.browser/FileAudioSource.ts
@@ -144,7 +144,7 @@ export class FileAudioSource implements IAudioSource {
 
     private readHeader(): Promise<AudioStreamFormatImpl> {
         // Read the wave header.
-        const maxHeaderSize: number = 128;
+        const maxHeaderSize: number = 512;
         const header: Blob = this.privFile.slice(0, maxHeaderSize);
         const headerReader: FileReader = new FileReader();
 


### PR DESCRIPTION
https://msasg.visualstudio.com/DefaultCollection/Skyman/_workitems/edit/3254801 
[Test file with large header ](http://talonsoftwares.com/upload/2422332.wav) doesn't work with JS SDK. 