### PR TITLE
Fix audio playback for iOS Safari

### DIFF
--- a/src/common.speech/DialogServiceAdapter.ts
+++ b/src/common.speech/DialogServiceAdapter.ts
@@ -21,6 +21,7 @@ import {
     MessageType,
     ServiceEvent,
 } from "../common/Exports";
+import { AudioOutputFormatImpl } from "../sdk/Audio/AudioOutputFormat";
 import { PullAudioOutputStreamImpl } from "../sdk/Audio/AudioOutputStream";
 import { AudioStreamFormatImpl } from "../sdk/Audio/AudioStreamFormat";
 import {
@@ -37,7 +38,6 @@ import {
     SpeechRecognitionCanceledEventArgs,
     SpeechRecognitionEventArgs,
     SpeechRecognitionResult,
-    SpeechSynthesisOutputFormat,
     TurnStatusReceivedEventArgs,
 } from "../sdk/Exports";
 import { DialogServiceTurnStateManager } from "./DialogServiceTurnStateManager";
@@ -603,7 +603,7 @@ export class DialogServiceAdapter extends ServiceRecognizerBase {
 
                 const pullAudioOutputStream: PullAudioOutputStreamImpl = turn.processActivityPayload(
                     activityPayload,
-                    (SpeechSynthesisOutputFormat as any)[this.privDialogServiceConnector.properties.getProperty(PropertyId.SpeechServiceConnection_SynthOutputFormat, undefined)]);
+                    AudioOutputFormatImpl.fromSpeechSynthesisOutputFormatString(this.privDialogServiceConnector.properties.getProperty(PropertyId.SpeechServiceConnection_SynthOutputFormat, undefined)));
                 const activity = new ActivityReceivedEventArgs(activityPayload.messagePayload, pullAudioOutputStream);
                 if (!!this.privDialogServiceConnector.activityReceived) {
                     try {

--- a/src/sdk/Audio/BaseAudioPlayer.ts
+++ b/src/sdk/Audio/BaseAudioPlayer.ts
@@ -39,16 +39,12 @@ export class BaseAudioPlayer {
      */
     public playAudioSample(newAudioData: ArrayBuffer, cb?: () => void, err?: (error: string) => void): void {
         marshalPromiseToCallbacks((async (): Promise<void> => {
-            if (!!(window as any).webkitAudioContext) {
-                await this.playAudio(newAudioData);
-            } else {
                 this.ensureInitializedContext();
                 const audioData = this.formatAudioData(newAudioData);
                 const newSamplesData = new Float32Array(this.samples.length + audioData.length);
                 newSamplesData.set(this.samples, 0);
                 newSamplesData.set(audioData, this.samples.length);
                 this.samples = newSamplesData;
-            }
         })(), cb, err);
     }
 

--- a/src/sdk/DialogServiceConnector.ts
+++ b/src/sdk/DialogServiceConnector.ts
@@ -18,6 +18,7 @@ import {
 } from "../common/Exports";
 import { ActivityReceivedEventArgs } from "./ActivityReceivedEventArgs";
 import { AudioConfigImpl } from "./Audio/AudioConfig";
+import { AudioOutputFormatImpl } from "./Audio/AudioOutputFormat";
 import { Contracts } from "./Contracts";
 import { DialogServiceConfig, DialogServiceConfigImpl } from "./DialogServiceConfig";
 import {
@@ -29,7 +30,6 @@ import {
     SpeechRecognitionResult
 } from "./Exports";
 import { PropertyId } from "./PropertyId";
-import { SpeechSynthesisOutputFormat } from "./SpeechSynthesisOutputFormat";
 import { TurnStatusReceivedEventArgs } from "./TurnStatusReceivedEventArgs";
 
 /**
@@ -270,7 +270,7 @@ export class DialogServiceConnector extends Recognizer {
                 connectionId: this.properties.getProperty(PropertyId.Conversation_Agent_Connection_Id),
                 conversationId: this.properties.getProperty(PropertyId.Conversation_Conversation_Id, undefined),
                 fromId: this.properties.getProperty(PropertyId.Conversation_From_Id, undefined),
-                ttsAudioFormat: (SpeechSynthesisOutputFormat as any)[this.properties.getProperty(PropertyId.SpeechServiceConnection_SynthOutputFormat, undefined)]
+                ttsAudioFormat: this.properties.getProperty(PropertyId.SpeechServiceConnection_SynthOutputFormat, undefined)
             },
             version: 0.2
         };


### PR DESCRIPTION
iOS is heavily (related to other browser functionality) restricted in media playback capabilities, especially when using webkitAudio. For example, decodeAudioData is restrictive and selective on the media it supports (while also being sparse in documentation about said functionality).

I spent some time looking at how we could provide the audio data in a way that BaseAudioContext would be happy with it, but in the end found we can actually stop using it altogether and instead directly provide the audio data as we do in other browsers.

I've also added a commit that addresses the audio format issue #314 