### PR TITLE
update speech synthesis format

### DIFF
--- a/src/sdk/Audio/AudioOutputFormat.ts
+++ b/src/sdk/Audio/AudioOutputFormat.ts
@@ -3,22 +3,12 @@
 
 import { INumberDictionary } from "../../common/Exports";
 import { SpeechSynthesisOutputFormat } from "../SpeechSynthesisOutputFormat";
-import { AudioStreamFormatImpl } from "./AudioStreamFormat";
-
-export enum AudioFormatTag {
-    PCM = 1,
-    MuLaw,
-    Siren,
-    MP3,
-    SILKSkype,
-    OGG_OPUS,
-    WEBM_OPUS,
-}
+import { AudioFormatTag, AudioStreamFormatImpl } from "./AudioStreamFormat";
 
 /**
  * @private
  * @class AudioOutputFormatImpl
- * Updated in version 1.16.0
+ * Updated in version 1.17.0
  */
 // tslint:disable-next-line:max-classes-per-file
 export class AudioOutputFormatImpl extends AudioStreamFormatImpl {
@@ -49,6 +39,7 @@ export class AudioOutputFormatImpl extends AudioStreamFormatImpl {
         [SpeechSynthesisOutputFormat.Ogg48Khz16BitMonoOpus]: "ogg-48khz-16bit-mono-opus",
         [SpeechSynthesisOutputFormat.Webm16Khz16BitMonoOpus]: "webm-16khz-16bit-mono-opus",
         [SpeechSynthesisOutputFormat.Webm24Khz16BitMonoOpus]: "webm-24khz-16bit-mono-opus",
+        [SpeechSynthesisOutputFormat.Raw24Khz16BitMonoTrueSilk]: "raw-24khz-16bit-mono-truesilk",
     };
     private priAudioFormatString: string;
     /**
@@ -80,7 +71,7 @@ export class AudioOutputFormatImpl extends AudioStreamFormatImpl {
                        audioFormatString: string,
                        requestAudioFormatString: string,
                        hasHeader: boolean) {
-        super(samplesPerSec, bitsPerSample, channels);
+        super(samplesPerSec, bitsPerSample, channels, formatTag);
         this.formatTag = formatTag;
         this.avgBytesPerSec = avgBytesPerSec;
         this.blockAlign = blockAlign;
@@ -101,7 +92,7 @@ export class AudioOutputFormatImpl extends AudioStreamFormatImpl {
         switch (speechSynthesisOutputFormatString) {
             case "raw-8khz-8bit-mono-mulaw":
                 return new AudioOutputFormatImpl(
-                    AudioFormatTag.PCM,
+                    AudioFormatTag.MuLaw,
                     1,
                     8000,
                     8000,
@@ -370,6 +361,17 @@ export class AudioOutputFormatImpl extends AudioStreamFormatImpl {
                     1,
                     24000,
                     8000,
+                    2,
+                    16,
+                    speechSynthesisOutputFormatString,
+                    speechSynthesisOutputFormatString,
+                    false);
+            case "raw-24khz-16bit-mono-truesilk":
+                return new AudioOutputFormatImpl(
+                    AudioFormatTag.SILKSkype,
+                    1,
+                    24000,
+                    48000,
                     2,
                     16,
                     speechSynthesisOutputFormatString,

--- a/src/sdk/Audio/AudioOutputFormat.ts
+++ b/src/sdk/Audio/AudioOutputFormat.ts
@@ -40,6 +40,8 @@ export class AudioOutputFormatImpl extends AudioStreamFormatImpl {
         [SpeechSynthesisOutputFormat.Webm16Khz16BitMonoOpus]: "webm-16khz-16bit-mono-opus",
         [SpeechSynthesisOutputFormat.Webm24Khz16BitMonoOpus]: "webm-24khz-16bit-mono-opus",
         [SpeechSynthesisOutputFormat.Raw24Khz16BitMonoTrueSilk]: "raw-24khz-16bit-mono-truesilk",
+        [SpeechSynthesisOutputFormat.Raw8Khz8BitMonoALaw]: "raw-8khz-8bit-mono-alaw",
+        [SpeechSynthesisOutputFormat.Riff8Khz8BitMonoALaw]: "riff-8khz-8bit-mono-alaw",
     };
     private priAudioFormatString: string;
     /**
@@ -377,6 +379,28 @@ export class AudioOutputFormatImpl extends AudioStreamFormatImpl {
                     speechSynthesisOutputFormatString,
                     speechSynthesisOutputFormatString,
                     false);
+            case "raw-8khz-8bit-mono-alaw":
+                return new AudioOutputFormatImpl(
+                    AudioFormatTag.ALaw,
+                    1,
+                    8000,
+                    8000,
+                    1,
+                    8,
+                    speechSynthesisOutputFormatString,
+                    speechSynthesisOutputFormatString,
+                    false);
+            case "riff-8khz-8bit-mono-alaw":
+                return new AudioOutputFormatImpl(
+                    AudioFormatTag.ALaw,
+                    1,
+                    8000,
+                    8000,
+                    1,
+                    8,
+                    speechSynthesisOutputFormatString,
+                    "raw-8khz-8bit-mono-alaw",
+                    true);
             case "riff-16khz-16bit-mono-pcm":
             default:
                 return new AudioOutputFormatImpl(

--- a/src/sdk/Audio/AudioStreamFormat.ts
+++ b/src/sdk/Audio/AudioStreamFormat.ts
@@ -1,6 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+export enum AudioFormatTag {
+    PCM = 1,
+    MuLaw,
+    Siren,
+    MP3,
+    SILKSkype,
+    OGG_OPUS,
+    WEBM_OPUS,
+}
+
 /**
  * Represents audio stream format used for custom audio input configurations.
  * @class AudioStreamFormat
@@ -56,10 +66,12 @@ export class AudioStreamFormatImpl extends AudioStreamFormat {
      * @param {number} samplesPerSec - Samples per second.
      * @param {number} bitsPerSample - Bits per sample.
      * @param {number} channels - Number of channels.
+     * @param {AudioFormatTag} format - Audio format (PCM or mulaw).
      */
-    public constructor(samplesPerSec: number = 16000, bitsPerSample: number = 16, channels: number = 1) {
+    public constructor(samplesPerSec: number = 16000, bitsPerSample: number = 16, channels: number = 1, format: AudioFormatTag = AudioFormatTag.PCM) {
         super();
-        this.formatTag = 1;
+        /* 1 for PCM; 6 for mulaw */
+        this.formatTag = format === AudioFormatTag.PCM ? 1 : 6;
         this.bitsPerSample = bitsPerSample;
         this.samplesPerSec = samplesPerSec;
         this.channels = channels;
@@ -79,8 +91,8 @@ export class AudioStreamFormatImpl extends AudioStreamFormat {
         this.setString(view, 8, "WAVEfmt ");
         /* format chunk length */
         view.setUint32(16, 16, true);
-        /* sample format (raw) */
-        view.setUint16(20, 1, true);
+        /* audio format 1=PCM, 3=IEEE Float, 6=mulaw, 7=alaw, 257=IBM Mu-Law, 258=IBM A-Law, 259=ADPCM, 65534=Extensible */
+        view.setUint16(20, this.formatTag, true);
         /* channel count */
         view.setUint16(22, this.channels, true);
         /* sample rate */

--- a/src/sdk/Audio/AudioStreamFormat.ts
+++ b/src/sdk/Audio/AudioStreamFormat.ts
@@ -9,6 +9,7 @@ export enum AudioFormatTag {
     SILKSkype,
     OGG_OPUS,
     WEBM_OPUS,
+    ALaw,
 }
 
 /**
@@ -66,12 +67,23 @@ export class AudioStreamFormatImpl extends AudioStreamFormat {
      * @param {number} samplesPerSec - Samples per second.
      * @param {number} bitsPerSample - Bits per sample.
      * @param {number} channels - Number of channels.
-     * @param {AudioFormatTag} format - Audio format (PCM or mulaw).
+     * @param {AudioFormatTag} format - Audio format (PCM, alaw or mulaw).
      */
     public constructor(samplesPerSec: number = 16000, bitsPerSample: number = 16, channels: number = 1, format: AudioFormatTag = AudioFormatTag.PCM) {
         super();
-        /* 1 for PCM; 6 for mulaw */
-        this.formatTag = format === AudioFormatTag.PCM ? 1 : 6;
+        /* 1 for PCM; 6 for alaw; 7 for mulaw */
+        switch (format) {
+            case AudioFormatTag.PCM:
+                this.formatTag = 1;
+                break;
+            case AudioFormatTag.ALaw:
+                this.formatTag = 6;
+                break;
+            case AudioFormatTag.MuLaw:
+                this.formatTag = 7;
+                break;
+            default:
+        }
         this.bitsPerSample = bitsPerSample;
         this.samplesPerSec = samplesPerSec;
         this.channels = channels;
@@ -91,7 +103,7 @@ export class AudioStreamFormatImpl extends AudioStreamFormat {
         this.setString(view, 8, "WAVEfmt ");
         /* format chunk length */
         view.setUint32(16, 16, true);
-        /* audio format 1=PCM, 3=IEEE Float, 6=mulaw, 7=alaw, 257=IBM Mu-Law, 258=IBM A-Law, 259=ADPCM, 65534=Extensible */
+        /* audio format */
         view.setUint16(20, this.formatTag, true);
         /* channel count */
         view.setUint16(22, this.channels, true);

--- a/src/sdk/SpeechSynthesisOutputFormat.ts
+++ b/src/sdk/SpeechSynthesisOutputFormat.ts
@@ -4,7 +4,7 @@
 /**
  * Define speech synthesis audio output formats.
  * @enum SpeechSynthesisOutputFormat
- * Updated in version 1.16.0
+ * Updated in version 1.17.0
  */
 export enum SpeechSynthesisOutputFormat {
     /**
@@ -15,12 +15,14 @@ export enum SpeechSynthesisOutputFormat {
 
     /**
      * riff-16khz-16kbps-mono-siren
+     * @note Unsupported by the service. Do not use this value.
      * @member SpeechSynthesisOutputFormat.Riff16Khz16KbpsMonoSiren
      */
     Riff16Khz16KbpsMonoSiren ,
 
     /**
      * audio-16khz-16kbps-mono-siren
+     * @note Unsupported by the service. Do not use this value.
      * @member SpeechSynthesisOutputFormat.Audio16Khz16KbpsMonoSiren
      */
     Audio16Khz16KbpsMonoSiren,
@@ -165,4 +167,11 @@ export enum SpeechSynthesisOutputFormat {
      * @member SpeechSynthesisOutputFormat.Webm24Khz16BitMonoOpus
      */
     Webm24Khz16BitMonoOpus,
+
+    /**
+     * raw-24khz-16bit-mono-truesilk
+     * Added in version 1.17.0
+     * @member SpeechSynthesisOutputFormat.Raw24Khz16BitMonoTrueSilk
+     */
+     Raw24Khz16BitMonoTrueSilk,
 }

--- a/src/sdk/SpeechSynthesisOutputFormat.ts
+++ b/src/sdk/SpeechSynthesisOutputFormat.ts
@@ -174,4 +174,18 @@ export enum SpeechSynthesisOutputFormat {
      * @member SpeechSynthesisOutputFormat.Raw24Khz16BitMonoTrueSilk
      */
      Raw24Khz16BitMonoTrueSilk,
+
+    /**
+     * raw-8khz-8bit-mono-alaw
+     * Added in version 1.17.0
+     * @member SpeechSynthesisOutputFormat.Raw8Khz8BitMonoALaw
+     */
+     Raw8Khz8BitMonoALaw,
+
+    /**
+     * riff-8khz-8bit-mono-alaw
+     * Added in version 1.17.0
+     * @member SpeechSynthesisOutputFormat.Riff8Khz8BitMonoALaw
+     */
+     Riff8Khz8BitMonoALaw,
 }


### PR DESCRIPTION
- Add `Raw24Khz16BitMonoTrueSilk`, mark siren format as unsupported
- Call `onAudioEnd()` callback if the format is not supported for playback
- Update riff header for mulaw