### PR TITLE
Fix UnhandledPromiseRejection warning in Node

### DIFF
--- a/src/common.speech/RequestSession.ts
+++ b/src/common.speech/RequestSession.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { Z_NO_COMPRESSION } from "zlib";
 import { ReplayableAudioNode } from "../common.browser/Exports";
 import {
     createNoDashGuid,
@@ -164,8 +165,10 @@ export class RequestSession {
         if (!!this.privTurnDeferral && !!this.privInTurn) {
             // What? How are we starting a turn with another not done?
             this.privTurnDeferral.reject("Another turn started before current completed.");
+            // Avoid UnhandledPromiseRejection if privTurnDeferral is not being awaited
+            /* tslint:disable:no-empty */
+            this.privTurnDeferral.promise.then().catch(() => { });
         }
-
         this.privInTurn = true;
         this.privTurnDeferral = new Deferred<void>();
     }

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -254,11 +254,14 @@ export abstract class ServiceRecognizerBase implements IDisposable {
 
     public async stopRecognizing(): Promise<void> {
         if (this.privRequestSession.isRecognizing) {
-            await this.audioSource.turnOff();
-            await this.sendFinalAudio();
-            await this.privRequestSession.onStopRecognizing();
-            await this.privRequestSession.turnCompletionPromise;
-            await this.privRequestSession.dispose();
+            try {
+                await this.audioSource.turnOff();
+                await this.sendFinalAudio();
+                await this.privRequestSession.onStopRecognizing();
+                await this.privRequestSession.turnCompletionPromise;
+            } finally {
+                await this.privRequestSession.dispose();
+            }
         }
         return;
     }

--- a/src/common.speech/SynthesisTurn.ts
+++ b/src/common.speech/SynthesisTurn.ts
@@ -186,6 +186,9 @@ export class SynthesisTurn {
         if (!!this.privTurnDeferral && !!this.privInTurn) {
             // What? How are we starting a turn with another not done?
             this.privTurnDeferral.reject("Another turn started before current completed.");
+            // Avoid UnhandledPromiseRejection if privTurnDeferral is not being awaited
+            /* tslint:disable:no-empty */
+            this.privTurnDeferral.promise.then().catch(() => { });
         }
         this.privInTurn = true;
         this.privTurnDeferral = new Deferred<void>();


### PR DESCRIPTION
For long connection scenarios, ServiceAdapterBase can receive a turn.start message when the current turn hasn't finished, causing it to reject a promise that's not being awaited, resulting in a UnhandledPromiseRejection warning in Node. This PR handles the rejection to avoid that Unhandled warning (with no adverse effects if the promise is being awaited).