### PR TITLE
Mirroring typo fix from MicrosoftDocs/azure-docs-sdk-node#1279

### DIFF
--- a/src/sdk/RecognitionResult.ts
+++ b/src/sdk/RecognitionResult.ts
@@ -81,22 +81,22 @@ export class RecognitionResult {
     }
 
     /**
-     * Duration of recognized speech in 100 nano second incements.
+     * Duration of recognized speech in 100 nano second increments.
      * @member RecognitionResult.prototype.duration
      * @function
      * @public
-     * @returns {number} Duration of recognized speech in 100 nano second incements.
+     * @returns {number} Duration of recognized speech in 100 nano second increments.
      */
     public get duration(): number {
         return this.privDuration;
     }
 
     /**
-     * Offset of recognized speech in 100 nano second incements.
+     * Offset of recognized speech in 100 nano second increments.
      * @member RecognitionResult.prototype.offset
      * @function
      * @public
-     * @returns {number} Offset of recognized speech in 100 nano second incements.
+     * @returns {number} Offset of recognized speech in 100 nano second increments.
      */
     public get offset(): number {
         return this.privOffset;


### PR DESCRIPTION
A reader of the [docs.ms](https://docs.microsoft.com/en-us/javascript/api/microsoft-cognitiveservices-speech-sdk/speechrecognitionresult?view=azure-node-latest#properties) docs filed a [PR](https://github.com/MicrosoftDocs/azure-docs-sdk-node/pull/1279) to resolve this issue. 

To truly fix it, we need to fix it in source, which is here! Can someone give this a quick PR and approval? Thanks!