### PR TITLE
Fix long running timeout issue with endpoints

### DIFF
--- a/src/common.speech/RequestSession.ts
+++ b/src/common.speech/RequestSession.ts
@@ -104,7 +104,6 @@ export class RequestSession {
         this.privIsRecognizing = true;
         this.privTurnStartAudioOffset = 0;
         this.privLastRecoOffset = 0;
-        this.privRequestId = createNoDashGuid();
         this.privRecogNumber++;
         this.privServiceTelemetryListener = new ServiceTelemetryListener(this.privRequestId, this.privAudioSourceId, this.privAudioNodeId);
         this.onEvent(new RecognitionTriggeredEvent(this.requestId, this.privSessionId, this.privAudioSourceId, this.privAudioNodeId));
@@ -156,9 +155,12 @@ export class RequestSession {
         } else {
             // Start a new request set.
             this.privTurnStartAudioOffset = this.privLastRecoOffset;
-            this.privRequestId = createNoDashGuid();
             this.privAudioNode.replay();
         }
+    }
+
+    public onSpeechContext = (): void => {
+        this.privRequestId = createNoDashGuid();
     }
 
     public onServiceTurnStartResponse = (): void => {

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -485,6 +485,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
 
     protected sendSpeechContext = (connection: IConnection): Promise<void> => {
         const speechContextJson = this.speechContext.toJSON();
+        this.privRequestSession.onSpeechContext();
 
         if (speechContextJson) {
             return connection.send(new SpeechConnectionMessage(

--- a/tests/LongRunning/TranslationRecoReconnectTests.ts
+++ b/tests/LongRunning/TranslationRecoReconnectTests.ts
@@ -41,7 +41,6 @@ const BuildSpeechConfig: () => sdk.SpeechTranslationConfig = (): sdk.SpeechTrans
     expect(s).not.toBeUndefined();
     return s;
 };
-/*
 
 // Tests client reconnect after speech timeouts.
 test("Reconnect After timeout", (done: jest.DoneCallback) => {
@@ -196,7 +195,6 @@ test("Reconnect After timeout", (done: jest.DoneCallback) => {
             done.fail(err);
         });
 }, 1000 * 60 * 12);
-*/
 
 test("Test new connection on empty push stream for translator", (done: jest.DoneCallback) => {
     // tslint:disable-next-line:no-console
@@ -215,51 +213,32 @@ test("Test new connection on empty push stream for translator", (done: jest.Done
     s = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
     s.speechRecognitionLanguage = "en-US";
     s.addTargetLanguage("de-DE");
-    const startTime: number = Date.now();
-    let longPauseOccured: boolean = false;
-    let shortPause: boolean = false;
+    let disconnected: boolean = false;
+    let reconnected: boolean = false;
+    let reconnectTime: number;
 
     const openPushStream = (): sdk.PushAudioInputStream => {
         // create the push stream we need for the speech sdk.
         const pushStream: sdk.PushAudioInputStream = sdk.AudioInputStream.createPushStream();
-        const chunkSize: number = 1024;
+        const chunkSize: number = 512;
 
         // open the file and push it to the push stream in chunkSize bytes per "data" event.
-        const stream = fs.createReadStream(Settings.LongerWaveFile, { highWaterMark: chunkSize });
-        const pauseInSeconds = 2;
+        const stream = fs.createReadStream(Settings.EvenLongerWaveFile, { highWaterMark: chunkSize });
+        let pauseInSeconds = .2;
 
         stream.on("data", (arrayBuffer: Buffer): void => {
-            if (disconnected) {
-                stream.close();
-            } else {
-                pushStream.write(arrayBuffer.slice());
-                const currentTime: number = Date.now();
+            pushStream.write(arrayBuffer.slice());
 
-                // Using very small chunks, we paused for pauseInSeconds after reading each chunk,
-                // elongating the read time for the file.
-                if (shortPause) {
-                    stream.pause();
-                    // set timeout for resume
-                    setTimeout(
-                        () => {
-                            stream.resume();
-                        },
-                        pauseInSeconds * 1000);
-                } else if (!longPauseOccured && currentTime > startTime + (1000 * 60 * 9.8)) {
-                    // pause reading the file
-                    stream.pause();
-                    longPauseOccured = true;
-                    // calculate restart timer. we will pause 20 seconds.
-                    const waitMSec = Math.round(1000 * 20);
-                    // set timeout for resume
-                    setTimeout(
-                        () => {
-                            stream.resume();
-                        },
-                        waitMSec);
-                }
-                shortPause = !shortPause;
-            }
+            // Using very small chunks, we paused for pauseInSeconds after reading each chunk,
+            // elongating the read time for the file.
+            stream.pause();
+            pauseInSeconds = Math.random();
+            // set timeout for resume
+            setTimeout(
+                () => {
+                    stream.resume();
+                },
+                pauseInSeconds * 1000);
         });
         objsToClose.push(stream);
         objsToClose.push(pushStream);
@@ -269,27 +248,23 @@ test("Test new connection on empty push stream for translator", (done: jest.Done
 
     objsToClose.push(s);
 
-    /*
-    // Close p in 20 minutes.
-    const endTime: number = Date.now() + (1000 * 60 * 10); // 20 min.
-    WaitForCondition(() => {
-        return Date.now() >= endTime;
-    }, () => {
-    });
-    */
-
     const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(openPushStream());
 
     const r: sdk.TranslationRecognizer = new sdk.TranslationRecognizer(s, config);
     objsToClose.push(r);
 
-    let disconnected: boolean = false;
-
-    r.recognized = (o: sdk.TranslationRecognizer, e: sdk.TranslationRecognitionEventArgs) => {
-        try {
-            expect(sdk.ResultReason[e.result.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
-        } catch (error) {
-            done.fail(error);
+    r.recognizing = (s: sdk.TranslationRecognizer, event: sdk.TranslationRecognitionEventArgs) => {
+        if (reconnected) {
+            if (Date.now() < reconnectTime + (1000 * 60 * 10)) {
+                done();
+            } else {
+                done.fail("Recognizing callback didn't happen within 10 minutes after reconnect");
+            }
+        }
+    };
+    r.canceled = (s: sdk.TranslationRecognizer, e: sdk.TranslationRecognitionCanceledEventArgs) => {
+        if (e.errorCode === sdk.CancellationErrorCode.BadRequestParameters) {
+            done.fail("Bad Request received from service, rerun test");
         }
     };
 
@@ -298,15 +273,17 @@ test("Test new connection on empty push stream for translator", (done: jest.Done
     conn.disconnected = (args: sdk.ConnectionEventArgs): void => {
         disconnected = true;
     };
+    conn.connected = (args: sdk.ConnectionEventArgs): void => {
+        if (disconnected) {
+            reconnected = true;
+            reconnectTime = Date.now();
+        }
+    };
 
     r.startContinuousRecognitionAsync(() => {
-        WaitForCondition(() => (disconnected), () => {
-            // tslint:disable-next-line:no-console
-            console.log("DISCONNECTION REACHED");
-            done();
-        });
+        // empty block
     },
     (err: string) => {
         done.fail(err);
     });
-}, 1000 * 60 * 20); // 20 minutes.
+}, 1000 * 60 * 70); // 70 minutes.

--- a/tests/Settings.ts
+++ b/tests/Settings.ts
@@ -68,12 +68,14 @@ export class Settings {
     public static WaveFile8ch: string = Settings.InputDir + "Speech016_30s_xmos_8ch.wav";
     public static WaveFile44k: string = Settings.InputDir + "whatstheweatherlike.44khz.wav";
     public static LongerWaveFile: string = Settings.InputDir + "StreamingEnrollment.wav";
-    public static EvenLongerWaveFile: string = Settings.InputDir + "speechServiceOverview.wav";
     public static MonoChannelAlignedWaveFile: string = Settings.InputDir + "only-a-test.wav";
     public static WaveFileLanguage: string = "en-US";
     public static WaveFileDuration: number = 12900000;
     public static WaveFileOffset: number = 1000000;
     public static WaveFileText: string = "What's the weather like?";
+
+    // Available at https://glharper-js-test.azurewebsites.net/speechServiceOverview.zip
+    public static EvenLongerWaveFile: string = Settings.InputDir + "speechServiceOverview.wav";
 
     public static AmbiguousWaveFile: string = Settings.InputDir + "wreck-a-nice-beach.wav";
 

--- a/tests/Settings.ts
+++ b/tests/Settings.ts
@@ -68,6 +68,7 @@ export class Settings {
     public static WaveFile8ch: string = Settings.InputDir + "Speech016_30s_xmos_8ch.wav";
     public static WaveFile44k: string = Settings.InputDir + "whatstheweatherlike.44khz.wav";
     public static LongerWaveFile: string = Settings.InputDir + "StreamingEnrollment.wav";
+    public static EvenLongerWaveFile: string = Settings.InputDir + "speechServiceOverview.wav";
     public static MonoChannelAlignedWaveFile: string = Settings.InputDir + "only-a-test.wav";
     public static WaveFileLanguage: string = "en-US";
     public static WaveFileDuration: number = 12900000;


### PR DESCRIPTION
From Friedel:
"run a 1hour recognition.

it will run a translation session, simulating a "bad" connection by delaying the audio randomly for 1-5seconds, then resuming the pushstream.

during that time one can see the following behavior:

  - the audio is correctly processed for n*10minutes + 9minutes:58seconds  (i.e., is almost exactly at a 10 minute boundary)
  - audio is delayed for (e.g.) 5 seconds (i.e., the delay will cross the 10minute boundary).
  - after 1second into that delay, the audio buffer seems to be empty
  - after another 1 seconds, the connection is at a 10min boundary and the service disconnects
  - the client immediately re-connects to the service
  - after another 3 seconds the client resumes audio

from that point on, one can see on the client that audio is "pushed" into the pushtream,

HOWEVER

on the service side we dont see any audio comming in and after 5 minutes the no-audio timeout triggers and an error message is sent on the websocket.

BUT

on the sdk side, as a consequence, the client will start to start sending audio on the existing connection again (note: even though the service indicated a audio timeout error, the client sdk does NOT reconnect but re-use the exisiting connection!)

so, since the service processes audio at 2x realtime, after a total of 10min the 10min audio is processed.
This "hides" the error since doing an overall timecheck, processing seems to be normal, however, during this 5minute window, no processing takes place.
"