### PR TITLE
Add protocol to agent as workaround

### DIFF
--- a/src/common.browser/WebsocketMessageAdapter.ts
+++ b/src/common.browser/WebsocketMessageAdapter.ts
@@ -118,6 +118,11 @@ export class WebsocketMessageAdapter {
                 const checkAgent: CertCheckAgent = new CertCheckAgent(this.proxyInfo);
 
                 options.agent = checkAgent.GetAgent();
+
+                // Workaround for https://github.com/microsoft/cognitive-services-speech-sdk-js/issues/465
+                // Which is root caused by https://github.com/TooTallNate/node-agent-base/issues/61
+                const uri = new URL(this.privUri);
+                (options.agent as any).protocol = uri.protocol;
                 this.privWebsocketClient = new ws(this.privUri, options);
             }
 

--- a/src/common.browser/WebsocketMessageAdapter.ts
+++ b/src/common.browser/WebsocketMessageAdapter.ts
@@ -122,7 +122,14 @@ export class WebsocketMessageAdapter {
                 // Workaround for https://github.com/microsoft/cognitive-services-speech-sdk-js/issues/465
                 // Which is root caused by https://github.com/TooTallNate/node-agent-base/issues/61
                 const uri = new URL(this.privUri);
-                (options.agent as any).protocol = uri.protocol;
+                let protocol: string = uri.protocol;
+
+                if (protocol?.toLocaleLowerCase() === "wss:") {
+                    protocol = "https:";
+                } else if (protocol?.toLocaleLowerCase() === "ws:") {
+                    protocol = "http:";
+                }
+                (options.agent as any).protocol = protocol;
                 this.privWebsocketClient = new ws(this.privUri, options);
             }
 


### PR DESCRIPTION
The long version is that agent-base (What the OCSP check agent is based on) uses the callstack to determine what protocol is being used. When Sentry is being used w/ the library, it asks for the protocol from a call stack that doesn't happen to have the expected modules in it, resulting in http being returned.

Except trying to connect to the Speech Service with http results in an error because https is required.

So explicitly set the protocol to whatever URL is being requested when using an agent.