### PR TITLE
Check if 'detailed' property is missing

### DIFF
--- a/src/common.speech/SpeechContext.ts
+++ b/src/common.speech/SpeechContext.ts
@@ -49,6 +49,11 @@ export class SpeechContext {
                 format: {}
             };
         }
+        if (this.privContext.phraseOutput.detailed === undefined) { 
+            this.privContext.phraseOutput.detailed = {
+                options: []
+            },
+        }
         this.privContext.phraseOutput.format = "Detailed";
         this.privContext.phraseOutput.detailed.options.push("PronunciationAssessment");
         if (this.privContext.phraseOutput.detailed.options.indexOf("WordTimings") === -1) {


### PR DESCRIPTION
Encountering an error, that 'detailed' is undefined, while developing with the speech-sdk. It's possible for the phraseOutput to be defined while its 'detailed' property is not, leading to errors.