### PR TITLE
Glharper/lid custom models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "bent": "^7.3.12",
         "https-proxy-agent": "^4.0.0",
         "simple-lru-cache": "0.0.2",
-        "url-parse": "^1.5.6",
+        "url-parse": "^1.5.10",
         "uuid": "^8.3.0",
         "ws": "^7.5.6"
       },
@@ -11430,10 +11430,10 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.6.tgz",
-      "integrity": "sha512-xj3QdUJ1DttD1LeSfvJlU1eiF1RvBSBfUu8GplFGdUzSO28y5yUtEl7wb//PI4Af6qh0o/K8545vUmucRrfWsw==",
-      "dependencies": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
@@ -21438,9 +21438,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.6.tgz",
-      "integrity": "sha512-xj3QdUJ1DttD1LeSfvJlU1eiF1RvBSBfUu8GplFGdUzSO28y5yUtEl7wb//PI4Af6qh0o/K8545vUmucRrfWsw==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "microsoft-cognitiveservices-speech-sdk",
   "author": "Microsoft Corporation",
   "homepage": "https://docs.microsoft.com/azure/cognitive-services/speech-service/",
-  "version": "1.18.1-alpha.0.1",
+  "version": "1.21.0-alpha.0.1",
   "license": "MIT",
   "description": "Microsoft Cognitive Services Speech SDK for JavaScript",
   "keywords": [
@@ -116,9 +116,7 @@
     "extend": "3.0.2",
     "set-value": "^4.0.1",
     "glob-parent": "^5.1.2",
-    "minimist": "1.2.5",
-    "yargs": "17.3.1",
-    "strip-ansi": "7.0.1"
+    "minimist": "1.2.5"
   },
   "sideEffects": false
 }

--- a/src/common.speech/RecognizerConfig.ts
+++ b/src/common.speech/RecognizerConfig.ts
@@ -61,6 +61,28 @@ export class RecognizerConfig {
         return this.parameters.getProperty(PropertyId.SpeechServiceConnection_AutoDetectSourceLanguages, undefined);
     }
 
+    public get recognitionEndpointVersion(): string {
+        return this.parameters.getProperty(PropertyId.SpeechServiceConnection_RecognitionEndpointVersion, undefined);
+    }
+
+    public get sourceLanguageModels(): { language: string, endpoint: string }[] {
+        const models: { language: string, endpoint: string }[] = [];
+        let modelsExist: boolean = false;
+        if (this.autoDetectSourceLanguages !== undefined) {
+            for (const language of this.autoDetectSourceLanguages.split(",")) {
+                const customProperty = language + PropertyId.SpeechServiceConnection_EndpointId.toString();
+                const modelId: string = this.parameters.getProperty(customProperty, undefined);
+                if (modelId !== undefined) {
+                    models.push( { language, endpoint: modelId });
+                    modelsExist = true;
+                } else {
+                    models.push( { language, endpoint: "" } );
+                }
+            }
+        }
+        return modelsExist ? models : undefined;
+    }
+
     public get maxRetryCount(): number {
         return this.privMaxRetryCount;
     }

--- a/src/common.speech/SpeechConnectionFactory.ts
+++ b/src/common.speech/SpeechConnectionFactory.ts
@@ -78,7 +78,11 @@ export class SpeechConnectionFactory extends ConnectionFactoryBase {
                     if (config.parameters.getProperty(ForceDictationPropertyName, "false") === "true") {
                         endpoint = host + this.dictationRelativeUri;
                     } else {
-                        endpoint = host + this.conversationRelativeUri;
+                        if (config.recognitionEndpointVersion !== undefined) {
+                            endpoint = host + `/speech/recognition/conversation/cognitiveservices/v${config.recognitionEndpointVersion}`;
+                        } else {
+                            endpoint = host + this.conversationRelativeUri;
+                        }
                     }
                     break;
                 case RecognitionMode.Dictation:

--- a/src/common.speech/SpeechServiceRecognizer.ts
+++ b/src/common.speech/SpeechServiceRecognizer.ts
@@ -57,6 +57,14 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                     resultType: "Always"
                 }
             });
+            const customModels: { language: string, endpoint: string }[] = recognizerConfig.sourceLanguageModels;
+            if (customModels !== undefined) {
+                this.privSpeechContext.setSection("phraseDetection", {
+                    customModels,
+                    onInterim: { action: "None" },
+                    onSuccess: { action: "None" },
+                });
+            }
         }
     }
 

--- a/src/sdk/PropertyId.ts
+++ b/src/sdk/PropertyId.ts
@@ -246,6 +246,12 @@ export enum PropertyId {
     SpeechServiceConnection_EnableAudioLogging,
 
     /**
+     * A string value representing the desired endpoint version to target for Speech Recognition.
+     * Added in version 1.21.0
+     */
+    SpeechServiceConnection_RecognitionEndpointVersion,
+
+    /**
      * The requested Cognitive Services Speech Service response output profanity setting.
      * Allowed values are "masked", "removed", and "raw".
      * Added in version 1.7.0.


### PR DESCRIPTION
Allow custom models to be set for at-start LID for SR scenarios using SourceLanguageConfig. (API already existed, but no wiring to speech.context generation.) 