### PR TITLE
"Default on" for word-level details, now including confidence

### DIFF
--- a/src/common.speech/ConnectionFactoryBase.ts
+++ b/src/common.speech/ConnectionFactoryBase.ts
@@ -75,6 +75,16 @@ export abstract class ConnectionFactoryBase implements IConnectionFactory {
             queryParams,
             endpoint);
 
+        if (queryParams[QueryParameterNames.Format].toLowerCase() === "detailed") {
+            // If not otherwise specified, automatically enable word-level timestamps for detailed results
+            if (!(QueryParameterNames.EnableWordLevelTimestamps in queryParams)) {
+                queryParams[QueryParameterNames.EnableWordLevelTimestamps] = "true";
+            }
+
+            // Match enablement/disablement of word-level confidence to enablement/disablement of word-level timestamps
+            queryParams[QueryParameterNames.EnableWordLevelConfidence] = queryParams[QueryParameterNames.EnableWordLevelTimestamps];
+        }
+
         const serviceProperties: IStringDictionary<string> = JSON.parse(config.parameters.getProperty(ServicePropertiesPropertyName, "{}")) as IStringDictionary<string>;
 
         Object.keys(serviceProperties).forEach((value: string): void => {

--- a/src/common.speech/QueryParameterNames.ts
+++ b/src/common.speech/QueryParameterNames.ts
@@ -8,6 +8,7 @@ export class QueryParameterNames {
     public static EnableAudioLogging: string = "storeAudio";
     public static EnableLanguageId: string = "lidEnabled";
     public static EnableWordLevelTimestamps: string = "wordLevelTimestamps";
+    public static EnableWordLevelConfidence: string = "wordLevelConfidence";
     public static EndSilenceTimeoutMs: string = "endSilenceTimeoutMs";
     public static Format: string = "format";
     public static InitialSilenceTimeoutMs: string = "initialSilenceTimeoutMs";

--- a/tests/SpeechConfigTests.ts
+++ b/tests/SpeechConfigTests.ts
@@ -814,6 +814,30 @@ describe("Connection URL Tests", () => {
                         "wordLevelConfidence=true"
                     );
 
+                    // enabling via requestWordLevelTimestamps should work the same way
+                    testUrlParameter(createMethod,
+                        (s: sdk.SpeechConfig): void => {
+                            s.requestWordLevelTimestamps();
+                        },
+                        recognizerCreateMethod,
+                        done,
+                        "format=detailed",
+                        "wordLevelTimestamps=true",
+                        "wordLevelConfidence=true"
+                    );
+
+                    // ditto for the property
+                    testUrlParameter(createMethod,
+                        (s: sdk.SpeechConfig): void => {
+                            s.setProperty(sdk.PropertyId.SpeechServiceResponse_RequestWordLevelTimestamps, 'true');
+                        },
+                        recognizerCreateMethod,
+                        done,
+                        "format=detailed",
+                        "wordLevelTimestamps=true",
+                        "wordLevelConfidence=true"
+                    );
+
                     // explicit disablement of word-level details (via timestamp) should work
                     testUrlParameter(createMethod,
                         (s: sdk.SpeechConfig): void => {

--- a/tests/SpeechConfigTests.ts
+++ b/tests/SpeechConfigTests.ts
@@ -798,6 +798,36 @@ describe("Connection URL Tests", () => {
                     );
                 });
 
+                test("detailed output format", (done: jest.DoneCallback) => {
+                    // tslint:disable-next-line:no-console
+                    console.info("Name: detailed output format");
+
+                    // detailed output format should auto-enable word-level details
+                    testUrlParameter(createMethod,
+                        (s: sdk.SpeechConfig): void => {
+                            s.outputFormat = sdk.OutputFormat.Detailed;
+                        },
+                        recognizerCreateMethod,
+                        done,
+                        "format=detailed",
+                        "wordLevelTimestamps=true",
+                        "wordLevelConfidence=true"
+                    );
+
+                    // explicit disablement of word-level details (via timestamp) should work
+                    testUrlParameter(createMethod,
+                        (s: sdk.SpeechConfig): void => {
+                            s.outputFormat = sdk.OutputFormat.Detailed;
+                            s.setProperty(sdk.PropertyId.SpeechServiceResponse_RequestWordLevelTimestamps, 'false');
+                        },
+                        recognizerCreateMethod,
+                        done,
+                        "format=detailed",
+                        "wordLevelTimestamps=false",
+                        "wordLevelConfidence=false"
+                    );
+                });
+
                 test("initialSilenceTimeoutMs", (done: jest.DoneCallback) => {
                     // tslint:disable-next-line:no-console
                     console.info("Name: initialSilenceTimeoutMs");


### PR DESCRIPTION
Currently:
- word-level timing values are "opt in" via the `request` method or setting a property; this implicitly sets result output format to detailed if it wasn't already
- word-level confidence values aren't officially exposed in any capacity

With the change:
- word-level confidence values piggyback on whatever enablement state word-level timing values have
- all word-level details will default to "on" for detailed output format (implicit or explicit) and can be turned off via the word-level timings property