### PR TITLE
Update README.md to remove broken link to non-existing JS Browser quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@ npm install microsoft-cognitiveservices-speech-sdk
 ## Documentation
 
 * [Quick tutorial - Node.js](https://docs.microsoft.com/azure/cognitive-services/speech-service/quickstart-js-node)
-* [Quick tutorial - Browser](https://docs.microsoft.com/azure/cognitive-services/speech-service/quickstart-js-browser)
 * [API Reference](https://aka.ms/csspeech/javascriptref)
-* [Samples](https://aka.ms/csspeech/samples)
 * [Speech SDK Homepage](https://aka.ms/csspeech)
+
+## Samples
+
+* Quick-start samples for Node.js: In the [Speech SDK samples repo](https://aka.ms/csspeech/samples) under quickstart/javascript/browser.
+* Quick-start samples for Browser: In the [Speech SDK samples repo](https://aka.ms/csspeech/samples) under quickstart/javascript/node.
+* Other Node.js and Browser samples: In the [Speech SDK samples repo](https://aka.ms/csspeech/samples) under samples/js.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ npm install microsoft-cognitiveservices-speech-sdk
 
 ## Samples
 
-* Quick-start samples for Node.js: In the [Speech SDK samples repo](https://aka.ms/csspeech/samples) under quickstart/javascript/browser.
-* Quick-start samples for Browser: In the [Speech SDK samples repo](https://aka.ms/csspeech/samples) under quickstart/javascript/node.
+* Quick-start samples for Node.js: In the [Speech SDK samples repo](https://aka.ms/csspeech/samples) under quickstart/javascript/node.
+* Quick-start samples for Browser: In the [Speech SDK samples repo](https://aka.ms/csspeech/samples) under quickstart/javascript/browser.
 * Other Node.js and Browser samples: In the [Speech SDK samples repo](https://aka.ms/csspeech/samples) under samples/js.
 
 ## Building


### PR DESCRIPTION
Also break apart the documentation section into two sections, one with documentation links and the other with samples links.

Fixes issue #544. Thank you fungiboletus for reporting this!