### PR TITLE
ignore undefined token

### DIFF
--- a/src/common.speech/CognitiveTokenAuthentication.ts
+++ b/src/common.speech/CognitiveTokenAuthentication.ts
@@ -25,10 +25,10 @@ export class CognitiveTokenAuthentication implements IAuthentication {
     }
 
     public fetch(authFetchEventId: string): Promise<AuthInfo> {
-        return this.privFetchCallback(authFetchEventId).then((token: string): AuthInfo => new AuthInfo(AuthHeader, CognitiveTokenAuthentication.privTokenPrefix + token));
+        return this.privFetchCallback(authFetchEventId).then((token: string): AuthInfo => new AuthInfo(AuthHeader, token === undefined ? undefined : CognitiveTokenAuthentication.privTokenPrefix + token));
     }
 
     public fetchOnExpiry(authFetchEventId: string): Promise<AuthInfo> {
-        return this.privFetchOnExpiryCallback(authFetchEventId).then((token: string): AuthInfo => new AuthInfo(AuthHeader, CognitiveTokenAuthentication.privTokenPrefix + token));
+        return this.privFetchOnExpiryCallback(authFetchEventId).then((token: string): AuthInfo => new AuthInfo(AuthHeader, token === undefined ? undefined : CognitiveTokenAuthentication.privTokenPrefix + token));
     }
 }


### PR DESCRIPTION
If auth token is not set, the SDK would append a header of `Authentication=bearer undefined`, which is not expected.