### PR TITLE
Create audio worklet blob on-demand

### DIFF
--- a/src/common.browser/PCMRecorder.ts
+++ b/src/common.browser/PCMRecorder.ts
@@ -19,25 +19,6 @@ export class PcmRecorder implements IRecorder {
         const waveStreamEncoder = new RiffPcmEncoder(context.sampleRate, desiredSampleRate);
 
         const micInput = context.createMediaStreamSource(mediaStream);
-        if (!this.privSpeechProcessorScript) {
-            const workletScript = `class SP extends AudioWorkletProcessor {
-                constructor(options) {
-                  super(options);
-                }
-                process(inputs, outputs) {
-                  const input = inputs[0];
-                  const output = [];
-                  for (let channel = 0; channel < input.length; channel += 1) {
-                    output[channel] = input[channel];
-                  }
-                  this.port.postMessage(output[0]);
-                  return true;
-                }
-              }
-              registerProcessor('speech-processor', SP);`;
-            const blob = new Blob([workletScript], { type: "application/javascript; charset=utf-8" });
-            this.privSpeechProcessorScript = URL.createObjectURL(blob);
-        }
 
         const attachScriptProcessor = (): void => {
             // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -82,7 +63,27 @@ export class PcmRecorder implements IRecorder {
         // https://webaudio.github.io/web-audio-api/#audioworklet
         // Using AudioWorklet to improve audio quality and avoid audio glitches due to blocking the UI thread
 
-        if (!!this.privSpeechProcessorScript && !!context.audioWorklet) {
+        if (!!context.audioWorklet) {
+            if (!this.privSpeechProcessorScript) {
+                const workletScript = `class SP extends AudioWorkletProcessor {
+                    constructor(options) {
+                      super(options);
+                    }
+                    process(inputs, outputs) {
+                      const input = inputs[0];
+                      const output = [];
+                      for (let channel = 0; channel < input.length; channel += 1) {
+                        output[channel] = input[channel];
+                      }
+                      this.port.postMessage(output[0]);
+                      return true;
+                    }
+                  }
+                  registerProcessor('speech-processor', SP);`;
+                const blob = new Blob([workletScript], { type: "application/javascript; charset=utf-8" });
+                this.privSpeechProcessorScript = URL.createObjectURL(blob);
+            }
+
             context.audioWorklet
                 .addModule(this.privSpeechProcessorScript)
                 .then((): void => {


### PR DESCRIPTION
> Fixes #572.

## Design

Today, if `AudioContext.audioWorklet` is falsy, audio worklet is not supported by the environment. However, `PCMRecorder` will continue to create the audio worklet blob URL regardless.

This pull request creates the audio worklet blob URL only if the `AudioContext` support audio worklet.

## Future improvements

There are more improvements that could be done in this code in later iterations.

### Investigate data URL than blob URL

If Content Security Policy (CSP) is enabled on the web app, blob URL will probably need to be relaxed by CSP to run this code.

CSP probably not needed for data URL. I don't have a lot of experience on CSP, more investigations need to be done.

Using data URL also means we need a Base64 converter, slightly less convenient than blob.

### Consider using stringified IIFE code than literal strings

The code could looks like:

```ts
function runWorklet() {
  class SP extends AudioWorkletProcessor {
    constructor(options) {
      super(options);
    }
    process(inputs, outputs) {
      const input = inputs[0];
      const output = [];
      for (let channel = 0; channel < input.length; channel += 1) {
        output[channel] = input[channel];
      }
      this.port.postMessage(output[0]);
      return true;
    }
  }
  registerProcessor('speech-processor', SP);
}

const blob = new Blob([`(${runWorklet})()`], { type: "application/javascript; charset=utf-8" });
this.privSpeechProcessorScript = URL.createObjectURL(blob);
```

One caveat here: despite this code is rather simple, if Babel or other transpiler is introduced, this code may change significantly in a way that the `AudioWorkletGlobalScope` may not have enough transpile helpers to make it work in the audio worklet environment. (e.g. regenerator-runtime, Babel helpers for iterators, etc.). Some more investigations would be needed to understand its impact.

As the current code snippet is simple and requires very few maintenances, I think leaving the code as-is is okay for now. But in case we need to expand it into future, we could look into stringified IIFE code.