### PR TITLE
Fix endpointId property is not been implemented in TranslationConnectionFactory

### DIFF
--- a/src/common.speech/TranslationConnectionFactory.ts
+++ b/src/common.speech/TranslationConnectionFactory.ts
@@ -42,6 +42,13 @@ export class TranslationConnectionFactory extends ConnectionFactoryBase {
             from: config.parameters.getProperty(PropertyId.SpeechServiceConnection_RecoLanguage),
             to: config.parameters.getProperty(PropertyId.SpeechServiceConnection_TranslationToLanguages),
         };
+        const endpointId: string = config.parameters.getProperty(PropertyId.SpeechServiceConnection_EndpointId, undefined);
+
+        if (endpointId) {
+            if (!endpoint || endpoint.search(QueryParameterNames.CustomSpeechDeploymentId) === -1) {
+                queryParams[QueryParameterNames.CustomSpeechDeploymentId] = endpointId;
+            }
+        }
 
         this.setCommonUrlParams(config, queryParams, endpoint);
         this.setUrlParameter(


### PR DESCRIPTION
### Step to reproduce

```js
var speechTranslationConfig = SpeechSDK.SpeechTranslationConfig.fromSubscription("<<subscriptionKey>>", "<<serviceRegion>>");
speechTranslationConfig.endpointId = "<<endpoint-guid>>";
speechTranslationConfig.speechRecognitionLanguage = "en-US";
speechTranslationConfig.addTargetLanguage("ja-JP");
var audioConfig = SpeechSDK.AudioConfig.fromDefaultMicrophoneInput();
var recognizer = new SpeechSDK.TranslationRecognizer(speechTranslationConfig, audioConfig);
recognizer.startContinuousRecognitionAsync();
```

The connected WebSocket does not have `cid` parameter set.

### Cause
`SpeechTranslationConfig.ts` has `endpointId` property defined but it's not properly been handled in TranslationConnectionFactory and sets to WebSocket url.

### Why should fix
The tutorial in https://learn.microsoft.com/en-us/azure/cognitive-services/Speech-Service/how-to-recognize-speech?pivots=programming-language-javascript#use-a-custom-endpoint shows how to set custom endpoint using `endpointId` property.
The `SpeechTranslationConfig` class has the property designed but it's not been properly implemented.