### PR TITLE
Initial changes to support speech.phrase in translation service reco

### DIFF
--- a/src/common.speech/ConversationServiceRecognizer.ts
+++ b/src/common.speech/ConversationServiceRecognizer.ts
@@ -1,0 +1,175 @@
+import { IAudioSource } from "../common/Exports";
+import {
+    CancellationErrorCode,
+    CancellationReason,
+    OutputFormat,
+    PropertyCollection,
+    PropertyId,
+    Recognizer,
+    ResultReason,
+    SpeechRecognitionEventArgs,
+    SpeechRecognitionResult,
+    TranslationRecognitionEventArgs,
+    TranslationRecognitionResult,
+    TranslationRecognizer
+} from "../sdk/Exports";
+import {
+    DetailedSpeechPhrase,
+    EnumTranslation,
+    IAuthentication,
+    IConnectionFactory,
+    OutputFormatPropertyName,
+    RecognitionStatus,
+    RecognizerConfig,
+    ServiceRecognizerBase,
+    SimpleSpeechPhrase,
+    TranscriberRecognizer
+} from "./Exports";
+import { ITranslationPhrase } from "./ServiceMessages/TranslationPhrase";
+import { SpeechConnectionMessage } from "./SpeechConnectionMessage.Internal";
+
+export class ConversationServiceRecognizer extends ServiceRecognizerBase {
+
+    public constructor(
+        authentication: IAuthentication,
+        connectionFactory: IConnectionFactory,
+        audioSource: IAudioSource,
+        recognizerConfig: RecognizerConfig,
+        recognizer: Recognizer) {
+        super(authentication, connectionFactory, audioSource, recognizerConfig, recognizer);
+        this.handleSpeechPhraseMessage = async (textBody: string, recognizer: Recognizer): Promise<void> => this.handleSpeechPhrase(textBody, recognizer);
+    }
+
+
+    // eslint-disable-next-line require-await
+    protected processTypeSpecificMessages(connectionMessage: SpeechConnectionMessage): Promise<boolean> {
+        // Implementing to allow inheritance
+        void connectionMessage;
+        return;
+    }
+
+    protected cancelRecognition(
+        sessionId: string,
+        requestId: string,
+        cancellationReason: CancellationReason,
+        errorCode: CancellationErrorCode,
+        error: string): void {
+            // Implementing to allow inheritance
+            void sessionId;
+            void requestId;
+            void cancellationReason;
+            void errorCode;
+            void error;
+        }
+
+    protected async handleSpeechPhrase(textBody: string, recognizer: Recognizer): Promise<void> {
+
+        const simple: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(textBody);
+        const resultReason: ResultReason = EnumTranslation.implTranslateRecognitionResult(simple.RecognitionStatus);
+        let result: SpeechRecognitionResult;
+        const resultProps: PropertyCollection = new PropertyCollection();
+        resultProps.setProperty(PropertyId.SpeechServiceResponse_JsonResult, textBody);
+        const simpleOffset = simple.Offset + this.privRequestSession.currentTurnAudioOffset;
+
+        this.privRequestSession.onPhraseRecognized(this.privRequestSession.currentTurnAudioOffset + simple.Offset + simple.Duration);
+
+        if (ResultReason.Canceled === resultReason) {
+            const cancelReason: CancellationReason = EnumTranslation.implTranslateCancelResult(simple.RecognitionStatus);
+            const cancellationErrorCode: CancellationErrorCode = EnumTranslation.implTranslateCancelErrorCode(simple.RecognitionStatus);
+
+            await this.cancelRecognitionLocal(
+                cancelReason,
+                cancellationErrorCode,
+                EnumTranslation.implTranslateErrorDetails(cancellationErrorCode));
+
+        } else {
+            if (!(this.privRequestSession.isSpeechEnded && resultReason === ResultReason.NoMatch && simple.RecognitionStatus !== RecognitionStatus.InitialSilenceTimeout)) {
+                if (!!recognizer && recognizer instanceof TranslationRecognizer) {
+                    try {
+                        const phrase: { SpeechPhrase: ITranslationPhrase } = JSON.parse(textBody) as { SpeechPhrase: ITranslationPhrase };
+                        const translationResult = new TranslationRecognitionResult(
+                            undefined,
+                            this.privRequestSession.requestId,
+                            resultReason,
+                            phrase.SpeechPhrase.Text,
+                            phrase.SpeechPhrase.Duration,
+                            simpleOffset,
+                            "",
+                            JSON.stringify(phrase.SpeechPhrase),
+                            resultProps);
+
+                        const ev = new TranslationRecognitionEventArgs(translationResult, simpleOffset, this.privRequestSession.sessionId);
+                        recognizer.recognized(recognizer, ev);
+                    } catch (error) {
+                        // Not going to let errors in the event handler
+                        // trip things up.
+                    }
+                    return;
+                }
+                if (this.privRecognizerConfig.parameters.getProperty(OutputFormatPropertyName) === OutputFormat[OutputFormat.Simple]) {
+                    result = new SpeechRecognitionResult(
+                        this.privRequestSession.requestId,
+                        resultReason,
+                        simple.DisplayText,
+                        simple.Duration,
+                        simpleOffset,
+                        simple.Language,
+                        simple.LanguageDetectionConfidence,
+                        simple.SpeakerId,
+                        undefined,
+                        textBody,
+                        resultProps);
+                } else {
+                    const detailed: DetailedSpeechPhrase = DetailedSpeechPhrase.fromJSON(textBody);
+                    const totalOffset: number = detailed.Offset + this.privRequestSession.currentTurnAudioOffset;
+                    const offsetCorrectedJson: string = detailed.getJsonWithCorrectedOffsets(totalOffset);
+
+                    result = new SpeechRecognitionResult(
+                        this.privRequestSession.requestId,
+                        resultReason,
+                        detailed.Text,
+                        detailed.Duration,
+                        totalOffset,
+                        detailed.Language,
+                        detailed.LanguageDetectionConfidence,
+                        detailed.SpeakerId,
+                        undefined,
+                        offsetCorrectedJson,
+                        resultProps);
+                }
+
+                if (!!recognizer && recognizer instanceof TranscriberRecognizer) {
+                    try {
+                        const event: SpeechRecognitionEventArgs = new SpeechRecognitionEventArgs(result, result.offset, this.privRequestSession.sessionId);
+                        recognizer.recognized(this.privRecognizer, event);
+                        if (!!this.privSuccessCallback) {
+                            try {
+                                this.privSuccessCallback(result);
+                            } catch (e) {
+                                if (!!this.privErrorCallback) {
+                                    this.privErrorCallback(e as string);
+                                }
+                            }
+                            // Only invoke the call back once.
+                            // and if it's successful don't invoke the
+                            // error after that.
+                            this.privSuccessCallback = undefined;
+                            this.privErrorCallback = undefined;
+                        }
+                        /* eslint-disable no-empty */
+                    } catch (error) {
+                        // Not going to let errors in the event handler
+                        // trip things up.
+                    }
+                }
+            }
+        }
+    }
+
+    /*
+    protected async handleSpeechHypothesis(textBody: string, recognized: (sender: Recognizer, event: SpeechRecognitionEventArgs) => void): Promise<void> {
+        void textBody;
+        void recognized;
+    }
+    */
+}

--- a/src/common.speech/ConversationServiceRecognizer.ts
+++ b/src/common.speech/ConversationServiceRecognizer.ts
@@ -40,8 +40,6 @@ export class ConversationServiceRecognizer extends ServiceRecognizerBase {
         this.handleSpeechHypothesisMessage = (textBody: string): void => this.handleSpeechHypothesis(textBody);
     }
 
-
-    // eslint-disable-next-line require-await
     protected async processTypeSpecificMessages(connectionMessage: SpeechConnectionMessage): Promise<boolean> {
         let processed: boolean = false;
         switch (connectionMessage.path.toLowerCase()) {

--- a/src/common.speech/Exports.ts
+++ b/src/common.speech/Exports.ts
@@ -11,6 +11,7 @@ export * from "./ISynthesisConnectionFactory";
 export * from "./IntentConnectionFactory";
 export * from "./RecognitionEvents";
 export * from "./ServiceRecognizerBase";
+export * from "./ConversationServiceRecognizer";
 export * from "./RecognizerConfig";
 export * from "./SpeechServiceInterfaces";
 export * from "./WebsocketMessageFormatter";

--- a/src/common.speech/ServiceMessages/TranslationPhrase.ts
+++ b/src/common.speech/ServiceMessages/TranslationPhrase.ts
@@ -10,7 +10,7 @@ export interface ITranslationPhrase {
     RecognitionStatus: RecognitionStatus;
     Offset: number;
     Duration: number;
-    Translation: ITranslations;
+    Translation?: ITranslations;
     Text: string;
     DisplayText?: string;
 }

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -27,7 +27,6 @@ import {
     RecognitionEventArgs,
     Recognizer,
     SessionEventArgs,
-    SpeechRecognitionEventArgs,
     SpeechRecognitionResult,
 } from "../sdk/Exports";
 import { Callback } from "../sdk/Transcription/IConversation";
@@ -572,8 +571,8 @@ export abstract class ServiceRecognizerBase implements IDisposable {
     }
 
     protected configConnectionOverride: (connection: IConnection) => Promise<IConnection> = undefined;
-    protected handleSpeechPhraseMessage: (textBody: string, recognizer: Recognizer) => Promise<void> = undefined;
-    protected handleSpeechHypothesisMessage: (textBody: string, recognizing: (sender: Recognizer, event: SpeechRecognitionEventArgs) => void) => Promise<void> = undefined;
+    protected handleSpeechPhraseMessage: (textBody: string) => Promise<void> = undefined;
+    protected handleSpeechHypothesisMessage: (textBody: string) => void = undefined;
 
     protected sendSpeechServiceConfig(connection: IConnection, requestSession: RequestSession, SpeechServiceConfigJson: string): Promise<void> {
         requestSession.onSpeechContext();

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -27,6 +27,7 @@ import {
     RecognitionEventArgs,
     Recognizer,
     SessionEventArgs,
+    SpeechRecognitionEventArgs,
     SpeechRecognitionResult,
 } from "../sdk/Exports";
 import { Callback } from "../sdk/Transcription/IConversation";
@@ -571,6 +572,8 @@ export abstract class ServiceRecognizerBase implements IDisposable {
     }
 
     protected configConnectionOverride: (connection: IConnection) => Promise<IConnection> = undefined;
+    protected handleSpeechPhraseMessage: (textBody: string, recognizer: Recognizer) => Promise<void> = undefined;
+    protected handleSpeechHypothesisMessage: (textBody: string, recognizing: (sender: Recognizer, event: SpeechRecognitionEventArgs) => void) => Promise<void> = undefined;
 
     protected sendSpeechServiceConfig(connection: IConnection, requestSession: RequestSession, SpeechServiceConfigJson: string): Promise<void> {
         requestSession.onSpeechContext();

--- a/src/common.speech/TranslationServiceRecognizer.ts
+++ b/src/common.speech/TranslationServiceRecognizer.ts
@@ -237,16 +237,13 @@ export class TranslationServiceRecognizer extends ConversationServiceRecognizer 
                 }
                 processed = true;
                 break;
-            case "speech.phrase":
-                if (!!this.handleSpeechPhraseMessage) {
-                    await this.handleSpeechPhraseMessage(connectionMessage.textBody, this.privTranslationRecognizer);
-                }
-                processed = true;
-                break;
             default:
                 break;
         }
-        return processed;
+        if (!processed) {
+            return super.processTypeSpecificMessages(connectionMessage);
+        }
+        return true;
     }
 
     // Cancels recognition.
@@ -306,7 +303,7 @@ export class TranslationServiceRecognizer extends ConversationServiceRecognizer 
 
         let resultReason: ResultReason;
         if (serviceResult instanceof TranslationPhrase) {
-            if (serviceResult.Translation.TranslationStatus === TranslationStatus.Success) {
+            if (!!serviceResult.Translation && serviceResult.Translation.TranslationStatus === TranslationStatus.Success) {
                 resultReason = ResultReason.TranslatedSpeech;
             } else {
                 resultReason = ResultReason.RecognizedSpeech;

--- a/src/common.speech/TranslationServiceRecognizer.ts
+++ b/src/common.speech/TranslationServiceRecognizer.ts
@@ -63,7 +63,10 @@ export class TranslationServiceRecognizer extends ConversationServiceRecognizer 
     protected async processTypeSpecificMessages(connectionMessage: SpeechConnectionMessage): Promise<boolean> {
 
         const resultProps: PropertyCollection = new PropertyCollection();
-        let processed: boolean = false;
+        let processed: boolean = await super.processTypeSpecificMessages(connectionMessage);
+        if (processed) {
+            return true;
+        }
 
         const handleTranslationPhrase = async (translatedPhrase: TranslationPhrase): Promise<void> => {
             this.privRequestSession.onPhraseRecognized(this.privRequestSession.currentTurnAudioOffset + translatedPhrase.Offset + translatedPhrase.Duration);
@@ -240,10 +243,7 @@ export class TranslationServiceRecognizer extends ConversationServiceRecognizer 
             default:
                 break;
         }
-        if (!processed) {
-            return super.processTypeSpecificMessages(connectionMessage);
-        }
-        return true;
+        return processed;
     }
 
     // Cancels recognition.

--- a/src/common.speech/TranslationServiceRecognizer.ts
+++ b/src/common.speech/TranslationServiceRecognizer.ts
@@ -23,9 +23,9 @@ import {
 } from "../sdk/Exports";
 import {
     CancellationErrorCodePropertyName,
+    ConversationServiceRecognizer,
     EnumTranslation,
     RecognitionStatus,
-    ServiceRecognizerBase,
     SynthesisStatus,
     TranslationHypothesis,
     TranslationPhrase,
@@ -38,7 +38,7 @@ import { ITranslationPhrase } from "./ServiceMessages/TranslationPhrase";
 import { SpeechConnectionMessage } from "./SpeechConnectionMessage.Internal";
 
 // eslint-disable-next-line max-classes-per-file
-export class TranslationServiceRecognizer extends ServiceRecognizerBase {
+export class TranslationServiceRecognizer extends ConversationServiceRecognizer {
     private privTranslationRecognizer: TranslationRecognizer;
 
     public constructor(
@@ -234,6 +234,12 @@ export class TranslationServiceRecognizer extends ServiceRecognizerBase {
                         break;
                     default:
                         break;
+                }
+                processed = true;
+                break;
+            case "speech.phrase":
+                if (!!this.handleSpeechPhraseMessage) {
+                    await this.handleSpeechPhraseMessage(connectionMessage.textBody, this.privTranslationRecognizer);
                 }
                 processed = true;
                 break;

--- a/src/sdk/Transcription/ConversationTranslator.ts
+++ b/src/sdk/Transcription/ConversationTranslator.ts
@@ -71,7 +71,7 @@ class ConversationTranslationRecognizer extends TranslationRecognizer {
                     this.fireCancelEvent(e.result.errorDetails);
                 } else {
                     if (!!this.privTranslator.recognized) {
-                        this.privTranslator.recognized(tr, e);
+                        this.privTranslator.recognized(this.privTranslator, e);
                     }
                 }
                 return;
@@ -151,8 +151,8 @@ export class ConversationTranslator extends ConversationCommon implements IConve
     public textMessageReceived: (sender: IConversationTranslator, event: ConversationTranslationEventArgs) => void;
     public transcribed: (sender: IConversationTranslator, event: ConversationTranslationEventArgs) => void;
     public transcribing: (sender: IConversationTranslator, event: ConversationTranslationEventArgs) => void;
-    public recognized: (sender: TranslationRecognizer, event: TranslationRecognitionEventArgs) => void;
-    public recognizing: (sender: TranslationRecognizer, event: TranslationRecognitionEventArgs) => void;
+    public recognized: (sender: IConversationTranslator, event: TranslationRecognitionEventArgs) => void;
+    public recognizing: (sender: IConversationTranslator, event: TranslationRecognitionEventArgs) => void;
 
     private privSpeechRecognitionLanguage: string;
     private privProperties: PropertyCollection;

--- a/src/sdk/Transcription/ConversationTranslator.ts
+++ b/src/sdk/Transcription/ConversationTranslator.ts
@@ -64,14 +64,17 @@ class ConversationTranslationRecognizer extends TranslationRecognizer {
 
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             this.recognized = async (tr: TranslationRecognizer, e: TranslationRecognitionEventArgs): Promise<void> => {
-                // TODO: add support for getting recognitions from here if own speech
-
                 // if there is an error connecting to the conversation service from the speech service the error will be returned in the ErrorDetails field.
                 if (e.result?.errorDetails) {
                     await this.cancelSpeech();
                     // TODO: format the error message contained in 'errorDetails'
                     this.fireCancelEvent(e.result.errorDetails);
+                } else {
+                    if (!!this.privTranslator.recognized) {
+                        this.privTranslator.recognized(tr, e);
+                    }
                 }
+                return;
             };
 
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -148,6 +151,8 @@ export class ConversationTranslator extends ConversationCommon implements IConve
     public textMessageReceived: (sender: IConversationTranslator, event: ConversationTranslationEventArgs) => void;
     public transcribed: (sender: IConversationTranslator, event: ConversationTranslationEventArgs) => void;
     public transcribing: (sender: IConversationTranslator, event: ConversationTranslationEventArgs) => void;
+    public recognized: (sender: TranslationRecognizer, event: TranslationRecognitionEventArgs) => void;
+    public recognizing: (sender: TranslationRecognizer, event: TranslationRecognitionEventArgs) => void;
 
     private privSpeechRecognitionLanguage: string;
     private privProperties: PropertyCollection;

--- a/src/sdk/Transcription/ConversationTranslator.ts
+++ b/src/sdk/Transcription/ConversationTranslator.ts
@@ -62,6 +62,12 @@ class ConversationTranslationRecognizer extends TranslationRecognizer {
                 this.privSpeechState = SpeechState.Inactive;
             };
 
+            this.recognizing = (tr: TranslationRecognizer, e: TranslationRecognitionEventArgs): void => {
+                if (!!this.privTranslator.recognizing) {
+                    this.privTranslator.recognizing(this.privTranslator, e);
+                }
+            };
+
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             this.recognized = async (tr: TranslationRecognizer, e: TranslationRecognitionEventArgs): Promise<void> => {
                 // if there is an error connecting to the conversation service from the speech service the error will be returned in the ErrorDetails field.
@@ -149,8 +155,12 @@ export class ConversationTranslator extends ConversationCommon implements IConve
     public sessionStarted: (sender: ConversationHandler, event: SessionEventArgs) => void;
     public sessionStopped: (sender: ConversationHandler, event: SessionEventArgs) => void;
     public textMessageReceived: (sender: IConversationTranslator, event: ConversationTranslationEventArgs) => void;
+
+    // Callbacks for whole conversation results
     public transcribed: (sender: IConversationTranslator, event: ConversationTranslationEventArgs) => void;
     public transcribing: (sender: IConversationTranslator, event: ConversationTranslationEventArgs) => void;
+
+    // Callbacks for detecting speech/translation results from self
     public recognized: (sender: IConversationTranslator, event: TranslationRecognitionEventArgs) => void;
     public recognizing: (sender: IConversationTranslator, event: TranslationRecognitionEventArgs) => void;
 

--- a/src/sdk/TranslationRecognitionResult.ts
+++ b/src/sdk/TranslationRecognitionResult.ts
@@ -31,6 +31,10 @@ export class TranslationRecognitionResult extends SpeechRecognitionResult {
         this.privTranslations = translations;
     }
 
+    public static fromSpeechRecognitionResult(result: SpeechRecognitionResult): TranslationRecognitionResult {
+        return new TranslationRecognitionResult(undefined, result.resultId, result.reason, result.text, result.duration, result.offset, result.errorDetails, result.json, result.properties);
+    }
+
     /**
      * Presents the translation results. Each item in the dictionary represents
      * a translation result in one of target languages, where the key is the name

--- a/tests/ConversationTranslatorTests.ts
+++ b/tests/ConversationTranslatorTests.ts
@@ -236,7 +236,7 @@ describe("conversation service tests", () => {
 
     }, 80000);
 
-    test.skip("Start Conversation, invalid nickname [400025]", (done: jest.DoneCallback) => {
+    test("Start Conversation, invalid nickname [400025]", (done: jest.DoneCallback) => {
 
         let errorMessage: string;
 
@@ -283,7 +283,7 @@ describe("conversation service tests", () => {
 
     }, 80000);
 
-    test.skip("Start Conversation, join as host and mute participants", (done: jest.DoneCallback) => {
+    test("Start Conversation, join as host and mute participants", (done: jest.DoneCallback) => {
 
         // eslint-disable-next-line no-console
         console.info("Start Conversation, join as host, mute participants");
@@ -377,7 +377,7 @@ describe("conversation service tests", () => {
 
     }, 40000);
 
-    test.skip("Start Conversation, join as host and send message", (done: jest.DoneCallback) => {
+    test("Start Conversation, join as host and send message", (done: jest.DoneCallback) => {
 
         // eslint-disable-next-line no-console
         console.info("Start Conversation, join as host and send message");
@@ -439,7 +439,7 @@ describe("conversation service tests", () => {
 
     }, 60000);
 
-    test.skip("Start Conversation, join as host and eject participant", (done: jest.DoneCallback) => {
+    test("Start Conversation, join as host and eject participant", (done: jest.DoneCallback) => {
 
         // eslint-disable-next-line no-console
         console.info("Start Conversation, join as host and eject participant");
@@ -536,7 +536,7 @@ describe("conversation service tests", () => {
 
     }, 60000);
 
-    test.skip("Start Conversation, join as host and set service property", (done: jest.DoneCallback) => {
+    test("Start Conversation, join as host and set service property", (done: jest.DoneCallback) => {
 
         // eslint-disable-next-line no-console
         console.info("Start Conversation, join as host and set service property");
@@ -591,18 +591,23 @@ describe("conversation service tests", () => {
                         done(error);
                     }
                 });
-                ct.transcribed = ((s: sdk.ConversationTranslator, e: sdk.ConversationTranslationEventArgs) => {
-                    expect(e.result.text).toContain("weather");
-                    ct.stopTranscribingAsync(
-                        () => {
-                            ct.leaveConversationAsync(() => {
-                                c.endConversationAsync(
-                                    done,
-                                    (e: string) => { done(e); });
+                ct.recognized = ((s: sdk.ConversationTranslator, e: sdk.TranslationRecognitionEventArgs) => {
+                    if (e.result.text !== "") {
+                        expect(e.result.text).toContain("weather");
+                        ct.stopTranscribingAsync(
+                            () => {
+                                ct.leaveConversationAsync(() => {
+                                    c.endConversationAsync(
+                                        done,
+                                        (e: string) => { done(e); });
+                                },
+                                (e: string) => { done(e); });
                             },
                             (e: string) => { done(e); });
-                        },
-                        (e: string) => { done(e); });
+                    }
+                });
+                ct.transcribed = ((s: sdk.ConversationTranslator, e: sdk.ConversationTranslationEventArgs) => {
+                    expect(e.result.text).toContain("weather");
                 });
 
                 const lang: string = "en-US";

--- a/tests/ConversationTranslatorTests.ts
+++ b/tests/ConversationTranslatorTests.ts
@@ -677,7 +677,7 @@ describe("conversation service tests", () => {
                         done(error);
                     }
                 });
-                ct.recognized = ((s: sdk.TranslationRecognizer, e: sdk.TranslationRecognitionEventArgs) => {
+                ct.recognized = ((s: sdk.ConversationTranslator, e: sdk.TranslationRecognitionEventArgs) => {
                     if (e.result.text !== "") {
                         expect(e.result.text).toContain("weather");
                         ct.stopTranscribingAsync(

--- a/tests/Settings.ts
+++ b/tests/Settings.ts
@@ -14,6 +14,8 @@ export class Settings {
 
     public static SpeechTestEndpointId: string = "<<YOUR_TEST_ENDPOINT_ID>>";
 
+    public static ConversationTranslatorSwedenEndpoint: string = "wss://transcribe.westus.cts.speech.microsoft.com/speech/recognition/dynamicaudio";
+
     // Endpoint and key for timeout testing.
     // Endpoint should reduce standard speech timeout to value specified in SpeechServiceTimeoutSeconds
     // If undefined, production timeout of 10 seconds will be used, but at the cost of greatly increased test


### PR DESCRIPTION
Internal Ref ID 4700152
This PR aims to enable the Sweden scenario for Conversation Translator, namely the ability to connect to a transcription speech service and still receive recognized/recognizing callback events.

Which means TranslationServiceRecognizer needs to be able to handle speech.* messages from the transcription services (it currently only handles translation.* messages).