### PR TITLE
Support configuring PhraseListGrammar for ConversationTranslator

### DIFF
--- a/src/sdk/Transcription/ConversationTranslator.ts
+++ b/src/sdk/Transcription/ConversationTranslator.ts
@@ -19,6 +19,7 @@ import {
     AudioConfig,
     CancellationErrorCode,
     CancellationReason,
+    PhraseListGrammar,
     ProfanityOption,
     PropertyCollection,
     PropertyId,
@@ -221,6 +222,18 @@ export class ConversationTranslator extends ConversationCommon implements IConve
         currentProperties[name] = value;
 
         this.privProperties.setProperty(ServicePropertiesPropertyName, JSON.stringify(currentProperties));
+    }
+
+    public getPhraseListGrammarAsync(cb?: Callback, err?: Callback): void {
+        marshalPromiseToCallbacks((async (): Promise<PhraseListGrammar> => {
+            if (this.privCTRecognizer === undefined) {
+                await this.connectTranslatorRecognizer();
+            }
+
+            Contracts.throwIfNullOrUndefined(this.privCTRecognizer, this.privErrors.permissionDeniedSend);
+
+            return PhraseListGrammar.fromRecognizer(this.privCTRecognizer);
+        })(), cb, err);
     }
 
     /**


### PR DESCRIPTION
The `ConversationTranslator` does currently not support configuring the PhraseListGrammar (see #611). Phrase Lists can, therefore, not be configured when using it. This change adds an asynchronous function (adopting the existing style with callbacks) to get the `PhraseListGrammar`.

It optionally connects the translator beforehand (`connectTranslatorRecognizer`), as this would only happen when calling `startTranscribingAsync`.

# Usage example
```js
this.conversation.getPhraseListGrammarAsync((phraseListGrammar) => {
  phraseListGrammar.addPhrases(['Grombirasalad', 'Flädlessupp']);
}, handleError)

// call startTranscribingAsync afterwards
```

I validated the implementation locally, and the phrase list was successfully applied.