### PR TITLE
chore: update UUID lib and corresponding types lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "bent": "^7.3.12",
         "https-proxy-agent": "^4.0.0",
         "simple-lru-cache": "0.0.2",
-        "uuid": "^8.3.0",
+        "uuid": "^9.0.0",
         "ws": "^7.5.6"
       },
       "devDependencies": {
@@ -26,7 +26,7 @@
         "@types/prettier": "<2.6.0",
         "@types/request": "^2.48.3",
         "@types/rimraf": "^3.0.0",
-        "@types/uuid": "^3.3.3",
+        "@types/uuid": "^9.0.0",
         "@types/ws": "^6.0.4",
         "@typescript-eslint/eslint-plugin": "^5.26.0",
         "@typescript-eslint/eslint-plugin-tslint": "^5.27.0",
@@ -1400,9 +1400,10 @@
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
-      "version": "3.4.10",
-      "dev": true,
-      "license": "MIT"
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "6.0.4",
@@ -7192,6 +7193,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "27.5.1",
       "dev": true,
@@ -10865,8 +10875,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -12268,7 +12279,9 @@
       "dev": true
     },
     "@types/uuid": {
-      "version": "3.4.10",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
       "dev": true
     },
     "@types/ws": {
@@ -16138,6 +16151,12 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
         }
       }
     },
@@ -18614,7 +18633,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2"
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/prettier": "<2.6.0",
     "@types/request": "^2.48.3",
     "@types/rimraf": "^3.0.0",
-    "@types/uuid": "^3.3.3",
+    "@types/uuid": "^9.0.0",
     "@types/ws": "^6.0.4",
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/eslint-plugin-tslint": "^5.27.0",
@@ -112,7 +112,7 @@
     "bent": "^7.3.12",
     "https-proxy-agent": "^4.0.0",
     "simple-lru-cache": "0.0.2",
-    "uuid": "^8.3.0",
+    "uuid": "^9.0.0",
     "ws": "^7.5.6"
   },
   "overrides": {


### PR DESCRIPTION
The currently used version of the UUID library used has an issue when run in Jest via the jsdom (browser) environment. Due to this, any tests that interface with this library at all must use hacks to either bump the library from the package or to run the test with node versions of packages. This updates the UUID library to v9 which resolves these issues.

Other changes include major performance improvements and some other changes [noted here](https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md)

v9 does however come with a few breaking changes (changes in supported platforms), that as far as I can tell are acceptable here. The README indicates the project requires Node 12+, which is still supported by this change to UUID. The only part I am unsure about is the drop of support for IE11 and Safari 10, as I can't find any browser support documentation for this library. Given IE11 is considered end of life, I am assuming this is fine but thought I'd mention it here to be sure.

I also noticed that the types library was still on a version much earlier than the UUID library, so I've updated that as well.