### PR TITLE
Add StartConsoleOutput and StopConsoleOutput APIs

### DIFF
--- a/src/common.browser/ConsoleLoggingListener.ts
+++ b/src/common.browser/ConsoleLoggingListener.ts
@@ -10,7 +10,7 @@ import { Contracts } from "../sdk/Contracts";
 export class ConsoleLoggingListener implements IEventListener<PlatformEvent> {
     private privLogLevelFilter: LogLevel;
     private privLogPath: fs.PathLike = undefined;
-    private privAllowConsoleOutput: boolean = true;
+    private privEnableConsoleOutput: boolean = true;
 
     public constructor(logLevelFilter: LogLevel = LogLevel.None) { // Console output disabled by default
         this.privLogLevelFilter = logLevelFilter;
@@ -22,7 +22,7 @@ export class ConsoleLoggingListener implements IEventListener<PlatformEvent> {
     }
 
     public set enableConsoleOutput(enableOutput: boolean) {
-        this.privAllowConsoleOutput = enableOutput;
+        this.privEnableConsoleOutput = enableOutput;
     }
 
     public onEvent(event: PlatformEvent): void {
@@ -32,7 +32,7 @@ export class ConsoleLoggingListener implements IEventListener<PlatformEvent> {
                 fs.writeFileSync(this.privLogPath, log + "\n", { flag: "a+" });
             }
 
-            if (this.privAllowConsoleOutput) {
+            if (this.privEnableConsoleOutput) {
                 switch (event.eventType) {
                     case LogLevel.Debug:
                         // eslint-disable-next-line no-console

--- a/src/common.browser/ConsoleLoggingListener.ts
+++ b/src/common.browser/ConsoleLoggingListener.ts
@@ -10,6 +10,7 @@ import { Contracts } from "../sdk/Contracts";
 export class ConsoleLoggingListener implements IEventListener<PlatformEvent> {
     private privLogLevelFilter: LogLevel;
     private privLogPath: fs.PathLike = undefined;
+    private privAllowConsoleOutput: boolean = true;
 
     public constructor(logLevelFilter: LogLevel = LogLevel.None) { // Console output disabled by default
         this.privLogLevelFilter = logLevelFilter;
@@ -20,6 +21,10 @@ export class ConsoleLoggingListener implements IEventListener<PlatformEvent> {
         this.privLogPath = path;
     }
 
+    public set enableConsoleOutput(enableOutput: boolean) {
+        this.privAllowConsoleOutput = enableOutput;
+    }
+
     public onEvent(event: PlatformEvent): void {
         if (event.eventType >= this.privLogLevelFilter) {
             const log = this.toString(event);
@@ -27,27 +32,29 @@ export class ConsoleLoggingListener implements IEventListener<PlatformEvent> {
                 fs.writeFileSync(this.privLogPath, log + "\n", { flag: "a+" });
             }
 
-            switch (event.eventType) {
-                case LogLevel.Debug:
-                    // eslint-disable-next-line no-console
-                    console.debug(log);
-                    break;
-                case LogLevel.Info:
-                    // eslint-disable-next-line no-console
-                    console.info(log);
-                    break;
-                case LogLevel.Warning:
-                    // eslint-disable-next-line no-console
-                    console.warn(log);
-                    break;
-                case LogLevel.Error:
-                    // eslint-disable-next-line no-console
-                    console.error(log);
-                    break;
-                default:
-                    // eslint-disable-next-line no-console
-                    console.log(log);
-                    break;
+            if (this.privAllowConsoleOutput) {
+                switch (event.eventType) {
+                    case LogLevel.Debug:
+                        // eslint-disable-next-line no-console
+                        console.debug(log);
+                        break;
+                    case LogLevel.Info:
+                        // eslint-disable-next-line no-console
+                        console.info(log);
+                        break;
+                    case LogLevel.Warning:
+                        // eslint-disable-next-line no-console
+                        console.warn(log);
+                        break;
+                    case LogLevel.Error:
+                        // eslint-disable-next-line no-console
+                        console.error(log);
+                        break;
+                    default:
+                        // eslint-disable-next-line no-console
+                        console.log(log);
+                        break;
+                }
             }
         }
     }

--- a/src/sdk/Diagnostics.ts
+++ b/src/sdk/Diagnostics.ts
@@ -15,8 +15,20 @@ export class Diagnostics {
     private static privListener: ConsoleLoggingListener = undefined;
 
     public static SetLoggingLevel(logLevel: LogLevel): void {
-        this.privListener =  new ConsoleLoggingListener(logLevel);
+        this.privListener = new ConsoleLoggingListener(logLevel);
         Events.instance.attachConsoleListener(this.privListener);
+    }
+
+    public static EnableConsoleOutput(): void {
+        if (!!this.privListener) {
+            this.privListener.enableConsoleOutput = true;
+        }
+    }
+
+    public static DisableConsoleOutput(): void {
+        if (!!this.privListener) {
+            this.privListener.enableConsoleOutput = false;
+        }
     }
 
     public static SetLogOutputPath(path: string): void {

--- a/src/sdk/Diagnostics.ts
+++ b/src/sdk/Diagnostics.ts
@@ -19,13 +19,13 @@ export class Diagnostics {
         Events.instance.attachConsoleListener(this.privListener);
     }
 
-    public static EnableConsoleOutput(): void {
+    public static StartConsoleOutput(): void {
         if (!!this.privListener) {
             this.privListener.enableConsoleOutput = true;
         }
     }
 
-    public static DisableConsoleOutput(): void {
+    public static StopConsoleOutput(): void {
         if (!!this.privListener) {
             this.privListener.enableConsoleOutput = false;
         }


### PR DESCRIPTION
Service team wants this JS API for cleaner node debugging.
The issue is, with file logging enabled, super verbose console output is distracting. This is a QoL feature to make node testing less cumbersome.