### PR TITLE
Added 'LocaleName' in VoiceInfo Class

### DIFF
--- a/src/sdk/SynthesisVoicesResult.ts
+++ b/src/sdk/SynthesisVoicesResult.ts
@@ -22,7 +22,7 @@ export class SynthesisVoicesResult extends SynthesisResult {
             super(requestId, ResultReason.VoicesListRetrieved, undefined, new PropertyCollection());
             this.privVoices = [];
             for (const item of json) {
-                this.privVoices.push(new VoiceInfo(item as { Name: string; LocalName: string; ShortName: string; Gender: string; VoiceType: string; Locale: string; StyleList: string[] }));
+                this.privVoices.push(new VoiceInfo(item as { Name: string; LocalName: string; LocaleName: string; ShortName: string; Gender: string; VoiceType: string; Locale: string; StyleList: string[] }));
             }
         } else {
             super(requestId, ResultReason.Canceled, errorDetails ? errorDetails : "Error information unavailable", new PropertyCollection());

--- a/src/sdk/VoiceInfo.ts
+++ b/src/sdk/VoiceInfo.ts
@@ -34,17 +34,19 @@ export class VoiceInfo {
     private privLocale: string;
     private privShortName: string;
     private privLocalName: string;
+    private privLocaleName: string;
     private privGender: SynthesisVoiceGender;
     private privVoiceType: SynthesisVoiceType;
     private privStyleList: string[] = [];
     private privVoicePath: string;
 
-    public constructor(json: { Name: string; LocalName: string; ShortName: string; Gender: string; VoiceType: string; Locale: string; StyleList: string[] }) {
+    public constructor(json: { Name: string; LocalName: string; ShortName: string; Gender: string; VoiceType: string; LocaleName: string ; Locale: string; StyleList: string[] }) {
         this.privVoicePath = "";
         if (!!json) {
             this.privName = json.Name;
             this.privLocale = json.Locale;
             this.privShortName = json.ShortName;
+            this.privLocaleName = json.LocaleName;
             this.privLocalName = json.LocalName;
             this.privVoiceType = json.VoiceType.endsWith("Standard") ? SynthesisVoiceType.OnlineStandard : SynthesisVoiceType.OnlineNeural;
             this.privGender = json.Gender === "Male" ? SynthesisVoiceGender.Male : json.Gender === "Female" ? SynthesisVoiceGender.Female : SynthesisVoiceGender.Unknown;
@@ -70,6 +72,10 @@ export class VoiceInfo {
 
     public get localName(): string {
         return this.privLocalName;
+    }
+
+    public get localeName(): string {
+        return this.privLocaleName;
     }
 
     public get gender(): SynthesisVoiceGender {


### PR DESCRIPTION
### Description:
This pull request adds support for the 'LocaleName' property in the Azure Cognitive Speech SDK, aligning it with the functionality provided by the web API.

### Motivation:
The web API in the Azure Cognitive Speech service at `/cognitiveservices/voices/list` returns a value for 'LocaleName', which indicates the locale or language of the speech input or output. However, this property was missing in the SDK's class variable, causing a mismatch in functionality between the web API and the SDK.

[Reference Link](https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech?tabs=streaming#get-a-list-of-voices)