### PR TITLE
Added `DisplayName` to `VoiceInfo` to match the Web API

### DIFF
--- a/src/sdk/SynthesisVoicesResult.ts
+++ b/src/sdk/SynthesisVoicesResult.ts
@@ -22,7 +22,7 @@ export class SynthesisVoicesResult extends SynthesisResult {
             super(requestId, ResultReason.VoicesListRetrieved, undefined, new PropertyCollection());
             this.privVoices = [];
             for (const item of json) {
-                this.privVoices.push(new VoiceInfo(item as { Name: string; LocalName: string; LocaleName: string; ShortName: string; Gender: string; VoiceType: string; Locale: string; StyleList: string[] }));
+                this.privVoices.push(new VoiceInfo(item as { Name: string; LocalName: string; DisplayName: string; LocaleName: string; ShortName: string; Gender: string; VoiceType: string; Locale: string; StyleList: string[] }));
             }
         } else {
             super(requestId, ResultReason.Canceled, errorDetails ? errorDetails : "Error information unavailable", new PropertyCollection());

--- a/src/sdk/VoiceInfo.ts
+++ b/src/sdk/VoiceInfo.ts
@@ -33,6 +33,7 @@ export class VoiceInfo {
     private privName: string;
     private privLocale: string;
     private privShortName: string;
+    private privDisplayName: string;
     private privLocalName: string;
     private privLocaleName: string;
     private privGender: SynthesisVoiceGender;
@@ -40,13 +41,14 @@ export class VoiceInfo {
     private privStyleList: string[] = [];
     private privVoicePath: string;
 
-    public constructor(json: { Name: string; LocalName: string; ShortName: string; Gender: string; VoiceType: string; LocaleName: string ; Locale: string; StyleList: string[] }) {
+    public constructor(json: { Name: string; LocalName: string; DisplayName: string; ShortName: string; Gender: string; VoiceType: string; LocaleName: string ; Locale: string; StyleList: string[] }) {
         this.privVoicePath = "";
         if (!!json) {
             this.privName = json.Name;
             this.privLocale = json.Locale;
             this.privShortName = json.ShortName;
             this.privLocaleName = json.LocaleName;
+            this.privDisplayName = json.DisplayName;
             this.privLocalName = json.LocalName;
             this.privVoiceType = json.VoiceType.endsWith("Standard") ? SynthesisVoiceType.OnlineStandard : SynthesisVoiceType.OnlineNeural;
             this.privGender = json.Gender === "Male" ? SynthesisVoiceGender.Male : json.Gender === "Female" ? SynthesisVoiceGender.Female : SynthesisVoiceGender.Unknown;
@@ -68,6 +70,10 @@ export class VoiceInfo {
 
     public get shortName(): string {
         return this.privShortName;
+    }
+
+    public get displayName(): string {
+        return this.privDisplayName;
     }
 
     public get localName(): string {


### PR DESCRIPTION
### Description:

This PR adds the `DisplayName` property to `VoiceInfo` and `SynthesisVoicesResult`, to match the data returned by the Web API.

### Motivation:

This property was returned by the API, but missing in `VoiceInfo`.

[Reference Link](https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech?tabs=streaming#get-a-list-of-voices)