### PR TITLE
[pronunciation assessment] expose word level accuracy score and error…

### DIFF
--- a/src/sdk/PronunciationAssessmentConfig.ts
+++ b/src/sdk/PronunciationAssessmentConfig.ts
@@ -193,7 +193,11 @@ export class PronunciationAssessmentConfig {
 
         // always set dimension to Comprehensive
         paramsJson.dimension = "Comprehensive";
-        paramsJson.enableMiscue = this.enableMiscue;
+
+        const enableMiscueString = this.privProperties.getProperty(PropertyId.PronunciationAssessment_EnableMiscue);
+        if (enableMiscueString) {
+            paramsJson.enableMiscue = this.enableMiscue;
+        }
 
         this.privProperties.setProperty(PropertyId.PronunciationAssessment_Params, JSON.stringify(paramsJson));
     }

--- a/src/sdk/PronunciationAssessmentConfig.ts
+++ b/src/sdk/PronunciationAssessmentConfig.ts
@@ -58,6 +58,8 @@ export class PronunciationAssessmentConfig {
      * @param {string} json The json string containing the pronunciation assessment parameters.
      * @return {PronunciationAssessmentConfig} Instance of PronunciationAssessmentConfig
      * @summary Creates an instance of the PronunciationAssessmentConfig from json.
+     * This method is designed to support the pronunciation assessment parameters still in preview.
+     * Under normal circumstances, use the constructor instead.
      */
     public static fromJSON(json: string): PronunciationAssessmentConfig {
         Contracts.throwIfNullOrUndefined(json, "json");

--- a/src/sdk/PronunciationAssessmentResult.ts
+++ b/src/sdk/PronunciationAssessmentResult.ts
@@ -29,7 +29,10 @@ interface WordResult {
             NBestPhonemes: { Phoneme: string }[];
         };
      }[];
-
+    PronunciationAssessment?: {
+        AccuracyScore: number;
+        ErrorType: string;
+    };
     Syllables: { Syllable: string }[];
 }
 

--- a/tests/PronunciationAssessmentTests.ts
+++ b/tests/PronunciationAssessmentTests.ts
@@ -150,7 +150,7 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
         objsToClose.push(r);
 
         const p: sdk.PronunciationAssessmentConfig = new sdk.PronunciationAssessmentConfig(Settings.WaveFileText,
-            PronunciationAssessmentGradingSystem.HundredMark, PronunciationAssessmentGranularity.Phoneme, true);
+            PronunciationAssessmentGradingSystem.HundredMark, PronunciationAssessmentGranularity.Phoneme, false);
         objsToClose.push(p);
         p.applyTo(r);
 
@@ -178,6 +178,56 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
                 expect(pronResult.detailResult.Words[0].Word).not.toBeUndefined();
                 expect(pronResult.detailResult.Words[0].Phonemes[0].Phoneme).not.toBeUndefined();
                 expect(pronResult.detailResult.Words[0].Syllables[0].Syllable).not.toBeUndefined();
+                expect(pronResult.pronunciationScore).toBeGreaterThan(0);
+                expect(pronResult.accuracyScore).toBeGreaterThan(0);
+                expect(pronResult.fluencyScore).toBeGreaterThan(0);
+                expect(pronResult.completenessScore).toBeGreaterThan(0);
+                done();
+            } catch (error) {
+                done(error);
+            }
+        }, (error: string) => {
+            done(error);
+        });
+    });
+
+    test("test Pronunciation Assessment with miscue enabled", (done: jest.DoneCallback) => {
+        // eslint-disable-next-line no-console
+        console.info("Name: test Pronunciation Assessment with miscue enabled");
+        const s: sdk.SpeechConfig = BuildSpeechConfig();
+        objsToClose.push(s);
+
+        const r: sdk.SpeechRecognizer = BuildRecognizerFromWaveFile(s, Settings.WaveFile);
+        objsToClose.push(r);
+
+        const p: sdk.PronunciationAssessmentConfig = new sdk.PronunciationAssessmentConfig(Settings.WaveFileText + " buddy",
+            PronunciationAssessmentGradingSystem.HundredMark, PronunciationAssessmentGranularity.Phoneme, true);
+        objsToClose.push(p);
+        p.applyTo(r);
+
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done(error);
+            }
+        };
+
+        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
+            try {
+                expect(result).not.toBeUndefined();
+                expect(result.errorDetails).toBeUndefined();
+                expect(result.text).toEqual(Settings.WaveFileText);
+                expect(result.properties).not.toBeUndefined();
+                const jsonString = result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult);
+                expect(jsonString).not.toBeUndefined();
+                const jsonResult = JSON.parse(jsonString);
+                expect(jsonResult.SNR).toBeGreaterThan(0);
+                const pronResult = sdk.PronunciationAssessmentResult.fromResult(result);
+                expect(pronResult).not.toBeUndefined();
+                expect(pronResult.detailResult).not.toBeUndefined();
+                expect(pronResult.detailResult.Words[4].Word).not.toBeUndefined();
+                expect(pronResult.detailResult.Words[4].PronunciationAssessment.ErrorType).toEqual("Omission")
                 expect(pronResult.pronunciationScore).toBeGreaterThan(0);
                 expect(pronResult.accuracyScore).toBeGreaterThan(0);
                 expect(pronResult.fluencyScore).toBeGreaterThan(0);


### PR DESCRIPTION
… type in pronunciation result

Also fix a bug where the `miscue` property is overwrite by mistake for pronunciation config constructed from json

see https://github.com/Azure-Samples/cognitive-services-speech-sdk/issues/1995