### PR TITLE
initial fix to enable translations for v2 endpoints

### DIFF
--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -230,8 +230,8 @@ export abstract class ServiceRecognizerBase implements IDisposable {
     }
 
     protected setLanguageIdJson(): void {
+        const phraseDetection = this.privSpeechContext.getSection("phraseDetection") as PhraseDetection;
         if (this.privRecognizerConfig.autoDetectSourceLanguages !== undefined) {
-            const phraseDetection = this.privSpeechContext.getSection("phraseDetection") as PhraseDetection;
             const sourceLanguages: string[] = this.privRecognizerConfig.autoDetectSourceLanguages.split(",");
 
             let speechContextLidMode;
@@ -248,13 +248,12 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                 onSuccess: { action: "Recognize" },
                 onUnknown: { action: "None" }
             });
-            const targetLanguages: string = this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceConnection_TranslationToLanguages, undefined);
             this.privSpeechContext.setSection("phraseOutput", {
                 interimResults: {
-                    resultType: (targetLanguages === undefined) ? "Auto" : "None"
+                    resultType: "Auto"
                 },
                 phraseResults: {
-                    resultType: (targetLanguages === undefined) ? "Always" : "None"
+                    resultType: "Always"
                 }
             });
             const customModels: CustomModel[] = this.privRecognizerConfig.sourceLanguageModels;
@@ -263,13 +262,22 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                 phraseDetection.onInterim = { action: "None" };
                 phraseDetection.onSuccess = { action: "None" };
             }
-            if (targetLanguages !== undefined) {
-                phraseDetection.onInterim = { action: "Translate" };
-                phraseDetection.onSuccess = { action: "Translate" };
-            }
-
-            this.privSpeechContext.setSection("phraseDetection", phraseDetection);
         }
+        const targetLanguages: string = this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceConnection_TranslationToLanguages, undefined);
+        if (targetLanguages !== undefined) {
+            phraseDetection.onInterim = { action: "Translate" };
+            phraseDetection.onSuccess = { action: "Translate" };
+            this.privSpeechContext.setSection("phraseOutput", {
+                interimResults: {
+                    resultType: "None"
+                },
+                phraseResults: {
+                    resultType: "None"
+                }
+            });
+        }
+
+        this.privSpeechContext.setSection("phraseDetection", phraseDetection);
     }
 
     protected setOutputDetailLevelJson(): void {

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -57,12 +57,6 @@ interface CustomModel {
     endpoint: string;
 }
 
-export interface TranslationSection {
-    targetLanguages: string[];
-    output: { interimResults: { mode: "Always" } };
-    onSuccess: { action: string };
-}
-
 export interface PhraseDetection {
     customModels?: CustomModel[];
     onInterim?: { action: string };
@@ -200,10 +194,20 @@ export abstract class ServiceRecognizerBase implements IDisposable {
             const translationVoice: string =  this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceConnection_TranslationVoice, undefined);
             const action = ( translationVoice !== undefined ) ? "Synthesize" : "None";
             this.privSpeechContext.setSection("translation", {
-                targetLanguages: languages,
                 onSuccess: { action },
-                output: { interimResults: { mode: "Always" } }
+                output: { interimResults: { mode: "Always" } },
+                targetLanguages: languages,
             });
+
+            if (translationVoice !== undefined) {
+                const languageToVoiceMap: { [key: string]: string } = {};
+                for (const lang of languages) {
+                    languageToVoiceMap[lang] = translationVoice;
+                }
+                this.privSpeechContext.setSection("synthesis", {
+                    defaultVoices: languageToVoiceMap
+                });
+            }
         }
     }
 

--- a/src/sdk/SpeechTranslationConfig.ts
+++ b/src/sdk/SpeechTranslationConfig.ts
@@ -319,8 +319,10 @@ export class SpeechTranslationConfigImpl extends SpeechTranslationConfig {
         Contracts.throwIfNullOrWhitespace(value, "value");
 
         const languages: string[] = this.targetLanguages;
-        languages.push(value);
-        this.privSpeechProperties.setProperty(PropertyId.SpeechServiceConnection_TranslationToLanguages, languages.join(","));
+        if (!languages.includes(value)) {
+            languages.push(value);
+            this.privSpeechProperties.setProperty(PropertyId.SpeechServiceConnection_TranslationToLanguages, languages.join(","));
+        }
     }
 
     /**

--- a/tests/TranslationRecognizerTests.ts
+++ b/tests/TranslationRecognizerTests.ts
@@ -6,22 +6,16 @@ import {
     ConsoleLoggingListener,
     WebsocketMessageAdapter,
 } from "../src/common.browser/Exports";
-import { ServiceRecognizerBase } from "../src/common.speech/Exports";
 import {
     Events,
-    EventType
 } from "../src/common/Exports";
 
-import { ByteBufferAudioFile } from "./ByteBufferAudioFile";
 import { Settings } from "./Settings";
-import { validateTelemetry } from "./TelemetryUtil";
 import {
     closeAsyncObjects,
     WaitForCondition
 } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
-
-import { AudioStreamFormatImpl } from "../src/sdk/Audio/AudioStreamFormat";
 
 let objsToClose: any[];
 
@@ -136,7 +130,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
         console.info("Name: Translate Multiple Targets");
         const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
         objsToClose.push(s);
-        s.addTargetLanguage("en-US");
+        s.addTargetLanguage("fr-FR");
 
         const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
         objsToClose.push(r);
@@ -155,8 +149,8 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                 expect(res.errorDetails).toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
                 expect("Wie ist das Wetter?").toEqual(res.translations.get("de", ""));
-                expect("What's the weather like?").toEqual(res.translations.get("en", ""));
-                expect(res.translations.languages).toEqual(["en", "de"]);
+                expect("Quel temps fait-il?").toEqual(res.translations.get("fr", ""));
+                expect(res.translations.languages).toEqual(["fr", "de"]);
                 expect(r.targetLanguages.length).toEqual(res.translations.languages.length);
                 r.removeTargetLanguage("de-DE");
                 expect(r.targetLanguages.includes("de-DE")).toBeFalsy();
@@ -167,9 +161,9 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                         expect(secondRes).not.toBeUndefined();
                         expect(secondRes.errorDetails).toBeUndefined();
                         expect(sdk.ResultReason[secondRes.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
-                        expect("What's the weather like?").toEqual(secondRes.translations.get("en", ""));
+                        expect("Quel temps fait-il?").toEqual(secondRes.translations.get("fr", ""));
                         expect(secondRes.translations.languages.includes("es")).toBeTruthy();
-                        expect(secondRes.translations.languages.includes("en")).toBeTruthy();
+                        expect(secondRes.translations.languages.includes("fr")).toBeTruthy();
                         expect(secondRes.translations.languages.includes("de")).toBeFalsy();
                         expect("¿Cómo es el clima?").toEqual(secondRes.translations.get("es", ""));
                         done();
@@ -299,21 +293,14 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
         // eslint-disable-next-line no-console
         console.info("Name: fromV2EndPoint with Subscription key");
 
-        const endpoint = "wss://" + Settings.SpeechRegion + ".stt.speech.microsoft.com/speech/universal/v2?SpeechContext-translation.targetLanguages=[\"de-de\"]";
+        const targetLanguage = "de-DE";
+        const endpoint = `wss://${Settings.SpeechRegion}.stt.speech.microsoft.com/speech/universal/v2`;
 
         const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromEndpoint(new URL(endpoint), Settings.SpeechSubscriptionKey);
         objsToClose.push(s);
 
-        s.addTargetLanguage("de-DE");
+        s.addTargetLanguage(targetLanguage);
         s.speechRecognitionLanguage = "en-US";
-        s.setServiceProperty("language", "en-US", sdk.ServicePropertyChannel.UriQueryParameter);
-        s.setServiceProperty("SpeechContext-phraseDetection.interimResults", "true", sdk.ServicePropertyChannel.UriQueryParameter);
-        s.setServiceProperty("SpeechContext-phraseDetection.onInterim.action", "Translate", sdk.ServicePropertyChannel.UriQueryParameter);
-        s.setServiceProperty("SpeechContext-phraseDetection.onSuccess.action", "Translate", sdk.ServicePropertyChannel.UriQueryParameter);
-        s.setServiceProperty("SpeechContext-phraseOutput.interimResults.resultType", "Hypothesis", sdk.ServicePropertyChannel.UriQueryParameter);
-        s.setServiceProperty("SpeechContext-translation.onSuccess.action", "None", sdk.ServicePropertyChannel.UriQueryParameter);
-        s.setServiceProperty("SpeechContext-translation.output.includePassThroughResults", "true", sdk.ServicePropertyChannel.UriQueryParameter);
-        s.setServiceProperty("SpeechContext-translation.output.interimResults.mode", "Always", sdk.ServicePropertyChannel.UriQueryParameter);
 
         const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
         objsToClose.push(r);
@@ -330,8 +317,8 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                 expect(res).not.toBeUndefined();
                 expect(res.errorDetails).toBeUndefined();
                 expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
-                expect(res.translations.get("de-de", undefined) !== undefined).toEqual(true);
-                expect("Wie ist das Wetter?").toEqual(res.translations.get("de-de", ""));
+                expect(res.translations.get(targetLanguage, undefined) !== undefined).toEqual(true);
+                expect("Wie ist das Wetter?").toEqual(res.translations.get(targetLanguage, ""));
                 expect(res.text).toEqual("What's the weather like?");
                 done();
             },


### PR DESCRIPTION
when CLID is set, or v2 endpoint is used for translation, translation result weren't returned. this fixes that.