### PR TITLE
v2 translation hypothesis, conditionally import audioWorkerUrl method using import.meta

### DIFF
--- a/src/common.browser/PCMRecorder.ts
+++ b/src/common.browser/PCMRecorder.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { RiffPcmEncoder, Stream } from "../common/Exports";
-import { getAudioWorkerUrl } from "./AudioWorkerUrl";
 import { IRecorder } from "./IRecorder";
 
 export class PcmRecorder implements IRecorder {
@@ -91,7 +90,10 @@ export class PcmRecorder implements IRecorder {
         const skipAudioWorklet = !!this.privSpeechProcessorScript && this.privSpeechProcessorScript.toLowerCase() === "ignore";
 
         if (!!context.audioWorklet && !skipAudioWorklet) {
-            this.privSpeechProcessorScript = getAudioWorkerUrl();
+            /* eslint-disable-next-line */
+            const audioUrl = require("./AudioWorkerUrl");
+            /* eslint-disable-next-line */
+            this.privSpeechProcessorScript = audioUrl.getAudioWorkerUrl();
 
             context.audioWorklet
                 .addModule(this.privSpeechProcessorScript)

--- a/src/common.speech/ServiceMessages/TranslationHypothesis.ts
+++ b/src/common.speech/ServiceMessages/TranslationHypothesis.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { Contracts } from "../../sdk/Contracts";
 import { ITranslations } from "../Exports";
 import { TranslationStatus } from "../TranslationStatus";
 
@@ -15,13 +16,21 @@ export interface ITranslationHypothesis {
 export class TranslationHypothesis implements ITranslationHypothesis {
     private privTranslationHypothesis: ITranslationHypothesis;
 
-    private constructor(json: string) {
-        this.privTranslationHypothesis = JSON.parse(json) as ITranslationHypothesis;
+    private constructor(hypothesis: ITranslationHypothesis) {
+        this.privTranslationHypothesis = hypothesis;
         this.privTranslationHypothesis.Translation.TranslationStatus = TranslationStatus[this.privTranslationHypothesis.Translation.TranslationStatus as unknown as keyof typeof TranslationStatus];
     }
 
     public static fromJSON(json: string): TranslationHypothesis {
-        return new TranslationHypothesis(json);
+        return new TranslationHypothesis(JSON.parse(json) as ITranslationHypothesis);
+    }
+
+    public static fromTranslationResponse(translationHypothesis: { SpeechHypothesis: ITranslationHypothesis }): TranslationHypothesis {
+        Contracts.throwIfNullOrUndefined(translationHypothesis, "translationHypothesis");
+        const hypothesis: ITranslationHypothesis = translationHypothesis.SpeechHypothesis;
+        translationHypothesis.SpeechHypothesis = undefined;
+        hypothesis.Translation = (translationHypothesis as unknown as ITranslations);
+        return new TranslationHypothesis(hypothesis);
     }
 
     public get Duration(): number {

--- a/src/common.speech/ServiceMessages/TranslationPhrase.ts
+++ b/src/common.speech/ServiceMessages/TranslationPhrase.ts
@@ -11,7 +11,7 @@ export interface ITranslationPhrase {
     Offset: number;
     Duration: number;
     Translation?: ITranslations;
-    Text: string;
+    Text?: string;
     DisplayText?: string;
     PrimaryLanguage?: IPrimaryLanguage;
 }
@@ -52,19 +52,19 @@ export class TranslationPhrase implements ITranslationPhrase {
         return this.privTranslationPhrase.Duration;
     }
 
-    public get Text(): string {
+    public get Text(): string | undefined {
         return this.privTranslationPhrase.Text;
     }
 
-    public get Language(): string {
+    public get Language(): string | undefined {
         return this.privTranslationPhrase.PrimaryLanguage?.Language;
     }
 
-    public get Confidence(): string {
+    public get Confidence(): string | undefined {
         return this.privTranslationPhrase.PrimaryLanguage?.Confidence;
     }
 
-    public get Translation(): ITranslations {
+    public get Translation(): ITranslations | undefined {
         return this.privTranslationPhrase.Translation;
     }
 }

--- a/tests/AudioOutputStreamTests.ts
+++ b/tests/AudioOutputStreamTests.ts
@@ -7,9 +7,6 @@ import { Settings } from "./Settings";
 import { closeAsyncObjects } from "./Utilities";
 
 let objsToClose: any[];
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
 
 beforeAll(() => {
     // Override inputs, if necessary

--- a/tests/AutoSourceLangDetectionTests.ts
+++ b/tests/AutoSourceLangDetectionTests.ts
@@ -27,10 +27,6 @@ import { Settings } from "./Settings";
 import { closeAsyncObjects, WaitForCondition } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 let objsToClose: any[];
 const defaultTargetLanguage: string = "de-DE";
 

--- a/tests/AutoSourceLangDetectionTests.ts
+++ b/tests/AutoSourceLangDetectionTests.ts
@@ -484,6 +484,16 @@ describe.each([true, false])("Service based tests", (forceNodeWebSocket: boolean
             }
         };
 
+        r.recognizing = (o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs) => {
+            expect(e.result).not.toBeUndefined();
+            expect(e.result.text).toContain("what's the");
+            expect(e.result.properties).not.toBeUndefined();
+            expect(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+            expect(e.result.translations).not.toBeUndefined();
+            expect(e.result.translations.languages[0]).toEqual(defaultTargetLanguage);
+            expect(e.result.translations.get(defaultTargetLanguage)).toContain("Wie ist das");
+        }
+
         r.recognized = (o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs) => {
             try {
                 if (e.result.reason === sdk.ResultReason.TranslatedSpeech) {

--- a/tests/ConnectionTests.ts
+++ b/tests/ConnectionTests.ts
@@ -22,10 +22,6 @@ import {
 
 import * as fs from "fs";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 let objsToClose: any[];
 
 beforeAll(() => {

--- a/tests/ConversationTranscriberTests.ts
+++ b/tests/ConversationTranscriberTests.ts
@@ -23,10 +23,6 @@ import { Settings } from "./Settings";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 import { closeAsyncObjects, RepeatingPullStream, WaitForCondition } from "./Utilities";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 let objsToClose: any[];
 
 beforeAll(() => {

--- a/tests/ConversationTranslatorTests.ts
+++ b/tests/ConversationTranslatorTests.ts
@@ -26,10 +26,6 @@ import {
 } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 // eslint-disable-next-line no-console
 const consoleInfo = console.info;
 

--- a/tests/DiagnosticsTests.ts
+++ b/tests/DiagnosticsTests.ts
@@ -9,10 +9,6 @@ import { closeAsyncObjects, WaitForCondition } from "./Utilities";
 
 let objsToClose: any[];
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll((): void => {
     // Override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/DialogServiceConnectorTests.ts
+++ b/tests/DialogServiceConnectorTests.ts
@@ -46,10 +46,6 @@ import {
 } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 // eslint-disable-next-line no-console
 const consoleInfo = console.info;
 const simpleMessageObj = { speak: "This is speech", text: "This is text", type: "message" };

--- a/tests/DynamicGrammarTests.ts
+++ b/tests/DynamicGrammarTests.ts
@@ -9,10 +9,6 @@ import {
 } from "../src/common.speech/Exports";
 import { Settings } from "./Settings";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll(() => {
     // Override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/GeneralRecognizerTests.ts
+++ b/tests/GeneralRecognizerTests.ts
@@ -5,10 +5,6 @@ import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
 import { Settings } from "./Settings";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 let bufferSize: number;
 beforeEach(() => {
     // eslint-disable-next-line no-console

--- a/tests/IntentRecognizerTests.ts
+++ b/tests/IntentRecognizerTests.ts
@@ -18,10 +18,6 @@ import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 import { AudioStreamFormatImpl } from "../src/sdk/Audio/AudioStreamFormat";
 
 let objsToClose: any[];
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 let bufferSize: number;
 
 beforeAll(() => {

--- a/tests/LanguageModelTests.ts
+++ b/tests/LanguageModelTests.ts
@@ -5,10 +5,6 @@ import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
 import { LanguageUnderstandingModelImpl } from "../src/sdk/LanguageUnderstandingModel";
 import { Settings } from "./Settings";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll(() => {
     // Override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/LongRunning/SpeechRecoAuthTokenErrorMessageTests.ts
+++ b/tests/LongRunning/SpeechRecoAuthTokenErrorMessageTests.ts
@@ -9,9 +9,6 @@ import { Settings } from "../Settings";
 import { CreateRepeatingPullStream, WaitForCondition } from "../Utilities";
 
 let objsToClose: any[];
-jest.mock("../../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
 
 beforeAll(() => {
     // override inputs, if necessary

--- a/tests/LongRunning/SpeechRecoAuthTokenRefreshTests.ts
+++ b/tests/LongRunning/SpeechRecoAuthTokenRefreshTests.ts
@@ -11,10 +11,6 @@ import { CreateRepeatingPullStream, WaitForCondition } from "../Utilities";
 
 let objsToClose: any[];
 
-jest.mock("../../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll(() => {
     // override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/LongRunning/SpeechRecoReconnectTests.ts
+++ b/tests/LongRunning/SpeechRecoReconnectTests.ts
@@ -11,10 +11,6 @@ import { WaitForCondition } from "../Utilities";
 
 let objsToClose: any[];
 
-jest.mock("../../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll((): void => {
     // override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/LongRunning/TranslationRecoReconnectTests.ts
+++ b/tests/LongRunning/TranslationRecoReconnectTests.ts
@@ -12,10 +12,6 @@ import { WaitForCondition } from "../Utilities";
 
 let objsToClose: any[];
 
-jest.mock("../../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll((): void => {
     // override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/MeetingTranscriberTests.ts
+++ b/tests/MeetingTranscriberTests.ts
@@ -13,10 +13,6 @@ import { Settings } from "./Settings";
 import { closeAsyncObjects } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 let objsToClose: any[];
 
 function sleep(milliseconds: number): Promise<any> {

--- a/tests/PronunciationAssessmentTests.ts
+++ b/tests/PronunciationAssessmentTests.ts
@@ -17,10 +17,6 @@ import { Settings } from "./Settings";
 import { closeAsyncObjects } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 let objsToClose: any[];
 
 beforeAll((): void => {

--- a/tests/PullInputStreamTests.ts
+++ b/tests/PullInputStreamTests.ts
@@ -16,10 +16,6 @@ import { Settings } from "./Settings";
 
 let bufferSize: number;
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll(() => {
     // Override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/PushInputStreamTests.ts
+++ b/tests/PushInputStreamTests.ts
@@ -15,10 +15,6 @@ import {
 } from "../src/sdk/Audio/AudioStreamFormat";
 import { Settings } from "./Settings";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 let bufferSize: number;
 beforeAll(() => {
     // Override inputs, if necessary

--- a/tests/ReplayableAudioNodeTests.ts
+++ b/tests/ReplayableAudioNodeTests.ts
@@ -14,10 +14,6 @@ let readCount: number;
 const targetBytes: number = 4096;
 const defaultAudioFormat: AudioStreamFormatImpl = sdk.AudioStreamFormat.getDefaultInputFormat() as AudioStreamFormatImpl;
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeEach(() => {
     readCount = 0;
 });

--- a/tests/SpeechConfigTests.ts
+++ b/tests/SpeechConfigTests.ts
@@ -19,10 +19,6 @@ import { closeAsyncObjects } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
 let objsToClose: any[];
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll((): void => {
     // Override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/SpeechContextTests.ts
+++ b/tests/SpeechContextTests.ts
@@ -10,10 +10,6 @@ import {
 } from "../src/common.speech/Exports";
 import { Settings } from "./Settings";
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll(() => {
     // Override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/SpeechRecognizerSilenceTests.ts
+++ b/tests/SpeechRecognizerSilenceTests.ts
@@ -28,11 +28,6 @@ const Canceled: string = "Canceled";
 
 let objsToClose: any[];
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
-
 beforeAll(() => {
     // override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -59,10 +59,6 @@ const Canceled: string = "Canceled";
 
 let objsToClose: any[];
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll(() => {
     // override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -22,10 +22,6 @@ import {
 
 let objsToClose: any[];
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll(() => {
     // override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/TranslationRecognizerBasicsTests.ts
+++ b/tests/TranslationRecognizerBasicsTests.ts
@@ -26,10 +26,6 @@ import { AudioStreamFormatImpl } from "../src/sdk/Audio/AudioStreamFormat";
 
 let objsToClose: any[];
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
 beforeAll(() => {
     // Override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/TranslationRecognizerTests.ts
+++ b/tests/TranslationRecognizerTests.ts
@@ -19,11 +19,6 @@ import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
 let objsToClose: any[];
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
-
 beforeAll(() => {
     // Override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/TranslationSynthTests.ts
+++ b/tests/TranslationSynthTests.ts
@@ -20,11 +20,6 @@ import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
 let objsToClose: any[];
 
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
-
-
 beforeAll(() => {
     // Override inputs, if necessary
     Settings.LoadSettings();

--- a/tests/VoiceProfileClientTests.ts
+++ b/tests/VoiceProfileClientTests.ts
@@ -13,9 +13,6 @@ import { closeAsyncObjects } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
 let objsToClose: any[];
-jest.mock("../src/common.browser/AudioWorkerUrl", () => ({
-   getAudioWorkerUrl: (): string => "speech-processor.js"
-}));
 
 beforeAll((): void => {
     // Override inputs, if necessary


### PR DESCRIPTION
- add handling for v2 translation hypothesis messages
- React Native customers can't use import.meta, and customers not using browser microphone functionality don't need to deal with import.meta related errors. This conditionally loads the import.meta code if needed, not at SDK library load time.