### PR TITLE
fix race condition in stopRecognizing

### DIFF
--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -428,8 +428,8 @@ export abstract class ServiceRecognizerBase implements IDisposable {
             try {
                 await this.audioSource.turnOff();
                 await this.sendFinalAudio();
-                await this.privRequestSession.turnCompletionPromise;
                 await this.privRequestSession.onStopRecognizing();
+                await this.privRequestSession.turnCompletionPromise;
             } finally {
                 await this.privRequestSession.dispose();
             }
@@ -584,11 +584,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
 
             // indicates we are draining the queue and it came with no message;
             if (!message) {
-                if (!this.privRequestSession.isRecognizing) {
-                    return;
-                } else {
-                    return this.receiveMessage();
-                }
+                return this.receiveMessage();
             }
 
             this.privServiceHasSentMessage = true;

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -428,8 +428,8 @@ export abstract class ServiceRecognizerBase implements IDisposable {
             try {
                 await this.audioSource.turnOff();
                 await this.sendFinalAudio();
-                await this.privRequestSession.onStopRecognizing();
                 await this.privRequestSession.turnCompletionPromise;
+                await this.privRequestSession.onStopRecognizing();
             } finally {
                 await this.privRequestSession.dispose();
             }

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -593,17 +593,11 @@ export abstract class ServiceRecognizerBase implements IDisposable {
             if (connectionMessage.requestId.toLowerCase() === this.privRequestSession.requestId.toLowerCase()) {
                 switch (connectionMessage.path.toLowerCase()) {
                     case "turn.start":
-                        if (!this.privRequestSession.isRecognizing) {
-                            return; // Fix for gap in receiving turn.end #741
-                        }
                         this.privMustReportEndOfStream = true;
                         this.privRequestSession.onServiceTurnStartResponse();
                         break;
 
                     case "speech.startdetected":
-                        if (!this.privRequestSession.isRecognizing) {
-                            return; // Fix for gap in receiving turn.end #741
-                        }
                         const speechStartDetected: SpeechDetected = SpeechDetected.fromJSON(connectionMessage.textBody);
                         const speechStartEventArgs = new RecognitionEventArgs(speechStartDetected.Offset, this.privRequestSession.sessionId);
                         if (!!this.privRecognizer.speechStartDetected) {

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -593,11 +593,17 @@ export abstract class ServiceRecognizerBase implements IDisposable {
             if (connectionMessage.requestId.toLowerCase() === this.privRequestSession.requestId.toLowerCase()) {
                 switch (connectionMessage.path.toLowerCase()) {
                     case "turn.start":
+                        if (!this.privRequestSession.isRecognizing) {
+                            return; // Fix for gap in receiving turn.end #741
+                        }
                         this.privMustReportEndOfStream = true;
                         this.privRequestSession.onServiceTurnStartResponse();
                         break;
 
                     case "speech.startdetected":
+                        if (!this.privRequestSession.isRecognizing) {
+                            return; // Fix for gap in receiving turn.end #741
+                        }
                         const speechStartDetected: SpeechDetected = SpeechDetected.fromJSON(connectionMessage.textBody);
                         const speechStartEventArgs = new RecognitionEventArgs(speechStartDetected.Offset, this.privRequestSession.sessionId);
                         if (!!this.privRecognizer.speechStartDetected) {


### PR DESCRIPTION
Fix #741

In stopRecognizing, the privRequestSession.turnCompletionPromise depends on receiving a "turn.end" message from the service. 
The line above that turnCompletionPromise, however, indirectly stops receiveMessage() from receiving that "turn.end" message, setting privRequestSession.isRecognizing to false.

~~This PR puts those calls in the correct order to allow stopRecognizing to complete, and thus stopContinuousRecognitionAsync to properly invoke its callback function parameter.~~

This PR removes the isRecognizing check when waiting on an empty queue. The service seems to delay slightly sending turn.end related messages after 10m of silence, but in an ideal world that delay shouldn't cause an abnormality on the SDK side.