### PR TITLE
Remove __proto__ usage in RawWebsocketMessage.ts

### DIFF
--- a/src/common/RawWebsocketMessage.ts
+++ b/src/common/RawWebsocketMessage.ts
@@ -17,7 +17,7 @@ export class RawWebsocketMessage {
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (messageType === MessageType.Binary && payload.__proto__.constructor.name !== "ArrayBuffer") {
+        if (messageType === MessageType.Binary && Object.getPrototypeOf(payload).constructor.name !== "ArrayBuffer") {
             throw new InvalidOperationError("Payload must be ArrayBuffer");
         }
 


### PR DESCRIPTION
Currently this line uses __proto__ to get the objects prototype, which is [deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto), and according to Mozilla's docs "controversial and discouraged"). 

More concretely, this prevents this SDK from running in certain runtimes that do not support `__proto__` - like Deno (see here: https://github.com/denoland/deno/issues/4324). I suggest replacing this code to use the more modern `getPrototypeOf`. With that change, I can confirm this library runs on Deno as well now.