### PR TITLE
adds the onLogOutput callback to Diagnostics class

### DIFF
--- a/src/common.browser/ConsoleLoggingListener.ts
+++ b/src/common.browser/ConsoleLoggingListener.ts
@@ -12,6 +12,8 @@ export class ConsoleLoggingListener implements IEventListener<PlatformEvent> {
     private privLogPath: fs.PathLike = undefined;
     private privEnableConsoleOutput: boolean = true;
 
+    public logCallback: (s: string) => void;
+
     public constructor(logLevelFilter: LogLevel = LogLevel.None) { // Console output disabled by default
         this.privLogLevelFilter = logLevelFilter;
     }
@@ -28,6 +30,9 @@ export class ConsoleLoggingListener implements IEventListener<PlatformEvent> {
     public onEvent(event: PlatformEvent): void {
         if (event.eventType >= this.privLogLevelFilter) {
             const log = this.toString(event);
+            if (!!this.logCallback) {
+                this.logCallback(log);
+            }
             if (!!this.privLogPath) {
                 fs.writeFileSync(this.privLogPath, log + "\n", { flag: "a+" });
             }

--- a/src/sdk/Diagnostics.ts
+++ b/src/sdk/Diagnostics.ts
@@ -7,6 +7,8 @@ import { ConsoleLoggingListener } from "../common.browser/Exports.js";
 import { Events } from "../common/Exports.js";
 import { LogLevel } from "./LogLevel.js";
 
+type LogCallback = (s: string) => void;
+
 /**
  * Defines diagnostics API for managing console output
  * Added in version 1.21.0
@@ -38,6 +40,13 @@ export class Diagnostics {
             }
         } else {
             throw new Error("File system logging not available in browser.");
+        }
+    }
+
+
+    public static set onLogOutput( callback: LogCallback ) {
+        if (!!this.privListener) {
+            this.privListener.logCallback = callback;
         }
     }
 

--- a/tests/DiagnosticsTests.ts
+++ b/tests/DiagnosticsTests.ts
@@ -92,3 +92,31 @@ Settings.testIfDOMCondition("Diagnostics log file throws", (): void => {
     sdk.Diagnostics.SetLoggingLevel(sdk.LogLevel.Debug);
     expect((): void => sdk.Diagnostics.SetLogOutputPath(Settings.TestLogPath)).toThrow();
 });
+
+test("Diagnostics callback works", (done: jest.DoneCallback): void => {
+    sdk.Diagnostics.SetLoggingLevel(sdk.LogLevel.Debug);
+    // eslint-disable-next-line no-console
+    console.info("Name: callback invoked on debug output");
+
+    const s: sdk.SpeechConfig = BuildSpeechConfig();
+    objsToClose.push(s);
+
+    const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s);
+    objsToClose.push(r);
+
+    let callbackInvoked: boolean = false;
+    const connection: sdk.Connection = sdk.Connection.fromRecognizer(r);
+
+    const logCallback = (s: string): void => {
+        void s;
+        callbackInvoked = true;
+    };
+
+    sdk.Diagnostics.onLogOutput = logCallback;
+
+    connection.openConnection();
+
+    WaitForCondition((): boolean => callbackInvoked, (): void => {
+        connection.closeConnection(() => done());
+    });
+});


### PR DESCRIPTION
for situations where the customer may not be able to save logs to the file system (or just doesn't want to), this onLogOutput callback allows more flexible handling of log output.