### PR TITLE
Fix Division by Zero Error in audioOffsetMs Calculation

### DIFF
--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -666,7 +666,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
 
     private updateSpeakerDiarizationAudioOffset(): void {
         const bytesSent: number = this.privRequestSession.recognitionBytesSent;
-        const audioOffsetMs: number = bytesSent / this.privAverageBytesPerMs;
+        const audioOffsetMs: number = this.privAverageBytesPerMs != 0 ? bytesSent / this.privAverageBytesPerMs : 0;
         this.privSpeechContext.setSpeakerDiarizationAudioOffsetMs(audioOffsetMs);
     }
 

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -666,7 +666,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
 
     private updateSpeakerDiarizationAudioOffset(): void {
         const bytesSent: number = this.privRequestSession.recognitionBytesSent;
-        const audioOffsetMs: number = this.privAverageBytesPerMs != 0 ? bytesSent / this.privAverageBytesPerMs : 0;
+        const audioOffsetMs: number = this.privAverageBytesPerMs !== 0 ? bytesSent / this.privAverageBytesPerMs : 0;
         this.privSpeechContext.setSpeakerDiarizationAudioOffsetMs(audioOffsetMs);
     }
 


### PR DESCRIPTION
This pull request addresses a potential division by zero error in the calculation of audioOffsetMs within the ServiceRecognizerBase.ts file. The fix ensures that if this.privAverageBytesPerMs is zero, audioOffsetMs is set to zero instead of attempting to perform the division.

UAT Tracker ID : [304110](https://uatracker.microsoft.com/action?id=304110&cw=false&tab=Technical%20Feedback)

#### Changes Made:
- Updated the calculation of audioOffsetMs to include a conditional check that sets audioOffsetMs to zero if this.privAverageBytesPerMs is zero.

#### Code Changes:
```typescript
const audioOffsetMs: number = this.privAverageBytesPerMs != 0 ? bytesSent / this.privAverageBytesPerMs : 0;
```
#### Tested Scenario:
- The Current code throw an error when used in PowerApps PCF control for speech recognition .
```shell
ConversationTranscriptionCanceledEventArgs {privSessionId: '653442B08C524EA4ADDB66A19C992187', privOffset: undefined, privReason: 0, privErrorDetails: 'Could not deserialize speech context. websocket error code: 1007', privErrorCode: 2}