### PR TITLE
Align behavior for EndOfDictation message with Native SDK's

### DIFF
--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -2132,7 +2132,6 @@ test("Multiple ContReco calls share a connection", (done: jest.DoneCallback) => 
     r.recognized = (r: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
         try {
             const res: sdk.SpeechRecognitionResult = e.result;
-            console.info(res);
             expect(res).not.toBeUndefined();
             expect(disconnected).toEqual(false);
             expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -2088,7 +2088,7 @@ test("Multiple ContReco calls share a connection", (done: jest.DoneCallback) => 
     let sessionId: string;
 
     const pullStreamSource: RepeatingPullStream = new RepeatingPullStream(Settings.WaveFile);
-    const p: PullAudioInputStream = pullStreamSource.PullStream;;
+    const p: PullAudioInputStream = pullStreamSource.PullStream;
 
     const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
 
@@ -2132,14 +2132,12 @@ test("Multiple ContReco calls share a connection", (done: jest.DoneCallback) => 
     r.recognized = (r: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
         try {
             const res: sdk.SpeechRecognitionResult = e.result;
+            console.info(res);
             expect(res).not.toBeUndefined();
             expect(disconnected).toEqual(false);
-            if (0 !== recoCount % 2) {
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.NoMatch]);
-            } else {
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
-                expect(res.text).toContain("the weather like?");
-            }
+            expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+            expect(res.text).toContain("the weather like?");
+
             recoCount++;
         } catch (error) {
             done(error);
@@ -2168,7 +2166,7 @@ test("Multiple ContReco calls share a connection", (done: jest.DoneCallback) => 
     });
 
     WaitForCondition(() => {
-        return recoCount === 3;
+        return recoCount === 2;
     }, () => {
         r.stopContinuousRecognitionAsync(() => {
             done();


### PR DESCRIPTION
The JS SDK had used a complex if statement to attempt to align its event pattern with the native SDK's, when all it needed to do was to ignore EndOfDictation messages.

The same information conveyed by the EndOfDictation message is conveyed by the EndOfSpeech event which is still raised.

This complex if statement lead to some conditions where a result may not have been returned if the Speech Service was unable to recognize speech and send a NoMatch result.

One test case that weas counting recognized results needs adjustment, all others passed as they were.