### PR TITLE
Offset Fixes

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -64,8 +64,7 @@ jobs:
         ConversationTranscriptionKey:$(ConverstationTranscriptionKeyWestUSOnline) ^
         ConversationTranscriptionRegion:westus ^
         CustomVoiceSubscriptionKey:$(speech-ne-s0-key1) ^
-        CustomVoiceRegion:northeurope ^
-        ExecuteLongRunningTests = "true"
+        CustomVoiceRegion:northeurope
     displayName: Run tests
     condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
   - task: PublishTestResults@2

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -64,7 +64,8 @@ jobs:
         ConversationTranscriptionKey:$(ConverstationTranscriptionKeyWestUSOnline) ^
         ConversationTranscriptionRegion:westus ^
         CustomVoiceSubscriptionKey:$(speech-ne-s0-key1) ^
-        CustomVoiceRegion:northeurope
+        CustomVoiceRegion:northeurope ^
+        ExecuteLongRunningTests = "true"
     displayName: Run tests
     condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
   - task: PublishTestResults@2

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "test": "npm run lint && npm run jest --coverage",
     "jest": "jest",
     "lint": "eslint -c .eslintrc.cjs --ext .ts src",
+    "linttest": "eslint -c .eslintrc.cjs --ext .ts tests",
     "civersion": "node ci/version.cjs",
     "prepare": "npm run build",
     "setup": "npm install --package-lock-only --ignore-scripts --no-audit"

--- a/src/common.speech/ConversationTranscriptionServiceRecognizer.ts
+++ b/src/common.speech/ConversationTranscriptionServiceRecognizer.ts
@@ -70,23 +70,22 @@ export class ConversationTranscriptionServiceRecognizer extends ServiceRecognize
         switch (connectionMessage.path.toLowerCase()) {
             case "speech.hypothesis":
             case "speech.fragment":
-                const hypothesis: SpeechHypothesis = SpeechHypothesis.fromJSON(connectionMessage.textBody);
-                const offset: number = hypothesis.Offset + this.privRequestSession.currentTurnAudioOffset;
+                const hypothesis: SpeechHypothesis = SpeechHypothesis.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
 
                 result = new ConversationTranscriptionResult(
                     this.privRequestSession.requestId,
                     ResultReason.RecognizingSpeech,
                     hypothesis.Text,
                     hypothesis.Duration,
-                    offset,
+                    hypothesis.Offset,
                     hypothesis.Language,
                     hypothesis.LanguageDetectionConfidence,
                     hypothesis.SpeakerId,
                     undefined,
-                    connectionMessage.textBody,
+                    hypothesis.asJson(),
                     resultProps);
 
-                this.privRequestSession.onHypothesis(offset);
+                this.privRequestSession.onHypothesis(hypothesis.Offset);
 
                 const ev = new ConversationTranscriptionEventArgs(result, hypothesis.Duration, this.privRequestSession.sessionId);
 
@@ -102,10 +101,10 @@ export class ConversationTranscriptionServiceRecognizer extends ServiceRecognize
                 processed = true;
                 break;
             case "speech.phrase":
-                const simple: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(connectionMessage.textBody);
+                const simple: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
                 const resultReason: ResultReason = EnumTranslation.implTranslateRecognitionResult(simple.RecognitionStatus);
 
-                this.privRequestSession.onPhraseRecognized(this.privRequestSession.currentTurnAudioOffset + simple.Offset + simple.Duration);
+                this.privRequestSession.onPhraseRecognized(simple.Offset + simple.Duration);
 
                 if (ResultReason.Canceled === resultReason) {
                     const cancelReason: CancellationReason = EnumTranslation.implTranslateCancelResult(simple.RecognitionStatus);
@@ -124,29 +123,27 @@ export class ConversationTranscriptionServiceRecognizer extends ServiceRecognize
                                 resultReason,
                                 simple.DisplayText,
                                 simple.Duration,
-                                simple.Offset + this.privRequestSession.currentTurnAudioOffset,
+                                simple.Offset,
                                 simple.Language,
                                 simple.LanguageDetectionConfidence,
                                 simple.SpeakerId,
                                 undefined,
-                                connectionMessage.textBody,
+                                simple.asJson(),
                                 resultProps);
                         } else {
-                            const detailed: DetailedSpeechPhrase = DetailedSpeechPhrase.fromJSON(connectionMessage.textBody);
-                            const totalOffset: number = detailed.Offset + this.privRequestSession.currentTurnAudioOffset;
-                            const offsetCorrectedJson: string = detailed.getJsonWithCorrectedOffsets(totalOffset);
+                            const detailed: DetailedSpeechPhrase = DetailedSpeechPhrase.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
 
                             result = new ConversationTranscriptionResult(
                                 this.privRequestSession.requestId,
                                 resultReason,
                                 detailed.RecognitionStatus === RecognitionStatus.Success ? detailed.NBest[0].Display : undefined,
                                 detailed.Duration,
-                                totalOffset,
+                                detailed.Offset,
                                 detailed.Language,
                                 detailed.LanguageDetectionConfidence,
                                 simple.SpeakerId,
                                 undefined,
-                                offsetCorrectedJson,
+                                detailed.asJson(),
                                 resultProps);
                         }
 

--- a/src/common.speech/IntentServiceRecognizer.ts
+++ b/src/common.speech/IntentServiceRecognizer.ts
@@ -69,7 +69,7 @@ export class IntentServiceRecognizer extends ServiceRecognizerBase {
 
         switch (connectionMessage.path.toLowerCase()) {
             case "speech.hypothesis":
-                const speechHypothesis: SpeechHypothesis = SpeechHypothesis.fromJSON(connectionMessage.textBody);
+                const speechHypothesis: SpeechHypothesis = SpeechHypothesis.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
 
                 result = new IntentRecognitionResult(
                     undefined,
@@ -77,16 +77,16 @@ export class IntentServiceRecognizer extends ServiceRecognizerBase {
                     ResultReason.RecognizingIntent,
                     speechHypothesis.Text,
                     speechHypothesis.Duration,
-                    speechHypothesis.Offset + this.privRequestSession.currentTurnAudioOffset,
+                    speechHypothesis.Offset,
                     speechHypothesis.Language,
                     speechHypothesis.LanguageDetectionConfidence,
                     undefined,
-                    connectionMessage.textBody,
+                    speechHypothesis.asJson(),
                     resultProps);
 
                 this.privRequestSession.onHypothesis(result.offset);
 
-                ev = new IntentRecognitionEventArgs(result, speechHypothesis.Offset + this.privRequestSession.currentTurnAudioOffset, this.privRequestSession.sessionId);
+                ev = new IntentRecognitionEventArgs(result, speechHypothesis.Offset, this.privRequestSession.sessionId);
 
                 if (!!this.privIntentRecognizer.recognizing) {
                     try {
@@ -100,18 +100,18 @@ export class IntentServiceRecognizer extends ServiceRecognizerBase {
                 processed = true;
                 break;
             case "speech.phrase":
-                const simple: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(connectionMessage.textBody);
+                const simple: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
                 result = new IntentRecognitionResult(
                     undefined,
                     this.privRequestSession.requestId,
                     EnumTranslation.implTranslateRecognitionResult(simple.RecognitionStatus),
                     simple.DisplayText,
                     simple.Duration,
-                    simple.Offset + this.privRequestSession.currentTurnAudioOffset,
+                    simple.Offset,
                     simple.Language,
                     simple.LanguageDetectionConfidence,
                     undefined,
-                    connectionMessage.textBody,
+                    simple.asJson(),
                     resultProps);
 
                 ev = new IntentRecognitionEventArgs(result, result.offset, this.privRequestSession.sessionId);

--- a/src/common.speech/ServiceMessages/DetailedSpeechPhrase.ts
+++ b/src/common.speech/ServiceMessages/DetailedSpeechPhrase.ts
@@ -49,25 +49,15 @@ export class DetailedSpeechPhrase implements IDetailedSpeechPhrase {
         this.privDetailedSpeechPhrase.Offset += baseOffset;
 
         if (!!this.privDetailedSpeechPhrase.NBest) {
-            let firstWordOffset: number;
             for (const phrase of this.privDetailedSpeechPhrase.NBest) {
-                if (!!phrase.Words && !!phrase.Words[0]) {
-                    firstWordOffset = phrase.Words[0].Offset;
-                    break;
-                }
-            }
-            if (!!firstWordOffset && firstWordOffset < baseOffset) {
-                const offset: number = baseOffset - firstWordOffset;
-                for (const details of this.privDetailedSpeechPhrase.NBest) {
-                    if (!!details.Words) {
-                        for (const word of details.Words) {
-                            word.Offset += offset;
-                        }
+                if (!!phrase.Words) {
+                    for (const word of phrase.Words) {
+                        word.Offset += baseOffset;
                     }
-                    if (!!details.DisplayWords) {
-                        for (const word of details.DisplayWords) {
-                            word.Offset += offset;
-                        }
+                }
+                if (!!phrase.DisplayWords) {
+                    for (const word of phrase.DisplayWords) {
+                        word.Offset += baseOffset;
                     }
                 }
             }

--- a/src/common.speech/ServiceMessages/DetailedSpeechPhrase.ts
+++ b/src/common.speech/ServiceMessages/DetailedSpeechPhrase.ts
@@ -12,6 +12,7 @@ export interface IDetailedSpeechPhrase {
     PrimaryLanguage?: IPrimaryLanguage;
     DisplayText?: string;
     SpeakerId?: string;
+    [key: string]: any;
 }
 
 export interface IPhrase {
@@ -34,16 +35,19 @@ export interface IWord {
 export class DetailedSpeechPhrase implements IDetailedSpeechPhrase {
     private privDetailedSpeechPhrase: IDetailedSpeechPhrase;
 
-    private constructor(json: string) {
+    private constructor(json: string, baseOffset: number) {
         this.privDetailedSpeechPhrase = JSON.parse(json) as IDetailedSpeechPhrase;
-        this.privDetailedSpeechPhrase.RecognitionStatus = RecognitionStatus[this.privDetailedSpeechPhrase.RecognitionStatus as unknown as keyof typeof RecognitionStatus];
+        this.privDetailedSpeechPhrase.RecognitionStatus = this.mapRecognitionStatus(this.privDetailedSpeechPhrase.RecognitionStatus);
+        this.updateOffsets(baseOffset);
     }
 
-    public static fromJSON(json: string): DetailedSpeechPhrase {
-        return new DetailedSpeechPhrase(json);
+    public static fromJSON(json: string, baseOffset: number): DetailedSpeechPhrase {
+        return new DetailedSpeechPhrase(json, baseOffset);
     }
 
-    public getJsonWithCorrectedOffsets(baseOffset: number): string {
+    private updateOffsets(baseOffset: number): void {
+        this.privDetailedSpeechPhrase.Offset += baseOffset;
+
         if (!!this.privDetailedSpeechPhrase.NBest) {
             let firstWordOffset: number;
             for (const phrase of this.privDetailedSpeechPhrase.NBest) {
@@ -68,7 +72,15 @@ export class DetailedSpeechPhrase implements IDetailedSpeechPhrase {
                 }
             }
         }
-        return JSON.stringify(this.privDetailedSpeechPhrase);
+    }
+
+    public asJson(): string {
+        const jsonObj = { ...this.privDetailedSpeechPhrase };
+        // Convert the enum value to its string representation for serialization purposes.
+        return JSON.stringify({
+            ...jsonObj,
+            RecognitionStatus: RecognitionStatus[jsonObj.RecognitionStatus] as keyof typeof RecognitionStatus
+        });
     }
 
     public get RecognitionStatus(): RecognitionStatus {
@@ -97,5 +109,12 @@ export class DetailedSpeechPhrase implements IDetailedSpeechPhrase {
     }
     public get SpeakerId(): string {
         return this.privDetailedSpeechPhrase.SpeakerId;
+    }
+    private mapRecognitionStatus(status: any): RecognitionStatus {
+        if (typeof status === "string") {
+            return RecognitionStatus[status as keyof typeof RecognitionStatus];
+        } else if (typeof status === "number") {
+            return status;
+        }
     }
 }

--- a/src/common.speech/ServiceMessages/SimpleSpeechPhrase.ts
+++ b/src/common.speech/ServiceMessages/SimpleSpeechPhrase.ts
@@ -11,6 +11,7 @@ export interface ISimpleSpeechPhrase {
     Duration?: number;
     PrimaryLanguage?: IPrimaryLanguage;
     SpeakerId?: string;
+    [key: string]: any;
 }
 
 export interface IPrimaryLanguage {
@@ -21,13 +22,27 @@ export interface IPrimaryLanguage {
 export class SimpleSpeechPhrase implements ISimpleSpeechPhrase {
     private privSimpleSpeechPhrase: ISimpleSpeechPhrase;
 
-    private constructor(json: string) {
+    private constructor(json: string, baseOffset: number = 0) {
         this.privSimpleSpeechPhrase = JSON.parse(json) as ISimpleSpeechPhrase;
-        this.privSimpleSpeechPhrase.RecognitionStatus = RecognitionStatus[this.privSimpleSpeechPhrase.RecognitionStatus as unknown as keyof typeof RecognitionStatus];
+        this.privSimpleSpeechPhrase.RecognitionStatus = this.mapRecognitionStatus(this.privSimpleSpeechPhrase.RecognitionStatus); // RecognitionStatus[this.privSimpleSpeechPhrase.RecognitionStatus as unknown as keyof typeof RecognitionStatus];
+        this.updateOffset(baseOffset);
     }
 
-    public static fromJSON(json: string): SimpleSpeechPhrase {
-        return new SimpleSpeechPhrase(json);
+    public static fromJSON(json: string, baseOffset: number): SimpleSpeechPhrase {
+        return new SimpleSpeechPhrase(json, baseOffset);
+    }
+
+    private updateOffset(baseOffset: number): void {
+        this.privSimpleSpeechPhrase.Offset += baseOffset;
+    }
+
+    public asJson(): string {
+        const jsonObj = { ...this.privSimpleSpeechPhrase };
+        // Convert the enum value to its string representation for serialization purposes.
+        return JSON.stringify({
+            ...jsonObj,
+            RecognitionStatus: RecognitionStatus[jsonObj.RecognitionStatus] as keyof typeof RecognitionStatus
+        });
     }
 
     public get RecognitionStatus(): RecognitionStatus {
@@ -56,5 +71,13 @@ export class SimpleSpeechPhrase implements ISimpleSpeechPhrase {
 
     public get SpeakerId(): string {
         return this.privSimpleSpeechPhrase.SpeakerId;
+    }
+
+    private mapRecognitionStatus(status: any): RecognitionStatus {
+        if (typeof status === "string") {
+            return RecognitionStatus[status as keyof typeof RecognitionStatus];
+        } else if (typeof status === "number") {
+            return status;
+        }
     }
 }

--- a/src/common.speech/ServiceMessages/SpeechDetected.ts
+++ b/src/common.speech/ServiceMessages/SpeechDetected.ts
@@ -9,12 +9,13 @@ export interface ISpeechDetected {
 export class SpeechDetected implements ISpeechDetected {
     private privSpeechStartDetected: ISpeechDetected;
 
-    private constructor(json: string) {
+    private constructor(json: string, baseOffset: number) {
         this.privSpeechStartDetected = JSON.parse(json) as ISpeechDetected;
+        this.privSpeechStartDetected.Offset += baseOffset;
     }
 
-    public static fromJSON(json: string): SpeechDetected {
-        return new SpeechDetected(json);
+    public static fromJSON(json: string, baseOffset: number): SpeechDetected {
+        return new SpeechDetected(json, baseOffset);
     }
 
     public get Offset(): number {

--- a/src/common.speech/ServiceMessages/SpeechHypothesis.ts
+++ b/src/common.speech/ServiceMessages/SpeechHypothesis.ts
@@ -10,17 +10,27 @@ export interface ISpeechHypothesis {
     Duration: number;
     PrimaryLanguage?: IPrimaryLanguage;
     SpeakerId?: string;
+    [key: string]: any;
 }
 
 export class SpeechHypothesis implements ISpeechHypothesis {
     private privSpeechHypothesis: ISpeechHypothesis;
 
-    private constructor(json: string) {
+    private constructor(json: string, baseOffset: number) {
         this.privSpeechHypothesis = JSON.parse(json) as ISpeechHypothesis;
+        this.updateOffset(baseOffset);
     }
 
-    public static fromJSON(json: string): SpeechHypothesis {
-        return new SpeechHypothesis(json);
+    public static fromJSON(json: string, baseOffset: number): SpeechHypothesis {
+        return new SpeechHypothesis(json, baseOffset);
+    }
+
+    private updateOffset(baseOffset: number): void {
+        this.privSpeechHypothesis.Offset += baseOffset;
+    }
+
+    public asJson(): string {
+        return JSON.stringify(this.privSpeechHypothesis);
     }
 
     public get Text(): string {

--- a/src/common.speech/ServiceMessages/SpeechKeyword.ts
+++ b/src/common.speech/ServiceMessages/SpeechKeyword.ts
@@ -7,17 +7,19 @@ export interface ISpeechKeyword {
     Text: string;
     Offset: number;
     Duration: number;
+    [key: string]: any;
 }
 
 export class SpeechKeyword implements ISpeechKeyword {
     private privSpeechKeyword: ISpeechKeyword;
 
-    private constructor(json: string) {
+    private constructor(json: string, baseOffset: number) {
         this.privSpeechKeyword = JSON.parse(json) as ISpeechKeyword;
+        this.privSpeechKeyword.Offset += baseOffset;
     }
 
-    public static fromJSON(json: string): SpeechKeyword {
-        return new SpeechKeyword(json);
+    public static fromJSON(json: string, baseOffset: number): SpeechKeyword {
+        return new SpeechKeyword(json, baseOffset);
     }
 
     public get Status(): string {
@@ -34,5 +36,9 @@ export class SpeechKeyword implements ISpeechKeyword {
 
     public get Duration(): number {
         return this.privSpeechKeyword.Duration;
+    }
+
+    public asJson(): string {
+        return JSON.stringify(this.privSpeechKeyword);
     }
 }

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -608,7 +608,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                         break;
 
                     case "speech.startdetected":
-                        const speechStartDetected: SpeechDetected = SpeechDetected.fromJSON(connectionMessage.textBody);
+                        const speechStartDetected: SpeechDetected = SpeechDetected.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
                         const speechStartEventArgs = new RecognitionEventArgs(speechStartDetected.Offset, this.privRequestSession.sessionId);
                         if (!!this.privRecognizer.speechStartDetected) {
                             this.privRecognizer.speechStartDetected(this.privRecognizer, speechStartEventArgs);
@@ -623,7 +623,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                             // If the request was empty, the JSON returned is empty.
                             json = "{ Offset: 0 }";
                         }
-                        const speechStopDetected: SpeechDetected = SpeechDetected.fromJSON(json);
+                        const speechStopDetected: SpeechDetected = SpeechDetected.fromJSON(json, this.privRequestSession.currentTurnAudioOffset);
                         const speechStopEventArgs = new RecognitionEventArgs(speechStopDetected.Offset + this.privRequestSession.currentTurnAudioOffset, this.privRequestSession.sessionId);
                         if (!!this.privRecognizer.speechEndDetected) {
                             this.privRecognizer.speechEndDetected(this.privRecognizer, speechStopEventArgs);

--- a/src/common.speech/SpeechServiceRecognizer.ts
+++ b/src/common.speech/SpeechServiceRecognizer.ts
@@ -125,6 +125,7 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                             resultProps);
                     } else {
                         const detailed: DetailedSpeechPhrase = DetailedSpeechPhrase.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
+                        resultProps.setProperty(PropertyId.SpeechServiceResponse_JsonResult, detailed.asJson());
 
                         result = new SpeechRecognitionResult(
                             this.privRequestSession.requestId,

--- a/src/sdk/CancellationDetails.ts
+++ b/src/sdk/CancellationDetails.ts
@@ -33,7 +33,7 @@ export class CancellationDetails extends CancellationDetailsBase {
         let errorCode: CancellationErrorCode = CancellationErrorCode.NoError;
 
         if (result instanceof RecognitionResult && !!result.json) {
-            const simpleSpeech: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(result.json);
+            const simpleSpeech: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(result.json, 0); // Offset fixups are already done.
             reason = EnumTranslation.implTranslateCancelResult(simpleSpeech.RecognitionStatus);
         }
 

--- a/src/sdk/NoMatchDetails.ts
+++ b/src/sdk/NoMatchDetails.ts
@@ -30,7 +30,7 @@ export class NoMatchDetails {
      * @returns {NoMatchDetails} The no match details object being created.
      */
     public static fromResult(result: SpeechRecognitionResult | IntentRecognitionResult | TranslationRecognitionResult): NoMatchDetails {
-        const simpleSpeech: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(result.json);
+        const simpleSpeech: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(result.json, 0); // Offset fixups are already done.
 
         let reason: NoMatchReason = NoMatchReason.NotRecognized;
 
@@ -45,7 +45,6 @@ export class NoMatchDetails {
                 reason = NoMatchReason.NotRecognized;
                 break;
         }
-
         return new NoMatchDetails(reason);
     }
 

--- a/src/sdk/SpeechConfig.ts
+++ b/src/sdk/SpeechConfig.ts
@@ -498,6 +498,7 @@ export class SpeechConfigImpl extends SpeechConfig {
     }
     public requestWordLevelTimestamps(): void {
         this.privProperties.setProperty(PropertyId.SpeechServiceResponse_RequestWordLevelTimestamps, "true");
+        this.privProperties.setProperty(OutputFormatPropertyName, OutputFormat[OutputFormat.Detailed]);
     }
     public enableDictation(): void {
         this.privProperties.setProperty(ForceDictationPropertyName, "true");

--- a/tests/SpeechRecoReconnectTests.ts
+++ b/tests/SpeechRecoReconnectTests.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-import * as sdk from "../../microsoft.cognitiveservices.speech.sdk";
-import { ConsoleLoggingListener } from "../../src/common.browser/Exports";
-import { Events } from "../../src/common/Exports";
+import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
+import { ConsoleLoggingListener } from "../src/common.browser/Exports";
+import { SimpleSpeechPhrase } from "../src/common.speech/Exports";
+import { Events } from "../src/common/Exports";
 
-import { Settings } from "../Settings";
-import { WaveFileAudioInput } from "../WaveFileAudioInputStream";
+import { Settings } from "./Settings";
+import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
-import { WaitForCondition } from "../Utilities";
+import { WaitForCondition } from "./Utilities";
 
 
 let objsToClose: any[];
@@ -46,9 +47,15 @@ const BuildSpeechConfig: () => sdk.SpeechConfig = (): sdk.SpeechConfig => {
         s.setProperty(sdk.PropertyId.SpeechServiceConnection_Region, Settings.SpeechRegion);
     }
 
+    if (undefined !== Settings.proxyServer) {
+        s.setProxy(Settings.proxyServer, Settings.proxyPort);
+    }
+
     expect(s).not.toBeUndefined();
     return s;
 };
+
+jest.retryTimes(Settings.RetryCount);
 
 // Tests client reconnect after speech timeouts.
 test("Reconnect After timeout", (done: jest.DoneCallback): void => {
@@ -60,36 +67,17 @@ test("Reconnect After timeout", (done: jest.DoneCallback): void => {
 
     const alternatePhraseFileBuffer: ArrayBuffer = WaveFileAudioInput.LoadArrayFromFile(Settings.LuisWaveFile);
 
-    let s: sdk.SpeechConfig;
-    if (undefined === Settings.SpeechTimeoutEndpoint || undefined === Settings.SpeechTimeoutKey) {
-        if (!Settings.ExecuteLongRunningTestsBool) {
-            // eslint-disable-next-line no-console
-            console.info("Skipping test.");
-            done();
-            return;
-        }
-
-        // eslint-disable-next-line no-console
-        console.warn("Running timeout test against production, this will be very slow...");
-        s = BuildSpeechConfig();
-    } else {
-        s = sdk.SpeechConfig.fromEndpoint(new URL(Settings.SpeechTimeoutEndpoint), Settings.SpeechTimeoutKey);
-        s.setServiceProperty("maxConnectionDurationSecs", "30", sdk.ServicePropertyChannel.UriQueryParameter);
-    }
-
+    const s: sdk.SpeechConfig = BuildSpeechConfig();
     objsToClose.push(s);
-
-    if (Settings.proxyServer !== undefined && Settings.proxyPort !== undefined) {
-        s.setProxy(Settings.proxyServer, Settings.proxyPort);
-    }
+    s.setServiceProperty("maxConnectionDurationSecs", "30", sdk.ServicePropertyChannel.UriQueryParameter);
 
     let pumpSilence: boolean = false;
     let sendAlternateFile: boolean = false;
 
     let bytesSent: number = 0;
-    const targetLoops: number = 500;
+    const maxRecognitions: number = 500;
 
-    // Pump the audio from the wave file specified with 1 second silence between iterations indefinetly.
+    // Pump the audio from the wave file specified with 1 second silence between iterations indefinitely.
     const p = sdk.AudioInputStream.createPullStream(
         {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -118,10 +106,8 @@ test("Reconnect After timeout", (done: jest.DoneCallback): void => {
                         pumpSilence = true;
                         sendAlternateFile = !sendAlternateFile;
                     }
-
                     return readyToSend;
                 }
-
             },
         });
 
@@ -136,26 +122,50 @@ test("Reconnect After timeout", (done: jest.DoneCallback): void => {
     let connections: number = 0;
     let disconnects: number = 0;
     let postDisconnectReco: boolean = false;
+    let cancelled: boolean = false;
 
     const tenMinutesHns: number = 10 * 60 * 1000 * 10000;
 
     const connection: sdk.Connection = sdk.Connection.fromRecognizer(r);
 
+    r.recognizing = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
+        try {
+            // Log the offset
+            expect(sdk.ResultReason[e.result.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizingSpeech]);
+            expect(e.offset).toBeGreaterThanOrEqual(lastOffset);
+
+            let simpleResult: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult), 0);
+            expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
+            simpleResult = SimpleSpeechPhrase.fromJSON(e.result.json, 0);
+            expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+        } catch (error) {
+            done(error as string);
+        }
+    };
+
     r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
         try {
             // If the target number of loops has been seen already, don't check as the audio being sent could have been clipped randomly during a phrase,
             // and failing because of that isn't warranted.
-            if (recogCount <= targetLoops && !postDisconnectReco) {
+            if (recogCount <= maxRecognitions && !postDisconnectReco) {
 
                 expect(sdk.ResultReason[e.result.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                 expect(e.offset).toBeGreaterThanOrEqual(lastOffset);
+
+                let simpleResult: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult), 0);
+                expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
+                simpleResult = SimpleSpeechPhrase.fromJSON(e.result.json, 0);
+                expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
                 lastOffset = e.offset;
 
                 // If there is silence exactly at the moment of disconnect, an extra speech.phrase with text ="" is returned just before the
                 // connection is disconnected.
                 const modTen: number = e.result.offset % tenMinutesHns;
 
-                // If withing 100ms of an even 10 min, ignore text issues. The Speech Service is forceably ending turns at 10 minute intervals.
+                // If withing 100ms of an even 10 min, ignore text issues. The Speech Service is forcedly ending turns at 10 minute intervals.
                 if ("" !== e.result.text || modTen < 100 * 10000 || modTen > (tenMinutesHns - (100 * 10000))) {
                     if (alternatePhrase) {
                         expect(e.result.text).toEqual(Settings.LuisWavFileText);
@@ -170,7 +180,7 @@ test("Reconnect After timeout", (done: jest.DoneCallback): void => {
                     postDisconnectReco = true;
                 }
 
-                if (recogCount++ >= targetLoops) {
+                if (recogCount++ >= maxRecognitions) {
                     p.close();
                 }
             }
@@ -183,6 +193,7 @@ test("Reconnect After timeout", (done: jest.DoneCallback): void => {
         try {
             expect(e.errorDetails).toBeUndefined();
             expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.EndOfStream]);
+            cancelled = true;
         } catch (error) {
             done(error as string);
         }
@@ -197,7 +208,7 @@ test("Reconnect After timeout", (done: jest.DoneCallback): void => {
     };
 
     r.startContinuousRecognitionAsync((): void => {
-        WaitForCondition((): boolean => (!!postDisconnectReco), (): void => {
+        WaitForCondition((): boolean => (!!postDisconnectReco || !!cancelled), (): void => {
             r.stopContinuousRecognitionAsync((): void => {
                 try {
                     expect(connections).toEqual(2);
@@ -214,4 +225,4 @@ test("Reconnect After timeout", (done: jest.DoneCallback): void => {
         (err: string): void => {
             done(err);
         });
-}, 1000 * 60 * 35);
+}, 1000 * 60 * 2);

--- a/tests/SpeechRecognizerSilenceTests.ts
+++ b/tests/SpeechRecognizerSilenceTests.ts
@@ -3,14 +3,10 @@
 
 import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
 import { ConsoleLoggingListener, WebsocketMessageAdapter } from "../src/common.browser/Exports";
-import { ServiceRecognizerBase } from "../src/common.speech/Exports";
-import { HeaderNames } from "../src/common.speech/HeaderNames";
-import { QueryParameterNames } from "../src/common.speech/QueryParameterNames";
-import { ConnectionStartEvent, IDetachable } from "../src/common/Exports";
-import { Events, EventType, PlatformEvent } from "../src/common/Exports";
+import { SimpleSpeechPhrase } from "../src/common.speech/Exports";
+import { Events } from "../src/common/Exports";
 
 import { Settings } from "./Settings";
-import { validateTelemetry } from "./TelemetryUtil";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
 import * as fs from "fs";
@@ -29,13 +25,13 @@ const Canceled: string = "Canceled";
 
 let objsToClose: any[];
 
-beforeAll(() => {
+beforeAll((): void => {
     // override inputs, if necessary
     Settings.LoadSettings();
     Events.instance.attachListener(new ConsoleLoggingListener(sdk.LogLevel.Debug));
 });
 
-beforeEach(() => {
+beforeEach((): void => {
     objsToClose = [];
     // eslint-disable-next-line no-console
     console.info("------------------Starting test case: " + expect.getState().currentTestName + "-------------------------");
@@ -90,18 +86,18 @@ const BuildSpeechConfig: () => sdk.SpeechConfig = (): sdk.SpeechConfig => {
     return s;
 };
 
-describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
+describe.each([true])("Service based tests", (forceNodeWebSocket: boolean): void => {
 
-    beforeAll(() => {
+    beforeAll((): void => {
         WebsocketMessageAdapter.forceNpmWebSocket = forceNodeWebSocket;
     });
 
-    afterAll(() => {
+    afterAll((): void => {
         WebsocketMessageAdapter.forceNpmWebSocket = false;
     });
 
-    describe("Intiial Silence Tests", () => {
-        test("InitialSilenceTimeout (pull)", (done: jest.DoneCallback) => {
+    describe("Intiial Silence Tests", (): void => {
+        test("InitialSilenceTimeout (pull)", (done: jest.DoneCallback): void => {
             // eslint-disable-next-line no-console
             console.info("Name: InitialSilenceTimeout (pull)");
             let p: sdk.PullAudioInputStream;
@@ -113,7 +109,8 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
             p = sdk.AudioInputStream.createPullStream(
                 {
-                    close: () => { return; },
+                    // eslint-disable-next-line @typescript-eslint/no-empty-function
+                    close: (): void => { },
                     read: (buffer: ArrayBuffer): number => {
                         bytesSent += buffer.byteLength;
                         return buffer.byteLength;
@@ -132,7 +129,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             });
         }, 15000);
 
-        test("InitialSilenceTimeout (push)", (done: jest.DoneCallback) => {
+        test("InitialSilenceTimeout (push)", (done: jest.DoneCallback): void => {
             // eslint-disable-next-line no-console
             console.info("Name: InitialSilenceTimeout (push)");
             const p: sdk.PushAudioInputStream = sdk.AudioInputStream.createPushStream();
@@ -145,7 +142,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             testInitialSilenceTimeout(config, done);
         }, 15000);
 
-        Settings.testIfDOMCondition("InitialSilenceTimeout (File)", (done: jest.DoneCallback) => {
+        Settings.testIfDOMCondition("InitialSilenceTimeout (File)", (done: jest.DoneCallback): void => {
             // eslint-disable-next-line no-console
             console.info("Name: InitialSilenceTimeout (File)");
             const audioFormat: AudioStreamFormatImpl = sdk.AudioStreamFormat.getDefaultInputFormat() as AudioStreamFormatImpl;
@@ -171,15 +168,15 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
             let numReports: number = 0;
 
-            r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+            r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
                 done(e.errorDetails);
             };
 
-            r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
+            r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
                 try {
                     const res: sdk.SpeechRecognitionResult = e.result;
                     expect(res).not.toBeUndefined();
-                    expect(sdk.ResultReason.NoMatch).toEqual(res.reason);
+                    expect(sdk.ResultReason[sdk.ResultReason.NoMatch]).toEqual(sdk.ResultReason[res.reason]);
                     expect(res.text).toBeUndefined();
                     expect(res.properties).not.toBeUndefined();
                     expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
@@ -195,7 +192,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             };
 
             r.recognizeOnceAsync(
-                (p2: sdk.SpeechRecognitionResult) => {
+                (p2: sdk.SpeechRecognitionResult): void => {
                     try {
                         const res: sdk.SpeechRecognitionResult = p2;
                         numReports++;
@@ -213,11 +210,11 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                         done(error);
                     }
                 },
-                (error: string) => {
+                (error: string): void => {
                     fail(error);
                 });
 
-            WaitForCondition(() => (numReports === 2), () => {
+            WaitForCondition((): boolean => (numReports === 2), (): void => {
                 try {
                     if (!!addedChecks) {
                         addedChecks();
@@ -229,7 +226,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             });
         };
 
-        test.skip("InitialBabbleTimeout", (done: jest.DoneCallback) => {
+        test.skip("InitialBabbleTimeout", (done: jest.DoneCallback): void => {
             // eslint-disable-next-line no-console
             console.info("Name: InitialBabbleTimeout");
 
@@ -253,7 +250,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             };
 
             r.recognizeOnceAsync(
-                (p2: sdk.SpeechRecognitionResult) => {
+                (p2: sdk.SpeechRecognitionResult): void => {
                     try {
                         const res: sdk.SpeechRecognitionResult = p2;
                         expect(res).not.toBeUndefined();
@@ -267,7 +264,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                         done(error);
                     }
                 },
-                (error: string) => {
+                (error: string): void => {
                     r.close();
                     s.close();
                     done(error);
@@ -275,7 +272,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         });
     });
 
-    test("burst of silence", (done: jest.DoneCallback) => {
+    test("burst of silence", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: burst of silence");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -294,7 +291,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         expect(r).not.toBeUndefined();
         expect(r instanceof sdk.Recognizer);
 
-        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
             try {
                 expect(e.errorDetails).toBeUndefined();
                 expect(sdk.CancellationErrorCode[e.errorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.NoError]);
@@ -304,7 +301,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             }
         };
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 try {
                     const res: sdk.SpeechRecognitionResult = p2;
 
@@ -320,28 +317,22 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 
-    // For review: v2 endpoint does not appear to be setting a default
-    // initial silence timeout of < 70s, disabling until clarification received
-    // from service team
-    test.skip("InitialSilenceTimeout Continuous", (done: jest.DoneCallback) => {
+    test("InitialSilenceTimeout Continuous", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: InitialSilenceTimeout Continuous");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
         objsToClose.push(s);
 
-        let p: sdk.PullAudioInputStream;
-
-        p = sdk.AudioInputStream.createPullStream(
+        const p: sdk.PullAudioInputStream = sdk.AudioInputStream.createPullStream(
             {
-                close: () => { return; },
-                read: (buffer: ArrayBuffer): number => {
-                    return buffer.byteLength;
-                },
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                close: (): void => { },
+                read: (buffer: ArrayBuffer): number => buffer.byteLength,
             });
 
         const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
@@ -351,7 +342,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         expect(r).not.toBeUndefined();
         expect(r instanceof sdk.Recognizer);
 
-        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
             // Since the pull stream above will always return an empty array, there should be
             // no other reason besides an error for cancel to hit.
             done(e.errorDetails);
@@ -359,37 +350,37 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         let passed: boolean = false;
 
-        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
-
+        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
+            try{
+                console.warn(e.result);
             const res: sdk.SpeechRecognitionResult = e.result;
             expect(res).not.toBeUndefined();
             expect(sdk.ResultReason.NoMatch).toEqual(res.reason);
-            expect(res.text).toBeUndefined();
+            expect(res.text).toEqual("");
 
             const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
             expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
             passed = true;
+            } catch (error) {
+                done(error);
+            }
         };
 
-        /* tslint:disable:no-empty */
-        r.startContinuousRecognitionAsync(() => {
-        },
-            (error: string) => {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        r.startContinuousRecognitionAsync((): void => { },
+            (error: string): void => {
                 done(error);
             });
 
-        WaitForCondition(() => passed, () => {
-            r.stopContinuousRecognitionAsync(() => {
+        WaitForCondition((): boolean => passed, (): void => {
+            r.stopContinuousRecognitionAsync((): void => {
                 done();
-            }, (error: string) => done(error));
+            }, (error: string): void => done(error));
         });
 
     }, 30000);
 
-    // For review: v2 endpoint does not appear to be sending a NoMatch result
-    // on end silence timeout, instead sends a Recognized result with empty text
-    // disabling until clarification received from service team
-    test.skip("Silence After Speech", (done: jest.DoneCallback) => {
+    test("Silence After Speech", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Silence After Speech");
         // Pump valid speech and then silence until at least one speech end cycle hits.
@@ -411,8 +402,9 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         let speechEnded: number = 0;
         let canceled: boolean = false;
         let inTurn: boolean = false;
+        let lastOffset: number = 0;
 
-        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
+        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
             try {
                 if (e.result.reason === sdk.ResultReason.RecognizedSpeech) {
                     expect(speechRecognized).toEqual(false);
@@ -423,6 +415,16 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     expect(speechRecognized).toEqual(true);
                     noMatchCount++;
                 }
+                expect(e.result.offset).toBeGreaterThanOrEqual(lastOffset);
+
+                let simpleResult: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult), 0);
+                expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
+                simpleResult = SimpleSpeechPhrase.fromJSON(e.result.json, 0);
+                expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
+                lastOffset = e.result.offset;
+
             } catch (error) {
                 done(error);
             }
@@ -450,9 +452,9 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             speechEnded++;
         };
 
-        r.startContinuousRecognitionAsync(() => {
-            WaitForCondition(() => (canceled && !inTurn), () => {
-                r.stopContinuousRecognitionAsync(() => {
+        r.startContinuousRecognitionAsync((): void => {
+            WaitForCondition(():boolean => (canceled && !inTurn), (): void => {
+                r.stopContinuousRecognitionAsync((): void => {
                     try {
                         expect(speechEnded).toEqual(noMatchCount);
                         expect(noMatchCount).toBeGreaterThanOrEqual(2);
@@ -460,20 +462,17 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     } catch (error) {
                         done(error);
                     }
-                }, (error: string) => {
+                }, (error: string): void => {
                     done(error);
                 });
             });
         },
-            (err: string) => {
+            (err: string): void => {
                 done(err);
             });
     }, 30000);
 
-    // For review: v2 endpoint does not appear to be setting a default
-    // initial silence timeout of < 70s, disabling until clarification received
-    // from service team
-    test.skip("Silence Then Speech", (done: jest.DoneCallback) => {
+    test("Silence Then Speech", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Silence Then Speech");
         // Pump valid speech and then silence until at least one speech end cycle hits.
@@ -496,7 +495,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         let canceled: boolean = false;
         let inTurn: boolean = false;
 
-        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
+        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
             try {
                 if (e.result.reason === sdk.ResultReason.RecognizedSpeech) {
                     expect(speechRecognized).toEqual(false);
@@ -535,9 +534,9 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             speechEnded++;
         };
 
-        r.startContinuousRecognitionAsync(() => {
-            WaitForCondition(() => (canceled && !inTurn), () => {
-                r.stopContinuousRecognitionAsync(() => {
+        r.startContinuousRecognitionAsync((): void => {
+            WaitForCondition((): boolean => (canceled && !inTurn), (): void => {
+                r.stopContinuousRecognitionAsync((): void => {
                     try {
                         expect(speechEnded).toEqual(noMatchCount + 1);
                         expect(noMatchCount).toEqual(2);
@@ -545,12 +544,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     } catch (error) {
                         done(error);
                     }
-                }, (error: string) => {
+                }, (error: string): void => {
                     done(error);
                 });
             });
         },
-            (err: string) => {
+            (err: string): void => {
                 done(err);
             });
     }, 35000);

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -2443,7 +2443,7 @@ describe("PhraseList tests", (): void => {
         });
     }, 20000);
 
-    describe.only.each([sdk.OutputFormat.Simple, sdk.OutputFormat.Detailed])("Output Format", (outputFormat: sdk.OutputFormat): void => {
+    describe.each([sdk.OutputFormat.Simple, sdk.OutputFormat.Detailed])("Output Format", (outputFormat: sdk.OutputFormat): void => {
         test("Multi-Turn offset verification", (done: jest.DoneCallback): void => {
             // eslint-disable-next-line no-console
             console.info("Multi-Turn offset verification");

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -29,28 +29,24 @@
 //
 /* eslint-disable no-console */
 
+import * as fs from "fs";
+import { setTimeout } from "timers";
+import bent, { BentResponse } from "bent";
+
 import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
 import { ConsoleLoggingListener, WebsocketMessageAdapter } from "../src/common.browser/Exports";
-import { DetailedSpeechPhrase, ServiceRecognizerBase } from "../src/common.speech/Exports";
+import { ServiceRecognizerBase, SimpleSpeechPhrase } from "../src/common.speech/Exports";
 import { HeaderNames } from "../src/common.speech/HeaderNames";
 import { QueryParameterNames } from "../src/common.speech/QueryParameterNames";
 import { ConnectionStartEvent, createNoDashGuid, IDetachable } from "../src/common/Exports";
-import { Events, EventType, PlatformEvent } from "../src/common/Exports";
+import { Events, PlatformEvent } from "../src/common/Exports";
 
 import { Settings } from "./Settings";
 import { validateTelemetry } from "./TelemetryUtil";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
 
-import * as fs from "fs";
-import bent, { BentResponse } from "bent";
-
-import { setTimeout } from "timers";
 import { ByteBufferAudioFile } from "./ByteBufferAudioFile";
 import { closeAsyncObjects, RepeatingPullStream, WaitForCondition } from "./Utilities";
-
-import { AudioStreamFormatImpl } from "../src/sdk/Audio/AudioStreamFormat";
-import { Console } from "console";
-import { PullAudioInputStream } from "../microsoft.cognitiveservices.speech.sdk";
 
 const FIRST_EVENT_ID: number = 1;
 const Recognizing: string = "Recognizing";
@@ -60,13 +56,13 @@ const Canceled: string = "Canceled";
 let objsToClose: any[];
 
 
-beforeAll(() => {
+beforeAll((): void => {
     // override inputs, if necessary
     Settings.LoadSettings();
     Events.instance.attachListener(new ConsoleLoggingListener(sdk.LogLevel.Debug));
 });
 
-beforeEach(() => {
+beforeEach((): void => {
     objsToClose = [];
     // eslint-disable-next-line no-console
     console.info("------------------Starting test case: " + expect.getState().currentTestName + "-------------------------");
@@ -122,7 +118,7 @@ const BuildSpeechConfig: () => sdk.SpeechConfig = (): sdk.SpeechConfig => {
 };
 
 /*
-test("speech.event from service", (done: jest.DoneCallback) => {
+test("speech.event from service", (done: jest.DoneCallback): void => {
     // eslint-disable-next-line no-console
     console.info("Name: speech.event from service");
 
@@ -192,12 +188,12 @@ test("speech.event from service", (done: jest.DoneCallback) => {
 
     r.startContinuousRecognitionAsync(
         undefined,
-        (error: string) => {
+        (error: string): void => {
             done(error);
         });
 
-    WaitForCondition(() => (sessionDone), () => {
-        r.stopContinuousRecognitionAsync(() => {
+    WaitForCondition((): boolean => (sessionDone), (): void => {
+        r.stopContinuousRecognitionAsync((): void => {
            expect(receivedSpeechEvent).toEqual(true);
            done();
         });
@@ -205,21 +201,8 @@ test("speech.event from service", (done: jest.DoneCallback) => {
 
 }, 200000);
 */
-test("testDetailedSpeechPhrase1", (done: jest.DoneCallback) => {
-    // eslint-disable-next-line no-console
-    console.info("Name: testDetailedSpeechPhrase1");
-    try {
-        const testJsonString: string = `{"Id":"1234","RecognitionStatus":"Success","Offset":1,"Duration":4000000,"DisplayText":"This","NBest":[{"Confidence":0.9,"Lexical":"this","ITN":"this","MaskedITN":"this","Display":"This.","Words":[{"Word":"this","Offset":2,"Duration":4000000}]},{"Confidence":0.0,"Lexical":"","ITN":"","MaskedITN":"","Display":""}]}`;
-        const detailed: DetailedSpeechPhrase = DetailedSpeechPhrase.fromJSON(testJsonString);
-        const offsetCorrectedJson: string = detailed.getJsonWithCorrectedOffsets(3);
-        expect(offsetCorrectedJson).not.toBeUndefined();
-        done();
-    } catch (err) {
-        done(err);
-    }
-});
 
-test("testSpeechRecognizer1", () => {
+test("testSpeechRecognizer1", (): void => {
     // eslint-disable-next-line no-console
     console.info("Name: testSpeechRecognizer1");
     const speechConfig: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
@@ -235,7 +218,7 @@ test("testSpeechRecognizer1", () => {
     expect(r instanceof sdk.Recognizer);
 });
 
-test("testGetLanguage1", () => {
+test("testGetLanguage1", (): void => {
     // eslint-disable-next-line no-console
     console.info("Name: testGetLanguage1");
     const r: sdk.SpeechRecognizer = BuildRecognizerFromWaveFile();
@@ -244,7 +227,7 @@ test("testGetLanguage1", () => {
     expect(r.speechRecognitionLanguage).not.toBeNull();
 });
 
-test("testGetLanguage2", () => {
+test("testGetLanguage2", (): void => {
     // eslint-disable-next-line no-console
     console.info("Name: testGetLanguage2");
     const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -260,7 +243,7 @@ test("testGetLanguage2", () => {
     expect(language === r.speechRecognitionLanguage);
 });
 
-test("testGetOutputFormatDefault", () => {
+test("testGetOutputFormatDefault", (): void => {
     // eslint-disable-next-line no-console
     console.info("Name: testGetOutputFormatDefault");
     const r: sdk.SpeechRecognizer = BuildRecognizerFromWaveFile();
@@ -269,7 +252,7 @@ test("testGetOutputFormatDefault", () => {
     expect(r.outputFormat === sdk.OutputFormat.Simple);
 });
 
-test("testGetParameters", () => {
+test("testGetParameters", (): void => {
     // eslint-disable-next-line no-console
     console.info("Name: testGetParameters");
     const r: sdk.SpeechRecognizer = BuildRecognizerFromWaveFile();
@@ -282,7 +265,7 @@ test("testGetParameters", () => {
     expect(r.endpointId === r.properties.getProperty(sdk.PropertyId.SpeechServiceConnection_EndpointId, null)); // todo: is this really the correct mapping?
 });
 
-test("BadWavFileProducesError", (done: jest.DoneCallback) => {
+test("BadWavFileProducesError", (done: jest.DoneCallback): void => {
     // eslint-disable-next-line no-console
     console.info("Name: BadWavFileProducesError");
     const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -300,9 +283,8 @@ test("BadWavFileProducesError", (done: jest.DoneCallback) => {
 
     const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s, config);
 
-    /* tslint:disable:no-empty */
-    r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
-    }, (error: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    r.recognizeOnceAsync((): void => { }, (error: string): void => {
         try {
             expect(error).not.toBeUndefined();
             done();
@@ -312,17 +294,17 @@ test("BadWavFileProducesError", (done: jest.DoneCallback) => {
     });
 }, 15000);
 
-describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
+describe.each([true])("Service based tests", (forceNodeWebSocket: boolean): void => {
 
-    beforeAll(() => {
+    beforeAll((): void => {
         WebsocketMessageAdapter.forceNpmWebSocket = forceNodeWebSocket;
     });
 
-    afterAll(() => {
+    afterAll((): void => {
         WebsocketMessageAdapter.forceNpmWebSocket = false;
     });
 
-    test("44Khz Wave File", (done: jest.DoneCallback) => {
+    test("44Khz Wave File", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: 44Khz Wave File");
 
@@ -344,7 +326,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             }
         };
 
-        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult): void => {
             try {
                 expect(result).not.toBeUndefined();
                 expect(result.errorDetails).toBeUndefined();
@@ -356,12 +338,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             } catch (error) {
                 done(error);
             }
-        }, (error: string) => {
+        }, (error: string): void => {
             done(error);
         });
     });
 
-    test("testGetOutputFormatDetailed", (done: jest.DoneCallback) => {
+    test("testGetOutputFormatDetailed", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testGetOutputFormatDetailed");
 
@@ -383,7 +365,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             }
         };
 
-        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult): void => {
             try {
                 expect(result).not.toBeUndefined();
                 expect(result.errorDetails).toBeUndefined();
@@ -395,12 +377,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             } catch (error) {
                 done(error);
             }
-        }, (error: string) => {
+        }, (error: string): void => {
             done(error);
         });
     });
 
-    test("testGetOutputFormatDetailed with authorization token", (done: jest.DoneCallback) => {
+    test("testGetOutputFormatDetailed with authorization token", (done: jest.DoneCallback): void => {
         console.info("Name: testGetOutputFormatDetailed");
 
         const url = `https://${Settings.SpeechRegion}.api.cognitive.microsoft.com/`;
@@ -453,7 +435,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                 }
             };
 
-            r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
+            r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult): void => {
                 try {
                     expect(result).not.toBeUndefined();
                     expect(result.text).toEqual(Settings.WaveFileText);
@@ -464,13 +446,13 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                 } catch (error) {
                     done(error);
                 }
-            }, (error: string) => {
+            }, (error: string): void => {
                 done(error);
             });
         });
     }, 20000);
 
-    test("fromEndPoint with Subscription key", (done: jest.DoneCallback) => {
+    test("fromEndPoint with Subscription key", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: fromEndPoint with Subscription key");
 
@@ -495,7 +477,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             }
         };
 
-        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult): void => {
             try {
                 expect(result).not.toBeUndefined();
                 expect(result.text).toEqual(Settings.WaveFileText);
@@ -506,18 +488,18 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             } catch (error) {
                 done(error);
             }
-        }, (error: string) => {
+        }, (error: string): void => {
             done(error);
         });
     });
 
-    describe("Counts Telemetry", () => {
-        afterAll(() => {
+    describe("Counts Telemetry", (): void => {
+        afterAll((): void => {
             ServiceRecognizerBase.telemetryData = undefined;
         });
 
         // counts telemetry failing - investigate
-        test.skip("RecognizeOnce", (done: jest.DoneCallback) => {
+        test.skip("RecognizeOnce", (done: jest.DoneCallback): void => {
             // eslint-disable-next-line no-console
             console.info("Name: RecognizeOnce");
 
@@ -532,7 +514,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                 sessionId = e.sessionId;
             };
 
-            r.recognizing = (s: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
+            r.recognizing = (): void => {
                 hypoCounter++;
             };
 
@@ -558,7 +540,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                 }
             };
 
-            r.sessionStopped = (s: sdk.SpeechRecognizer, e: sdk.SpeechRecognitionEventArgs) => {
+            r.sessionStopped = (): void => {
                 try {
                     expect(telemetryEvents).toEqual(1);
                     done();
@@ -568,7 +550,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             };
 
             r.recognizeOnceAsync(
-                (p2: sdk.SpeechRecognitionResult) => {
+                (p2: sdk.SpeechRecognitionResult): void => {
                     try {
                         const res: sdk.SpeechRecognitionResult = p2;
                         expect(res).not.toBeUndefined();
@@ -583,12 +565,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     }
 
                 },
-                (error: string) => {
+                (error: string): void => {
                     done(error);
                 });
         });
 
-        test("testStopContinuousRecognitionAsyncWithTelemetry", (done: jest.DoneCallback) => {
+        test("testStopContinuousRecognitionAsyncWithTelemetry", (done: jest.DoneCallback): void => {
             // eslint-disable-next-line no-console
             console.info("Name: testStopContinuousRecognitionAsyncWithTelemetry");
 
@@ -635,7 +617,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                 }
             };
 
-            r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
+            r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
                 try {
                     recoCount++;
                     expect(sdk.ResultReason[e.result.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
@@ -663,7 +645,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             };
 
             r.startContinuousRecognitionAsync(
-                () => WaitForCondition(() => ((recoCount === 2) && canceled), () => {
+                (): void => WaitForCondition((): boolean => ((recoCount === 2) && canceled), (): void => {
                     try {
                         expect(telemetryEvents).toEqual(1);
                         done();
@@ -671,14 +653,14 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                         done(err);
                     }
                 }),
-                (err: string) => {
+                (err: string): void => {
                     done(err);
                 });
         });
 
     });
 
-    test("Event Tests (RecognizeOnce)", (done: jest.DoneCallback) => {
+    test("Event Tests (RecognizeOnce)", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Event Tests (RecognizeOnce)");
         const SpeechStartDetectedEvent = "SpeechStartDetectedEvent";
@@ -688,20 +670,20 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         const r: sdk.SpeechRecognizer = BuildRecognizerFromWaveFile();
         objsToClose.push(r);
 
-        const eventsMap: { [id: string]: number; } = {};
+        const eventsMap: { [id: string]: number } = {};
         let eventIdentifier: number = 1;
 
-        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
+        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
             eventsMap[Recognized] = eventIdentifier++;
         };
 
-        r.recognizing = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
+        r.recognizing = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[Recognizing + "-" + Date.now().toPrecision(4)] = now;
             eventsMap[Recognizing] = now;
         };
 
-        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
             eventsMap[Canceled] = eventIdentifier++;
             try {
                 expect(e.errorDetails).toBeUndefined();
@@ -711,22 +693,21 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         };
 
         // todo eventType should be renamed and be a function getEventType()
-        r.speechStartDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs) => {
+        r.speechStartDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
             const now: number = eventIdentifier++;
-            // eslint-disable-next-line no-string-literal
             eventsMap[SpeechStartDetectedEvent] = now;
         };
-        r.speechEndDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs) => {
+        r.speechEndDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[SpeechEndDetectedEvent] = now;
         };
 
-        r.sessionStarted = (o: sdk.Recognizer, e: sdk.SessionEventArgs) => {
+        r.sessionStarted = (o: sdk.Recognizer, e: sdk.SessionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[SessionStartedEvent] = now;
             eventsMap[SessionStartedEvent + "-" + Date.now().toPrecision(4)] = now;
         };
-        r.sessionStopped = (o: sdk.Recognizer, e: sdk.SessionEventArgs) => {
+        r.sessionStopped = (o: sdk.Recognizer, e: sdk.SessionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[SessionStoppedEvent] = now;
             eventsMap[SessionStoppedEvent + "-" + Date.now().toPrecision(4)] = now;
@@ -736,7 +717,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         //       this makes this test flaky
 
         r.recognizeOnceAsync(
-            (res: sdk.SpeechRecognitionResult) => {
+            (res: sdk.SpeechRecognitionResult): void => {
                 try {
                     expect(res).not.toBeUndefined();
                     expect(res.text).toEqual("What's the weather like?");
@@ -792,13 +773,13 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                 } catch (error) {
                     done(error);
                 }
-            }, (error: string) => {
+            }, (error: string): void => {
                 done(error);
             });
 
     });
 
-    test("Event Tests (Continuous)", (done: jest.DoneCallback) => {
+    test("Event Tests (Continuous)", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Event Tests (Continuous)");
         const SpeechStartDetectedEvent = "SpeechStartDetectedEvent";
@@ -810,20 +791,20 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         let sessionStopped: boolean = false;
 
-        const eventsMap: { [id: string]: number; } = {};
+        const eventsMap: { [id: string]: number } = {};
         let eventIdentifier: number = 1;
 
-        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
+        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
             eventsMap[Recognized] = eventIdentifier++;
         };
 
-        r.recognizing = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
+        r.recognizing = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[Recognizing + "-" + Date.now().toPrecision(4)] = now;
             eventsMap[Recognizing] = now;
         };
 
-        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
             try {
                 expect(e.errorDetails).toBeUndefined();
                 expect(sdk.CancellationErrorCode[e.errorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.NoError]);
@@ -835,23 +816,23 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         };
 
         // todo eventType should be renamed and be a function getEventType()
-        r.speechStartDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs) => {
+        r.speechStartDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
             const now: number = eventIdentifier++;
-            // eslint-disable-next-line no-string-literal
+
             eventsMap[SpeechStartDetectedEvent] = now;
         };
-        r.speechEndDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs) => {
+        r.speechEndDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[SpeechEndDetectedEvent] = now;
         };
 
-        r.sessionStarted = (o: sdk.Recognizer, e: sdk.SessionEventArgs) => {
+        r.sessionStarted = (o: sdk.Recognizer, e: sdk.SessionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[SessionStartedEvent] = now;
             eventsMap[SessionStartedEvent + "-" + Date.now().toPrecision(4)] = now;
         };
 
-        r.sessionStopped = (o: sdk.Recognizer, e: sdk.SessionEventArgs) => {
+        r.sessionStopped = (o: sdk.Recognizer, e: sdk.SessionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[SessionStoppedEvent] = now;
             eventsMap[SessionStoppedEvent + "-" + Date.now().toPrecision(4)] = now;
@@ -860,7 +841,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         r.startContinuousRecognitionAsync();
 
-        WaitForCondition(() => sessionStopped, () => {
+        WaitForCondition((): boolean => sessionStopped, (): void => {
             try {
                 // session events are first and last event
                 const LAST_RECORDED_EVENT_ID: number = --eventIdentifier;
@@ -919,12 +900,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         });
     }, 20000);
 
-    describe("Disables Telemetry", () => {
+    describe("Disables Telemetry", (): void => {
 
         // Re-enable telemetry
-        afterEach(() => sdk.Recognizer.enableTelemetry(true));
+        afterEach((): void => sdk.Recognizer.enableTelemetry(true));
 
-        test("testStopContinuousRecognitionAsyncWithoutTelemetry", (done: jest.DoneCallback) => {
+        test("testStopContinuousRecognitionAsyncWithoutTelemetry", (done: jest.DoneCallback): void => {
             // eslint-disable-next-line no-console
             console.info("Name: testStopContinuousRecognitionAsyncWithoutTelemetry");
             // start with telemetry disabled
@@ -942,7 +923,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                 telemetryEvents++;
             };
 
-            r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
+            r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
                 try {
                     eventDone = true;
                     expect(sdk.ResultReason[e.result.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
@@ -963,32 +944,32 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             };
 
             r.startContinuousRecognitionAsync(
-                () => WaitForCondition(() => (eventDone && canceled), () => {
+                (): void => WaitForCondition((): boolean => (eventDone && canceled), (): void => {
                     r.stopContinuousRecognitionAsync(
-                        () => {
+                        (): void => {
                             // since we disabled, there should be no telemetry
                             // event run through our handler
                             expect(telemetryEvents).toEqual(0);
                             done();
                         },
-                        (err: string) => {
+                        (err: string): void => {
                             done(err);
                         });
                 }),
-                (err: string) => {
+                (err: string): void => {
                     done(err);
                 });
         });
     });
 
-    test("Close with no recognition", () => {
+    test("Close with no recognition", (): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Close with no recognition");
         const r: sdk.SpeechRecognizer = BuildRecognizerFromWaveFile();
         objsToClose.push(r);
     });
 
-    test("Config is copied on construction", () => {
+    test("Config is copied on construction", (): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Config is copied on construction");
 
@@ -1021,7 +1002,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
     });
 
-    test("PushStream4KNoDelay", (done: jest.DoneCallback) => {
+    test("PushStream4KNoDelay", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: PushStream4KNoDelay");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1056,7 +1037,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 const res: sdk.SpeechRecognitionResult = p2;
                 try {
                     expect(res).not.toBeUndefined();
@@ -1071,12 +1052,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                 }
 
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 
-    test("Detailed output continuous recognition stops correctly", (done: jest.DoneCallback) => {
+    test("Detailed output continuous recognition stops correctly", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Detailed output continuous recognition stops correctly");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1102,7 +1083,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         r.startContinuousRecognitionAsync();
     }, 15000);
 
-    test("PushStream start-stop-start continuous recognition on PushStream", (done: jest.DoneCallback) => {
+    test("PushStream start-stop-start continuous recognition on PushStream", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: PushStream start-stop-start continuous recognition on PushStream");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1110,9 +1091,9 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         const pushStream: sdk.PushAudioInputStream = sdk.AudioInputStream.createPushStream();
 
         // open the file and push it to the push stream.
-        fs.createReadStream(Settings.LongerWaveFile).on("data", (arrayBuffer: Buffer) => {
+        fs.createReadStream(Settings.LongerWaveFile).on("data", (arrayBuffer: Buffer): void => {
             pushStream.write(arrayBuffer.slice());
-        }).on("end", () => {
+        }).on("end", (): void => {
             pushStream.close();
         });
 
@@ -1163,7 +1144,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         let success: number = 0;
 
-        const formatTestFiles: { file: string, sampleRate: number, bitRate: number, channels: number, formatTag: sdk.AudioFormatTag }[] = [
+        const formatTestFiles: { file: string; sampleRate: number; bitRate: number; channels: number; formatTag: sdk.AudioFormatTag }[] = [
             { file: Settings.WaveFile44k, sampleRate: 44100, bitRate: 16, channels: 1, formatTag: sdk.AudioFormatTag.PCM },
             { file: Settings.WaveFileAlaw, sampleRate: 16000, bitRate: 16, channels: 1, formatTag: sdk.AudioFormatTag.ALaw },
             { file: Settings.WaveFileMulaw, sampleRate: 16000, bitRate: 16, channels: 1, formatTag: sdk.AudioFormatTag.MuLaw },
@@ -1193,7 +1174,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             };
 
             r.recognizeOnceAsync(
-                (p2: sdk.SpeechRecognitionResult) => {
+                (p2: sdk.SpeechRecognitionResult): void => {
                     const res: sdk.SpeechRecognitionResult = p2;
                     try {
                         expect(res).not.toBeUndefined();
@@ -1208,15 +1189,15 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     }
 
                 },
-                (error: string) => {
+                (error: string): void => {
                     done(error);
                 });
 
         }
-        WaitForCondition(() => success === 3, done);
+        WaitForCondition((): boolean => success === 3, done);
     });
 
-    test("PushStream4KPostRecognizePush", (done: jest.DoneCallback) => {
+    test("PushStream4KPostRecognizePush", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: PushStream4KPostRecognizePush");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1241,7 +1222,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 try {
                     const res: sdk.SpeechRecognitionResult = p2;
 
@@ -1256,7 +1237,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
 
@@ -1271,7 +1252,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
     });
 
-    test("PullStreamFullFill", (done: jest.DoneCallback) => {
+    test("PullStreamFullFill", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: PullStreamFullFill");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1280,11 +1261,10 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         const fileBuffer: ArrayBuffer = WaveFileAudioInput.LoadArrayFromFile(Settings.WaveFile);
 
         let bytesSent: number = 0;
-        let p: sdk.PullAudioInputStream;
-
-        p = sdk.AudioInputStream.createPullStream(
+        const p: sdk.PullAudioInputStream = sdk.AudioInputStream.createPullStream(
             {
-                close: () => { return; },
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                close: (): void => { },
                 read: (buffer: ArrayBuffer): number => {
                     const copyArray: Uint8Array = new Uint8Array(buffer);
                     const start: number = bytesSent;
@@ -1293,7 +1273,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     bytesSent += (end - start);
 
                     if (bytesSent < buffer.byteLength) {
-                        setTimeout(() => p.close(), 1000);
+                        setTimeout((): void => p.close(), 1000);
                     }
 
                     return (end - start);
@@ -1317,7 +1297,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 const res: sdk.SpeechRecognitionResult = p2;
                 try {
                     expect(res).not.toBeUndefined();
@@ -1331,12 +1311,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 
-    test("PullStream44K", (done: jest.DoneCallback) => {
+    test("PullStream44K", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: PullStream44K");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1345,11 +1325,10 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         const fileBuffer: ArrayBuffer = WaveFileAudioInput.LoadArrayFromFile(Settings.WaveFile44k);
 
         let bytesSent: number = 0;
-        let p: sdk.PullAudioInputStream;
-
-        p = sdk.AudioInputStream.createPullStream(
+        const p: sdk.PullAudioInputStream = sdk.AudioInputStream.createPullStream(
             {
-                close: () => { return; },
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                close: (): void => { },
                 read: (buffer: ArrayBuffer): number => {
                     const copyArray: Uint8Array = new Uint8Array(buffer);
                     const start: number = bytesSent;
@@ -1358,7 +1337,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     bytesSent += (end - start);
 
                     if (bytesSent < buffer.byteLength) {
-                        setTimeout(() => p.close(), 1000);
+                        setTimeout((): void => p.close(), 1000);
                     }
 
                     return (end - start);
@@ -1383,7 +1362,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 const res: sdk.SpeechRecognitionResult = p2;
                 try {
                     expect(res).not.toBeUndefined();
@@ -1397,12 +1376,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     }, 120000);
 
-    test("PullStreamHalfFill", (done: jest.DoneCallback) => {
+    test("PullStreamHalfFill", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: PullStreamHalfFill");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1411,11 +1390,10 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         const fileBuffer: ArrayBuffer = WaveFileAudioInput.LoadArrayFromFile(Settings.WaveFile);
 
         let bytesSent: number = 0;
-        let p: sdk.PullAudioInputStream;
-
-        p = sdk.AudioInputStream.createPullStream(
+        const p: sdk.PullAudioInputStream = sdk.AudioInputStream.createPullStream(
             {
-                close: () => { return; },
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                close: (): void => { },
                 read: (buffer: ArrayBuffer): number => {
                     const copyArray: Uint8Array = new Uint8Array(buffer);
                     const start: number = bytesSent;
@@ -1425,7 +1403,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     bytesSent += (end - start);
 
                     if (bytesSent < buffer.byteLength) {
-                        setTimeout(() => p.close(), 1000);
+                        setTimeout((): void => p.close(), 1000);
                     }
 
                     return (end - start);
@@ -1448,7 +1426,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 try {
                     const res: sdk.SpeechRecognitionResult = p2;
 
@@ -1463,12 +1441,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 
-    test.skip("emptyFile", (done: jest.DoneCallback) => {
+    test.skip("emptyFile", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: emptyFile");
         // Server Responses:
@@ -1505,7 +1483,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 try {
                     expect(p2.reason).toEqual(sdk.ResultReason.Canceled);
                     const cancelDetails: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(p2);
@@ -1522,13 +1500,13 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 
     // service returning NoMatch, is this our fault?
-    test.skip("PullStreamSendHalfTheFile", (done: jest.DoneCallback) => {
+    test.skip("PullStreamSendHalfTheFile", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: PullStreamSendHalfTheFile");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1537,11 +1515,10 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         const fileBuffer: ArrayBuffer = WaveFileAudioInput.LoadArrayFromFile(Settings.WaveFile);
 
         let bytesSent: number = 0;
-        let p: sdk.PullAudioInputStream;
-
-        p = sdk.AudioInputStream.createPullStream(
+        const p: sdk.PullAudioInputStream = sdk.AudioInputStream.createPullStream(
             {
-                close: () => { return; },
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                close: (): void => { },
                 read: (buffer: ArrayBuffer): number => {
                     const copyArray: Uint8Array = new Uint8Array(buffer);
                     const start: number = bytesSent;
@@ -1572,7 +1549,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 const res: sdk.SpeechRecognitionResult = p2;
                 try {
                     expect(res).not.toBeUndefined();
@@ -1586,12 +1563,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 
-    test("RecognizeOnceAsync is async", (done: jest.DoneCallback) => {
+    test("RecognizeOnceAsync is async", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: RecognizeOnceAsync is async");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1608,8 +1585,8 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         let postCall: boolean = false;
         let resultSeen: boolean = false;
-        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs) => {
-            WaitForCondition(() => postCall, () => {
+        r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
+            WaitForCondition((): boolean => postCall, (): void => {
                 resultSeen = true;
                 try {
                     expect(e.result.errorDetails).toBeUndefined();
@@ -1636,7 +1613,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         postCall = true;
     }, 100000);
 
-    test("Audio Config is optional", () => {
+    test("Audio Config is optional", (): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Audio Config is optional");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1647,7 +1624,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         expect(r instanceof sdk.Recognizer).toEqual(true);
     });
 
-    Settings.testIfDOMCondition("Default mic is used when audio config is not specified.", () => {
+    Settings.testIfDOMCondition("Default mic is used when audio config is not specified.", (): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Default mic is used when audio config is not specified.");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1658,7 +1635,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         expect(r instanceof sdk.Recognizer).toEqual(true);
         // Node.js doesn't have a microphone natively. So we'll take the specific message that indicates that microphone init failed as evidence it was attempted.
-        r.recognizeOnceAsync(() => fail("RecognizeOnceAsync returned success when it should have failed"),
+        r.recognizeOnceAsync((): void => fail("RecognizeOnceAsync returned success when it should have failed"),
             (error: string): void => {
                 expect(error).toEqual("Error: Browser does not support Web Audio API (AudioContext is not available).");
             });
@@ -1666,13 +1643,13 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         r = new sdk.SpeechRecognizer(s);
         objsToClose.push(r);
 
-        r.startContinuousRecognitionAsync(() => fail("startContinuousRecognitionAsync returned success when it should have failed"),
+        r.startContinuousRecognitionAsync((): void => fail("startContinuousRecognitionAsync returned success when it should have failed"),
             (error: string): void => {
                 expect(error).toEqual("Error: Browser does not support Web Audio API (AudioContext is not available).");
             });
     });
 
-    test("Using disposed recognizer invokes error callbacks.", (done: jest.DoneCallback) => {
+    test("Using disposed recognizer invokes error callbacks.", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Using disposed recognizer invokes error callbacks.");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1684,9 +1661,9 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         let success: number = 0;
 
 
-        r.close(() => {
+        r.close((): void => {
 
-            r.recognizeOnceAsync(() => fail("RecognizeOnceAsync on closed recognizer called success callback"),
+            r.recognizeOnceAsync((): void => fail("RecognizeOnceAsync on closed recognizer called success callback"),
                 (error: string): void => {
                     try {
                         expect(error).toEqual("Error: the object is already disposed");
@@ -1696,7 +1673,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     }
                 });
 
-            r.startContinuousRecognitionAsync(() => fail("startContinuousRecognitionAsync on closed recognizer called success callback"),
+            r.startContinuousRecognitionAsync((): void => fail("startContinuousRecognitionAsync on closed recognizer called success callback"),
                 (error: string): void => {
                     try {
                         expect(error).toEqual("Error: the object is already disposed");
@@ -1706,7 +1683,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     }
                 });
 
-            r.stopContinuousRecognitionAsync(() => fail("stopContinuousRecognitionAsync on closed recognizer called success callback"),
+            r.stopContinuousRecognitionAsync((): void => fail("stopContinuousRecognitionAsync on closed recognizer called success callback"),
                 (error: string): void => {
                     try {
                         expect(error).toEqual("Error: the object is already disposed");
@@ -1716,15 +1693,15 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     }
                 });
 
-            WaitForCondition(() => success === 3, done);
+            WaitForCondition((): boolean => success === 3, done);
         }, (error: string): void => done(error));
     });
 
-    test.skip("Endpoint URL Test", (done: jest.DoneCallback) => {
+    test.skip("Endpoint URL Test", (done: jest.DoneCallback): void => {
         let uri: string;
 
         Events.instance.attachListener({
-            onEvent: (event: PlatformEvent) => {
+            onEvent: (event: PlatformEvent): void => {
                 if (event instanceof ConnectionStartEvent) {
                     const connectionEvent: ConnectionStartEvent = event as ConnectionStartEvent;
                     uri = connectionEvent.uri;
@@ -1749,7 +1726,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 try {
                     const res: sdk.SpeechRecognitionResult = p2;
                     expect(res).not.toBeUndefined();
@@ -1765,18 +1742,18 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 
-    describe("Connection URL Tests", () => {
+    describe("Connection URL Tests", (): void => {
         let uri: string;
         let detachObject: IDetachable;
 
-        beforeEach(() => {
+        beforeEach((): void => {
             detachObject = Events.instance.attachListener({
-                onEvent: (event: PlatformEvent) => {
+                onEvent: (event: PlatformEvent): void => {
                     if (event instanceof ConnectionStartEvent) {
                         const connectionEvent: ConnectionStartEvent = event as ConnectionStartEvent;
                         uri = connectionEvent.uri;
@@ -1785,9 +1762,9 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             });
         });
 
-        afterEach(() => {
+        afterEach((): void => {
             if (undefined !== detachObject) {
-                detachObject.detach().catch((error: string) => {
+                detachObject.detach().catch((error: string): void => {
                     throw new Error(error);
                 });
                 detachObject = undefined;
@@ -1796,7 +1773,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             uri = undefined;
         });
 
-        test.skip("Endpoint URL With Parameter Test", (done: jest.DoneCallback) => {
+        test.skip("Endpoint URL With Parameter Test", (done: jest.DoneCallback): void => {
             // eslint-disable-next-line no-console
             console.info("Name: Endpoint URL With Parameter Test");
 
@@ -1807,7 +1784,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             objsToClose.push(r);
 
             r.recognizeOnceAsync(
-                (p2: sdk.SpeechRecognitionResult) => {
+                (p2: sdk.SpeechRecognitionResult): void => {
                     try {
                         expect(uri).not.toBeUndefined();
                         // Make sure there's only a single ? in the URL.
@@ -1826,7 +1803,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
                 });
         }, 100000);
 
-        test("Endpoint URL With Auth Token Bearer added", (done: jest.DoneCallback) => {
+        test("Endpoint URL With Auth Token Bearer added", (done: jest.DoneCallback): void => {
             // eslint-disable-next-line no-console
             console.info("Name: Endpoint URL With Auth Token Bearer added");
 
@@ -1838,7 +1815,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             objsToClose.push(r);
 
             r.recognizeOnceAsync(
-                (p2: sdk.SpeechRecognitionResult) => {
+                (p2: sdk.SpeechRecognitionResult): void => {
                     try {
                         expect(uri).not.toBeUndefined();
                         // make sure "bearer " is being added to uri
@@ -1858,7 +1835,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         }, 100000);
     });
 
-    test("Connection Errors Propogate Async", (done: jest.DoneCallback) => {
+    test("Connection Errors Propogate Async", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Connection Errors Propogate Async");
         const s: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription("badKey", Settings.SpeechRegion);
@@ -1866,7 +1843,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         const r: sdk.SpeechRecognizer = BuildRecognizerFromWaveFile(s);
 
-        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
             try {
                 expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
                 expect(sdk.CancellationErrorCode[e.errorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.ConnectionFailure]);
@@ -1880,7 +1857,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
 
     }, 15000);
 
-    test("Connection Errors Propogate Sync", (done: jest.DoneCallback) => {
+    test("Connection Errors Propogate Sync", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Connection Errors Propogate Sync");
         const s: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription("badKey", Settings.SpeechRegion);
@@ -1890,7 +1867,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         objsToClose.push(r);
 
         let doneCount: number = 0;
-        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
             try {
                 expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
                 expect(sdk.CancellationErrorCode[e.errorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.ConnectionFailure]);
@@ -1901,7 +1878,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             }
         };
 
-        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult): void => {
             try {
                 const e: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(result);
                 expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
@@ -1913,11 +1890,11 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             }
         });
 
-        WaitForCondition(() => (doneCount === 2), done);
+        WaitForCondition((): boolean => (doneCount === 2), done);
 
     }, 15000);
 
-    test("RecognizeOnce Bad Language", (done: jest.DoneCallback) => {
+    test("RecognizeOnce Bad Language", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: RecognizeOnce Bad Language");
         const s: sdk.SpeechConfig = BuildSpeechConfig();
@@ -1928,7 +1905,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
         objsToClose.push(r);
         let doneCount: number = 0;
 
-        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+        r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
             try {
                 expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
                 expect(sdk.CancellationErrorCode[e.errorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.ConnectionFailure]);
@@ -1939,7 +1916,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             }
         };
 
-        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult) => {
+        r.recognizeOnceAsync((result: sdk.SpeechRecognitionResult): void => {
             try {
                 const e: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(result);
                 expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
@@ -1950,12 +1927,12 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean) => {
             } catch (error) {
                 done(error);
             }
-            WaitForCondition(() => (doneCount === 2), done);
+            WaitForCondition((): boolean => (doneCount === 2), done);
         });
     }, 15000);
 });
 
-Settings.testIfDOMCondition("Push Stream Async", (done: jest.DoneCallback) => {
+Settings.testIfDOMCondition("Push Stream Async", (done: jest.DoneCallback): void => {
     // eslint-disable-next-line no-console
     console.info("Name: Push Stream Async");
 
@@ -1965,9 +1942,9 @@ Settings.testIfDOMCondition("Push Stream Async", (done: jest.DoneCallback) => {
     const p: sdk.PushAudioInputStream = sdk.AudioInputStream.createPushStream();
     const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
 
-    fs.createReadStream(Settings.WaveFile).on("data", (buffer: Buffer) => {
+    fs.createReadStream(Settings.WaveFile).on("data", (buffer: Buffer): void => {
         p.write(buffer.buffer);
-    }).on("end", () => {
+    }).on("end", (): void => {
         p.close();
     });
 
@@ -1977,12 +1954,12 @@ Settings.testIfDOMCondition("Push Stream Async", (done: jest.DoneCallback) => {
     expect(r).not.toBeUndefined();
     expect(r instanceof sdk.Recognizer);
 
-    r.canceled = (r: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs) => {
+    r.canceled = (r: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
         done(e.errorDetails);
     };
 
     r.recognizeOnceAsync(
-        (p2: sdk.SpeechRecognitionResult) => {
+        (p2: sdk.SpeechRecognitionResult): void => {
             const res: sdk.SpeechRecognitionResult = p2;
 
             expect(res).not.toBeUndefined();
@@ -1990,12 +1967,12 @@ Settings.testIfDOMCondition("Push Stream Async", (done: jest.DoneCallback) => {
             expect(res.text).toEqual("What's the weather like?");
             done();
         },
-        (error: string) => {
+        (error: string): void => {
             done(error);
         });
 }, 10000);
 
-test("Multiple RecognizeOnce calls share a connection", (done: jest.DoneCallback) => {
+test("Multiple RecognizeOnce calls share a connection", (done: jest.DoneCallback): void => {
     // eslint-disable-next-line no-console
     console.info("Name: Multiple RecognizeOnce calls share a connection");
 
@@ -2003,7 +1980,7 @@ test("Multiple RecognizeOnce calls share a connection", (done: jest.DoneCallback
     objsToClose.push(s);
 
     const pullStreamSource: RepeatingPullStream = new RepeatingPullStream(Settings.WaveFile);
-    const p: PullAudioInputStream = pullStreamSource.PullStream;
+    const p: sdk.PullAudioInputStream = pullStreamSource.PullStream;
 
     const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
 
@@ -2036,7 +2013,7 @@ test("Multiple RecognizeOnce calls share a connection", (done: jest.DoneCallback
     };
 
     r.recognizeOnceAsync(
-        (p2: sdk.SpeechRecognitionResult) => {
+        (p2: sdk.SpeechRecognitionResult): void => {
             try {
                 const res: sdk.SpeechRecognitionResult = p2;
 
@@ -2050,15 +2027,13 @@ test("Multiple RecognizeOnce calls share a connection", (done: jest.DoneCallback
                 done(error);
             }
         },
-        (error: string) => {
+        (error: string): void => {
             done(error);
         });
 
-    WaitForCondition(() => {
-        return firstReco;
-    }, () => {
+    WaitForCondition((): boolean => firstReco, (): void => {
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 try {
                     const res: sdk.SpeechRecognitionResult = p2;
 
@@ -2072,13 +2047,13 @@ test("Multiple RecognizeOnce calls share a connection", (done: jest.DoneCallback
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 }, 15000);
 
-test("Multiple ContReco calls share a connection", (done: jest.DoneCallback) => {
+test("Multiple ContReco calls share a connection", (done: jest.DoneCallback): void => {
     // eslint-disable-next-line no-console
     console.info("Name: Multiple ContReco calls share a connection");
 
@@ -2088,7 +2063,7 @@ test("Multiple ContReco calls share a connection", (done: jest.DoneCallback) => 
     let sessionId: string;
 
     const pullStreamSource: RepeatingPullStream = new RepeatingPullStream(Settings.WaveFile);
-    const p: PullAudioInputStream = pullStreamSource.PullStream;
+    const p: sdk.PullAudioInputStream = pullStreamSource.PullStream;
 
     const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
 
@@ -2145,35 +2120,31 @@ test("Multiple ContReco calls share a connection", (done: jest.DoneCallback) => 
 
     r.startContinuousRecognitionAsync(
         undefined,
-        (error: string) => {
+        (error: string): void => {
             done(error);
         });
 
-    WaitForCondition(() => {
-        return recoCount === 1;
-    }, () => {
-        r.stopContinuousRecognitionAsync(() => {
+    WaitForCondition((): boolean => recoCount === 1, (): void => {
+        r.stopContinuousRecognitionAsync((): void => {
 
             pullStreamSource.StartRepeat();
 
             r.startContinuousRecognitionAsync(
                 undefined,
-                (error: string) => {
+                (error: string): void => {
                     done(error);
                 });
         });
     });
 
-    WaitForCondition(() => {
-        return recoCount === 2;
-    }, () => {
-        r.stopContinuousRecognitionAsync(() => {
+    WaitForCondition((): boolean => recoCount === 2, (): void => {
+        r.stopContinuousRecognitionAsync((): void => {
             done();
         });
     });
 }, 20000);
 
-test("StopContinous Reco does", (done: jest.DoneCallback) => {
+test("StopContinous Reco does", (done: jest.DoneCallback): void => {
     // eslint-disable-next-line no-console
     console.info("Name: StopContinous Reco does");
 
@@ -2181,10 +2152,9 @@ test("StopContinous Reco does", (done: jest.DoneCallback) => {
     objsToClose.push(s);
 
     let recognizing: boolean = true;
-    let failed: boolean = false;
 
     const pullStreamSource: RepeatingPullStream = new RepeatingPullStream(Settings.WaveFile);
-    const p: PullAudioInputStream = pullStreamSource.PullStream;
+    const p: sdk.PullAudioInputStream = pullStreamSource.PullStream;
 
     const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
 
@@ -2233,29 +2203,25 @@ test("StopContinous Reco does", (done: jest.DoneCallback) => {
 
     r.startContinuousRecognitionAsync(
         undefined,
-        (error: string) => {
+        (error: string): void => {
             done(error);
         });
 
-    WaitForCondition(() => {
-        return recoCount === 1;
-    }, () => {
-        r.stopContinuousRecognitionAsync(() => {
+    WaitForCondition((): boolean => recoCount === 1, (): void => {
+        r.stopContinuousRecognitionAsync((): void => {
             recognizing = false;
             pullStreamSource.StartRepeat();
 
-            setTimeout(() => {
-                if (!failed) {
-                    done();
-                }
+            setTimeout((): void => {
+                done();
             }, 5000);
         });
     });
 
 }, 100000);
 
-describe("PhraseList tests", () => {
-    test.skip("Ambiguous Speech default as expected", (done: jest.DoneCallback) => {
+describe("PhraseList tests", (): void => {
+    test.skip("Ambiguous Speech default as expected", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Ambiguous Speech default as expected");
 
@@ -2271,7 +2237,7 @@ describe("PhraseList tests", () => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 try {
                     const res: sdk.SpeechRecognitionResult = p2;
                     expect(res.errorDetails).toBeUndefined();
@@ -2283,13 +2249,13 @@ describe("PhraseList tests", () => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 
     // This test validates our ability to add features to the SDK in parallel / ahead of implementation by the Speech Service with no ill effects.
-    test.skip("Service accepts random speech.context sections w/o error", (done: jest.DoneCallback) => {
+    test.skip("Service accepts random speech.context sections w/o error", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Service accepts random speech.context sections w/o error.");
 
@@ -2308,7 +2274,7 @@ describe("PhraseList tests", () => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 try {
                     const res: sdk.SpeechRecognitionResult = p2;
                     expect(res.errorDetails).toBeUndefined();
@@ -2320,12 +2286,12 @@ describe("PhraseList tests", () => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 
-    test("Phraselist assists speech Reco.", (done: jest.DoneCallback) => {
+    test("Phraselist assists speech Reco.", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Phraselist assists speech Reco.");
 
@@ -2344,7 +2310,7 @@ describe("PhraseList tests", () => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 try {
                     const res: sdk.SpeechRecognitionResult = p2;
                     expect(res.errorDetails).toBeUndefined();
@@ -2356,12 +2322,12 @@ describe("PhraseList tests", () => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     });
 
-    test("Phraselist extra phraselists have no effect.", (done: jest.DoneCallback) => {
+    test("Phraselist extra phraselists have no effect.", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: Phraselist extra phraselists have no effect.");
 
@@ -2381,7 +2347,7 @@ describe("PhraseList tests", () => {
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 try {
                     const res: sdk.SpeechRecognitionResult = p2;
                     expect(res.errorDetails).toBeUndefined();
@@ -2393,13 +2359,13 @@ describe("PhraseList tests", () => {
                     done(error);
                 }
             },
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
     }, 10000);
 
     // Ambiguous file now gives "wreck a nice beach" without context
-    test.skip("Phraselist Clear works.", (done: jest.DoneCallback) => {
+    test.skip("Phraselist Clear works.", (done: jest.DoneCallback): void => {
 
         // eslint-disable-next-line no-console
         console.info("Name: Phraselist Clear works.");
@@ -2410,7 +2376,7 @@ describe("PhraseList tests", () => {
         let gotReco: boolean = false;
 
         const pullStreamSource: RepeatingPullStream = new RepeatingPullStream(Settings.AmbiguousWaveFile);
-        const p: PullAudioInputStream = pullStreamSource.PullStream;
+        const p: sdk.PullAudioInputStream = pullStreamSource.PullStream;
 
         const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
 
@@ -2455,13 +2421,11 @@ describe("PhraseList tests", () => {
 
         r.recognizeOnceAsync(
             undefined,
-            (error: string) => {
+            (error: string): void => {
                 done(error);
             });
 
-        WaitForCondition(() => {
-            return recoCount === 1;
-        }, () => {
+        WaitForCondition((): boolean => recoCount === 1, (): void => {
             dynamicPhrase.clear();
             phraseAdded = false;
             pullStreamSource.StartRepeat();
@@ -2469,15 +2433,115 @@ describe("PhraseList tests", () => {
 
             r.startContinuousRecognitionAsync(
                 undefined,
-                (error: string) => {
+                (error: string): void => {
                     done(error);
                 });
         });
 
-        WaitForCondition(() => {
-            return recoCount === 2;
-        }, () => {
+        WaitForCondition((): boolean => recoCount === 2, (): void => {
             done();
         });
     }, 20000);
+
+    describe.only.each([sdk.OutputFormat.Simple, sdk.OutputFormat.Detailed])("Output Format", (outptuFormat: sdk.OutputFormat): void => {
+        test("Multi-Turn offset verification", (done: jest.DoneCallback): void => {
+            // eslint-disable-next-line no-console
+            console.info("Name: Multiple Phrase Latency Reporting");
+
+            const s: sdk.SpeechConfig = BuildSpeechConfig();
+            objsToClose.push(s);
+
+            s.speechRecognitionLanguage = "en-US";
+            s.outputFormat = outptuFormat;
+
+            const pullStreamSource: RepeatingPullStream = new RepeatingPullStream(Settings.WaveFile);
+            const p: sdk.PullAudioInputStream = pullStreamSource.PullStream;
+
+            const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
+
+            const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(s, config);
+            objsToClose.push(r);
+
+            expect(r).not.toBeUndefined();
+            expect(r instanceof sdk.Recognizer);
+
+            let recoCount: number = 0;
+            let lastOffset: number = 0;
+
+            r.speechEndDetected = (r: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
+                try {
+                    expect(e.offset).toBeGreaterThan(lastOffset);
+                } catch (error) {
+                    done(error);
+                }
+                recoCount++;
+                pullStreamSource.StartRepeat();
+            };
+
+            r.speechStartDetected = (r: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
+                try {
+                    expect(e.offset).toBeGreaterThan(lastOffset);
+                } catch (error) {
+                    done(error);
+                }
+            };
+
+            r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+                try {
+                    expect(e.errorDetails).toBeUndefined();
+                } catch (error) {
+                    done(error);
+                }
+            };
+
+            r.recognizing = (r: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
+                try {
+                    expect(e.result).not.toBeUndefined();
+                    expect(e.offset).toBeGreaterThan(lastOffset);
+
+                    // Use some implementation details from the SDK to test the JSON has been exported correctly.
+                    let simpleResult: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult), 0);
+                    expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
+                    simpleResult = SimpleSpeechPhrase.fromJSON(e.result.json, 0);
+                    expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+                } catch (error) {
+                    done(error);
+                }
+            };
+
+            r.recognized = (r: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
+                try {
+                    const res: sdk.SpeechRecognitionResult = e.result;
+                    expect(res).not.toBeUndefined();
+                    expect(e.offset).toBeGreaterThan(lastOffset);
+
+                    // Use some implementation details from the SDK to test the JSON has been exported correctly.
+                    let simpleResult: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult), 0);
+                    expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
+                    simpleResult = SimpleSpeechPhrase.fromJSON(e.result.json, 0);
+                    expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
+                    lastOffset = e.offset;
+                } catch (error) {
+                    done(error);
+                }
+            };
+
+            r.startContinuousRecognitionAsync(
+                undefined,
+                (error: string): void => {
+                    done(error);
+                });
+
+            WaitForCondition((): boolean => (recoCount === 3), (): void => {
+                r.stopContinuousRecognitionAsync((): void => {
+                    done();
+                }, (error: string): void => {
+                    done(error);
+                });
+            });
+        }, 1000 * 60 * 2);
+    });
 });

--- a/tests/Utilities.ts
+++ b/tests/Utilities.ts
@@ -57,7 +57,8 @@ export class RepeatingPullStream {
 
         this.pullStream = sdk.AudioInputStream.createPullStream(
             {
-                close: () => { return; },
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                close: (): void => {},
                 read: (buffer: ArrayBuffer): number => {
 
                     if (!!this.sendSilence) {


### PR DESCRIPTION
While the strongly typed instance properties for the audio offsets had been fixed up to account for multiple turns, the underlying JSON in the result objects wasn't.

This addresses that and add test cases for them.

Fixed and re-enabled the silence detection tests.
Also cleaned up the linter errors in a couple of test files.