### PR TITLE
Initial add of new config system.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tests/**/*.js
 !tests/AudioPlayerTests/server/server.js
 distrib/*
 secrets/*
+tests/test.subscriptions.regions.json
 /**/speech.key
 .idea/
 test-javascript-junit.xml

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -50,21 +50,9 @@ jobs:
   - bash: "echo '##vso[task.setvariable variable=SPEECHSDK_RUN_TESTS]false'"
     condition: or(failed(), canceled())
     displayName: Skip tests on build failure
+  - template: generate-subscription-file.yml
   - script: |
-      RunTests.cmd ^
-        SpeechSubscriptionKey:$(WestCentralUSKeySkyMan) ^
-        SpeechRegion:westcentralus ^
-        LuisSubscriptionKey:$(luis-westus-s0-201809-key1) ^
-        LuisRegion:westus ^
-        SpeechTestEndpointId:ec3432b2-8584-4736-865a-556213b9f6fd ^
-        BotSubscription:$(DialogSubscriptionKey) ^
-        BotRegion:$(DialogRegion) ^
-        SpeakerIDSubscriptionKey:$(SpeakerRecognition-WestUS-Key) ^
-        SpeakerIDRegion:westus ^
-        ConversationTranscriptionKey:$(ConverstationTranscriptionKeyWestUSOnline) ^
-        ConversationTranscriptionRegion:westus ^
-        CustomVoiceSubscriptionKey:$(speech-ne-s0-key1) ^
-        CustomVoiceRegion:northeurope
+      RunTests.cmd
     displayName: Run tests
     condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
   - task: PublishTestResults@2

--- a/ci/generate-subscription-file.yml
+++ b/ci/generate-subscription-file.yml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+#
+#######################################################################################################
+# This file defines a reusable step that initializes the json file with the subscriptions and regions
+# required for testing. This step depends on the availability of the variables defined in
+# subscription_vars.yml.
+#######################################################################################################
+steps:
+- task: AzureKeyVault@2
+  inputs:
+    azureSubscription: 'ADO -> Speech Services - DEV - SDK' # Azure subscription
+    keyVaultName: "CarbonSDK-CICD"
+    secretsFilter: 'CarbonSubscriptionsJson'
+- task: file-creator@6
+  inputs:
+    filepath: '$(Build.SourcesDirectory)/secrets/test.subscriptions.regions.json'
+    filecontent: '$(CarbonSubscriptionsJson)'
+    fileoverwrite: true
+  displayName: "Ensure subscriptions .json file"

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+const fs = require('fs');
+const path = require('path');
+
+// Default configuration file
+const defaultConfigFile = './secrets/TestConfiguration.ts';
+const configJsonFile = './secrets/test.subscriptions.regions.json';
+
+// Determine which configuration file to use
+const getConfigFile = () => {
+    if (configJsonFile && fs.existsSync(path.resolve(configJsonFile))) {
+        console.log(`Using JSON configuration: ${configJsonFile}`);
+        return configJsonFile;
+    }
+    console.log(`Using default configuration: ${defaultConfigFile}`);
+    return defaultConfigFile;
+};
+
+const configFile = getConfigFile();
+
 module.exports = {
     projects: [
         {
@@ -15,7 +34,7 @@ module.exports = {
             moduleFileExtensions: ["ts", "js", "jsx", "json", "node"],
             testEnvironment: "jsdom",
             collectCoverage: false,
-            setupFilesAfterEnv: ["./secrets/TestConfiguration.ts"],
+            setupFilesAfterEnv: [configFile],
             testTimeout : 20000
         },
         {
@@ -31,7 +50,7 @@ module.exports = {
             moduleFileExtensions: ["ts", "js", "jsx", "json", "node"],
             testEnvironment: "node",
             collectCoverage: false,
-            setupFilesAfterEnv: ["./secrets/TestConfiguration.ts"],
+            setupFilesAfterEnv: [configFile],
             testTimeout : 30000
         }
     ],

--- a/tests/CONFIGURATION.md
+++ b/tests/CONFIGURATION.md
@@ -1,0 +1,62 @@
+# TypeScript Test Configuration
+
+This document describes how to set up the test configuration for the Cognitive Services Speech SDK TypeScript/JavaScript tests.
+
+## Configuration System
+
+The test configuration uses a file-based approach to store authentication and endpoint information. The configuration system reads information from these JSON files:
+
+- `test.subscriptions.regions.json` - Contains API keys, regions, and endpoints
+- Settings.ts: Contains general rarely changed test configurations.
+
+## Setting Up the Configuration
+
+### Secrets and Endpoints
+
+Create a file named `test.subscriptions.regions.json` with the following structure:
+
+```json
+{
+  "UnifiedSpeechSubscription": {
+    "Key": "your-speech-subscription-key",
+    "Region": "your-region",
+    "Endpoint": "https://your-region.api.cognitive.microsoft.com/"
+  },
+  "LanguageUnderstandingSubscription": {
+    "Key": "your-luis-subscription-key",
+    "Region": "your-region"
+  },
+  "SpeakerRecognitionSubscription": {
+    "Key": "your-speaker-id-key",
+    "Region": "your-region"
+  },
+  "ConversationTranscriptionPrincetonSubscription": {
+    "Key": "your-transcription-key",
+    "Region": "your-region"
+  },
+  "CustomVoiceSubscription": {
+    "Key": "your-custom-voice-key",
+    "Region": "your-region"
+  }
+}
+```
+
+The configuration loader will search for this file in the current directory and parent directories.
+
+## How It Works
+
+During initialization, the test framework will:
+
+1. Load the JSON configuration file
+2. Extract the relevant keys, regions, and endpoints
+3. Populate the Settings class with these values
+
+All tests will then use the values from the Settings class.
+
+## Adding New Configuration Values
+
+To add new subscription or region values:
+
+1. Add the key name to the `SubscriptionsRegionsKeys` class in `SubscriptionRegion.ts`
+2. Update the loading logic in `Settings.ts` if needed
+3. Add the entry to your `test.subscriptions.regions.json` file

--- a/tests/ConfigLoader.ts
+++ b/tests/ConfigLoader.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as fs from "fs";
+import * as path from "path";
+import { SubscriptionRegion } from "./SubscriptionRegion";
+
+/**
+ * Config loader that matches the C# implementation for loading subscription and region information.
+ */
+export class ConfigLoader {
+    private static _instance: ConfigLoader;
+    private _subscriptionsRegionsMap: Record<string, SubscriptionRegion> = {};
+    private _initialized: boolean = false;
+
+    /**
+     * Private constructor to enforce singleton pattern.
+     */
+    private constructor() { }
+
+    /**
+     * Gets the singleton instance of the ConfigLoader.
+     */
+    public static get instance(): ConfigLoader {
+        if (!this._instance) {
+            this._instance = new ConfigLoader();
+        }
+        return this._instance;
+    }
+
+    /**
+     * Gets the map of subscription regions.
+     */
+    public get subscriptionsRegionsMap(): Record<string, SubscriptionRegion> {
+        this.ensureInitialized();
+        return this._subscriptionsRegionsMap;
+    }
+
+    /**
+     * Initializes the config loader by reading the subscriptions and regions file.
+     * @param filePath Optional path to the subscriptions regions JSON file.
+     * @returns True if initialization was successful, false otherwise.
+     */
+    public initialize(filePath?: string): boolean {
+        if (this._initialized) {
+            return true;
+        }
+
+        const fileName = filePath || "./secrets/test.subscriptions.regions.json";
+
+        // Try to find the file in the current directory or parent directories
+        try {
+            const resolvedPath = this.findFile(fileName);
+            if (!resolvedPath) {
+                console.error(`Could not find ${fileName}`);
+                return false;
+            }
+
+            const fileContent = fs.readFileSync(resolvedPath, 'utf8');
+            this._subscriptionsRegionsMap = JSON.parse(fileContent);
+            this._initialized = true;
+            return true;
+        } catch (error) {
+            console.error(`Error loading ${fileName}: ${error.message}`);
+            return false;
+        }
+    }
+
+    /**
+     * Ensures that the config loader is initialized.
+     */
+    private ensureInitialized(): void {
+        if (!this._initialized) {
+            const success = this.initialize();
+            if (!success) {
+                console.warn("Failed to initialize ConfigLoader. Using empty configuration.");
+            }
+        }
+    }
+
+    /**
+     * Tries to find a file by searching in the current directory and parent directories.
+     * @param fileName The name of the file to find.
+     * @param maxDepth Maximum number of parent directories to search.
+     * @returns The resolved path to the file or undefined if not found.
+     */
+    private findFile(fileName: string, maxDepth: number = 5): string | undefined {
+        let currentDir = process.cwd();
+        let depth = 0;
+
+        while (depth < maxDepth) {
+            const filePath = path.join(currentDir, fileName);
+            console.info(`Searching for ${fileName} in ${currentDir}`);
+            if (fs.existsSync(filePath)) {
+                return filePath;
+            }
+
+            const parentDir = path.dirname(currentDir);
+            if (parentDir === currentDir) {
+                // We've reached the root directory
+                break;
+            }
+
+            currentDir = parentDir;
+            depth++;
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Gets a subscription region by key.
+     * @param key The key of the subscription region to get.
+     * @returns The subscription region or undefined if not found.
+     */
+    public getSubscriptionRegion(key: string): SubscriptionRegion | undefined {
+        return this.subscriptionsRegionsMap[key];
+    }
+}

--- a/tests/IntentRecognizerTests.ts
+++ b/tests/IntentRecognizerTests.ts
@@ -16,6 +16,8 @@ import {
     WaitForCondition
 } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
+import { ConfigLoader } from "./ConfigLoader";
+import { SubscriptionRegion, SubscriptionsRegionsKeys } from "./SubscriptionRegion";
 
 let objsToClose: any[];
 let bufferSize: number;
@@ -412,7 +414,9 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
         // eslint-disable-next-line no-console
         console.info("Name: RecognizedReceivedWithValidNonLUISKey");
 
-        const s: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription(Settings.SpeakerIDSubscriptionKey, Settings.SpeakerIDRegion);
+        const sub: SubscriptionRegion = ConfigLoader.instance.getSubscriptionRegion("SpeechSubscriptionWestUS");
+
+        const s: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription(sub.Key, sub.Region);
         objsToClose.push(s);
 
         const r: sdk.IntentRecognizer = BuildRecognizerFromWaveFile(s, Settings.AmbiguousWaveFile);

--- a/tests/Settings.ts
+++ b/tests/Settings.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { ConfigLoader } from "./ConfigLoader";
+import { SubscriptionsRegionsKeys } from "./SubscriptionRegion";
+
 export class Settings {
 
     public static RetryCount: number = 1;
@@ -118,9 +121,69 @@ export class Settings {
         Settings.LoadSettings();
     }
 
-    public static LoadSettings = () => {
+    public static LoadSettings(): void {
         if (Settings.IsSettingsInitialized) {
             return;
+        }
+
+        // Initialize the config loader to load the secrets and endpoints
+        const configLoader = ConfigLoader.instance;
+        const initialized = configLoader.initialize();
+
+        if (initialized) {
+            // Load the unified speech subscription
+            const unifiedSpeechSub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+            if (unifiedSpeechSub) {
+                Settings.SpeechSubscriptionKey = unifiedSpeechSub.Key;
+                Settings.SpeechRegion = unifiedSpeechSub.Region;
+                /* Skip for now until endpoing is fully supported
+                if (unifiedSpeechSub.Endpoint) {
+                    Settings.SpeechEndpoint = unifiedSpeechSub.Endpoint;
+                }
+                */
+            }
+
+            // Load the LUIS subscription
+            const luisSub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.LUIS_SUBSCRIPTION);
+            if (luisSub) {
+                Settings.LuisSubscriptionKey = luisSub.Key;
+                Settings.LuisRegion = luisSub.Region;
+            }
+
+            // Load the speaker recognition subscription
+            const speakerIdSub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.SPEAKER_RECOGNITION_SUBSCRIPTION);
+            if (speakerIdSub) {
+                Settings.SpeakerIDSubscriptionKey = speakerIdSub.Key;
+                Settings.SpeakerIDRegion = speakerIdSub.Region;
+            }
+
+            // Load the conversation transcription subscription
+            const conversationTranscriptionSub = configLoader.getSubscriptionRegion(
+                SubscriptionsRegionsKeys.CONVERSATION_TRANSCRIPTION_SUBSCRIPTION);
+            if (conversationTranscriptionSub) {
+                Settings.ConversationTranscriptionKey = conversationTranscriptionSub.Key;
+                Settings.ConversationTranscriptionRegion = conversationTranscriptionSub.Region;
+            }
+
+            // Load the custom voice subscription
+            const customVoiceSub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.CUSTOM_VOICE_SUBSCRIPTION);
+            if (customVoiceSub) {
+                Settings.CustomVoiceSubscriptionKey = customVoiceSub.Key;
+                Settings.CustomVoiceRegion = customVoiceSub.Region;
+            }
+
+            // Load the conversation translator settings
+            const conversationTranslatorSub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.CONVERSATION_TRANSLATOR);
+            if (conversationTranslatorSub) {
+                // These might be set from other configuration values
+                // but we'll use the region and key if available
+            }
+
+            const botSub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.DIALOG_SUBSCRIPTION);
+            if (botSub) {
+                Settings.BotSubscription = botSub.Key;
+                Settings.BotRegion = botSub.Region;
+            }
         }
 
         if (undefined === Settings.LuisAppKey) {

--- a/tests/SubscriptionRegion.ts
+++ b/tests/SubscriptionRegion.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Represents a subscription and region configuration matching the C# format.
+ */
+export interface SubscriptionRegion {
+    /**
+     * The subscription key.
+     */
+    Key: string;
+
+    /**
+     * The region for the subscription.
+     */
+    Region: string;
+
+    /**
+     * The endpoint URL (optional).
+     */
+    Endpoint?: string;
+
+    /**
+     * The Azure resource ID (optional).
+     */
+    ResourceId?: string;
+
+    /**
+     * Optional description.
+     */
+    Description?: string;
+
+    /**
+     * Optional secret value.
+     */
+    Secret?: string;
+}
+
+/**
+ * Keys for the standard subscription regions in the configuration.
+ */
+export class SubscriptionsRegionsKeys {
+    public static readonly UNIFIED_SPEECH_SUBSCRIPTION: string = "UnifiedSpeechSubscription";
+    public static readonly LUIS_SUBSCRIPTION: string = "LanguageUnderstandingSubscription";
+    public static readonly SPEAKER_RECOGNITION_SUBSCRIPTION: string = "SpeakerRecognitionSubscription";
+    public static readonly CONVERSATION_TRANSCRIPTION_SUBSCRIPTION: string = "ConversationTranscriptionPrincetonSubscription";
+    public static readonly CUSTOM_VOICE_SUBSCRIPTION: string = "CustomVoiceSubscription";
+    public static readonly DIALOG_SUBSCRIPTION: string = "DialogSubscription";
+    public static readonly CONVERSATION_TRANSLATOR: string = "ConversationTranslatorSubscription";
+    public static readonly AAD_SPEECH_CLIENT_SECRET: string = "AADSpeechClientSecret";
+    public static readonly CUSTOM_VOICE_REGION: string = "CustomVoiceRegion";
+}


### PR DESCRIPTION
This moves the JS repo to use the same format JSON secrets configuration file as the natvie code base, and in CI/CD fetches the file from the KV location.

Existing secrets management remains intact, so no dev inner loop need be changed.