### PR TITLE
Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@ LICENSE text
 *.txt text
 *.yml text
 *.html text
+*.ps1 text
 
 # Bash only with Unix line endings
 *.sh text eol=lf

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -34,7 +34,8 @@ jobs:
       npm ci && npm run civersion
       echo "COLLECTION_ID=$(System.CollectionId)"
       echo "DEFINITION_ID=$(System.DefinitionId)"
-      echo "SDK version = $SPEECHSDK_SEMVER2NOMETA"
+      echo "SDK version = $(SPEECHSDK_SEMVER2NOMETA)"
+      env
     displayName: Install packages and set version / SPEECHSDK_SEMVER2NOMETA
   - bash: |
       F=src/common.speech/SpeechServiceConfig.ts
@@ -47,29 +48,6 @@ jobs:
     displayName: Stamp SPEECHSDK_CLIENTSDK_VERSION
   - bash: npm pack
     displayName: Build and pack SDK
-  - bash: "echo '##vso[task.setvariable variable=SPEECHSDK_RUN_TESTS]false'"
-    condition: or(failed(), canceled())
-    displayName: Skip tests on build failure
-  - template: generate-subscription-file.yml
-  - script: |
-      RunTests.cmd
-    displayName: Run tests
-    condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
-  - task: PublishTestResults@2
-    displayName: Publish test results
-    inputs:
-      testRunner: JUnit
-      testResultsFiles: 'test-javascript-junit.xml'
-    condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
-  - bash: |
-        set -e
-        cd tests/packaging
-        echo "SDK version = $SPEECHSDK_SEMVER2NOMETA"
-        npm ci
-        npm install ../../microsoft-cognitiveservices-speech-sdk-$SPEECHSDK_SEMVER2NOMETA.tgz
-        npm run bundle
-    displayName: Run Test Bundle
-    condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
   - bash: |
       set -u -e -o pipefail -x
       PACKAGE_BASE=microsoft-cognitiveservices-speech-sdk
@@ -97,3 +75,248 @@ jobs:
       PathtoPublish: $(ArtifactOut)
       ArtifactName: JavaScript
       publishLocation: Container
+  - bash: "echo '##vso[task.setvariable variable=SPEECHSDK_RUN_TESTS]false'"
+    condition: or(failed(), canceled())
+    displayName: Skip tests on build failure
+- job : RunTest
+  pool:
+    name: $(WindowsPipelineName)
+  timeoutInMinutes: 60
+  condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
+  variables:
+    SPEECHSDK_RUN_TESTS: true
+  dependsOn: Build
+  steps:
+  - bash: ./ci/check-git-head.sh
+    displayName: Repository checks
+  - bash: |
+      npm ci && npm run civersion
+      echo "COLLECTION_ID=$(System.CollectionId)"
+      echo "DEFINITION_ID=$(System.DefinitionId)"
+      echo "SDK version = $(SPEECHSDK_SEMVER2NOMETA)"
+    displayName: Install packages and set version / SPEECHSDK_SEMVER2NOMETA
+  - bash: |
+      F=src/common.speech/SpeechServiceConfig.ts
+      [[ -f $F ]] || exit 1
+      perl -i.bak -p -e 'BEGIN { $c = 0 } $c += s/(?<=const SPEECHSDK_CLIENTSDK_VERSION = ")[^"]*/$(SPEECHSDK_SEMVER2NOMETA)/g; END { die "Patched SPEECHSDK_CLIENTSDK_VERSION $c time(s), expected 1.\n" if $c != 1 }' "$F"
+      E=$?
+      rm -f "$F.bak"
+      git diff
+      exit $E
+    displayName: Stamp SPEECHSDK_CLIENTSDK_VERSION
+  - template: generate-subscription-file.yml
+  - bash: |
+      set -u -e -x -o pipefail
+      npm run test:non-connection
+    displayName: Run tests
+    condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
+  - task: PublishTestResults@2
+    displayName: Publish test results
+    inputs:
+      testRunner: JUnit
+      testResultsFiles: 'test-javascript-junit.xml'
+      failTaskOnFailedTests: true
+    condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
+  - task: DownloadBuildArtifacts@1
+    displayName: Download artifacts
+    inputs:
+      buildType: current
+      downloadPath: $(Pipeline.Workspace)
+      artifactName: JavaScript
+  - bash: |
+        set -e
+        cd tests/packaging
+        echo "SDK version = $SPEECHSDK_SEMVER2NOMETA"
+        npm ci
+        PACKAGE_PATH="$(Pipeline.Workspace)/JavaScript/npm/microsoft-cognitiveservices-speech-sdk-$SPEECHSDK_SEMVER2NOMETA.tgz"
+        # Convert Windows path to proper format
+        PACKAGE_PATH=$(echo $PACKAGE_PATH | sed 's/\\/\//g')
+        npm install "$PACKAGE_PATH"
+
+        npm run bundle
+    displayName: Run Test Bundle
+    condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
+- job: RunConnectionTests
+  dependsOn: Build
+  pool:
+    name: CarbonUbuntu2204Hosted
+  timeoutInMinutes: 60
+  condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
+  variables:
+    SPEECHSDK_RUN_TESTS: true
+  steps:
+  - bash: ./ci/check-git-head.sh
+    displayName: Repository checks
+  - bash: |
+      npm ci && npm run civersion
+      echo "COLLECTION_ID=$(System.CollectionId)"
+      echo "DEFINITION_ID=$(System.DefinitionId)"
+      echo "SDK version = $SPEECHSDK_SEMVER2NOMETA"
+    displayName: Install packages and set version / SPEECHSDK_SEMVER2NOMETA
+  - bash: |
+      F=src/common.speech/SpeechServiceConfig.ts
+      [[ -f $F ]] || exit 1
+      perl -i.bak -p -e 'BEGIN { $c = 0 } $c += s/(?<=const SPEECHSDK_CLIENTSDK_VERSION = ")[^"]*/$(SPEECHSDK_SEMVER2NOMETA)/g; END { die "Patched SPEECHSDK_CLIENTSDK_VERSION $c time(s), expected 1.\n" if $c != 1 }' "$F"
+      E=$?
+      rm -f "$F.bak"
+      git diff
+      exit $E
+    displayName: Stamp SPEECHSDK_CLIENTSDK_VERSION
+  - template: generate-subscription-file.yml
+  - bash: |
+      # Define new Docker data directory  
+      NEW_DOCKER_DIR="/mnt/docker"  
+        
+      # Stop Docker service  
+      echo "Stopping Docker service..."  
+      sudo systemctl stop docker  
+        
+      # Create new Docker directory  
+      echo "Creating new Docker directory at $NEW_DOCKER_DIR..."  
+      sudo mkdir -p "$NEW_DOCKER_DIR"  
+        
+      # Update Docker daemon configuration  
+      echo "Updating Docker daemon configuration..."  
+      DOCKER_CONFIG_FILE="/etc/docker/daemon.json"  
+      sudo touch "$DOCKER_CONFIG_FILE"  
+      sudo chmod 666 "$DOCKER_CONFIG_FILE" # Temporarily change permissions to write  
+        
+      cat <<EOL | sudo tee "$DOCKER_CONFIG_FILE"  
+      {  
+        "data-root": "$NEW_DOCKER_DIR/docker"  
+      }  
+      EOL
+
+      sudo chmod 644 "$DOCKER_CONFIG_FILE" # Restore permissions 
+
+      # Start Docker service  
+      echo "Starting Docker service..."
+
+      # Actually restart the docker service, because it can have auto-started after the stop command  
+      sudo systemctl restart docker  
+
+      sudo systemctl status docker  
+        
+      # Verify the change  
+      echo "Verifying Docker configuration..."  
+
+      docker info
+
+      DOCKER_ROOT_DIR=$(docker info | grep "Docker Root Dir" | awk '{print $4}')  
+      if [ "$DOCKER_ROOT_DIR" == "$NEW_DOCKER_DIR/docker" ]; then  
+        echo "Docker data successfully moved to $DOCKER_ROOT_DIR"  
+      else  
+        echo "Error: Docker data directory is not set correctly."  
+        exit 1  
+      fi
+
+      sudo df
+    displayName: Move Docker data directory to /mnt
+  - template: get-docker-image.yml
+    parameters:
+      DockerImages: $(DOCKER_IMAGE) mcr.microsoft.com/azure-cognitive-services/speechservices/neural-text-to-speech:latest mcr.microsoft.com/azure-cognitive-services/speechservices/speech-to-text:latest mcr.microsoft.com/azure-cognitive-services/speechservices/language-detection:latest
+  - bash: |
+      set -u -e -x -o pipefail
+      . ci/functions.sh
+      . ci/load-build-secrets.sh
+
+      tts_port=$(find_free_port)  
+      echo "TTS Port: $tts_port"
+
+      host_ip=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+      echo "Host IP: $host_ip"
+
+      TTS_URL="ws://$host_ip:$tts_port"  
+      vsts_setvar TTS_CONTAINER_URL "$TTS_URL"
+
+      docker create -p $tts_port:5000 --memory 14g --cpus 4 --name tts_container mcr.microsoft.com/azure-cognitive-services/speechservices/neural-text-to-speech:latest EULA=accept Billing=https://$SPEECHSDK_SPEECH_REGION.api.cognitive.microsoft.com/ ApiKey=$SPEECHSDK_SPEECH_KEY
+      docker start tts_container
+    displayName: Create and start TTS Container
+  - bash: |
+      set -u -e -x -o pipefail
+      . ci/functions.sh
+      . ci/load-build-secrets.sh
+
+      sr_port=$(find_free_port)  
+      echo "SR Port: $sr_port"
+
+      host_ip=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')  
+      echo "Host IP: $host_ip"
+      SR_URL="ws://$host_ip:$sr_port"  
+      vsts_setvar SR_CONTAINER_URL "$SR_URL"
+
+      docker create -p $sr_port:5000 --memory 6g --cpus 4 --name sr_container mcr.microsoft.com/azure-cognitive-services/speechservices/speech-to-text:latest EULA=accept Billing=https://$SPEECHSDK_SPEECH_REGION.api.cognitive.microsoft.com/ ApiKey=$SPEECHSDK_SPEECH_KEY
+      docker start sr_container
+    displayName: Create and start ASR Container
+  - bash: |
+      set -u -e -x -o pipefail
+      . ci/functions.sh
+      . ci/load-build-secrets.sh
+
+      lid_port=$(find_free_port)  
+      echo "LID Port: $lid_port"
+
+      host_ip=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')  
+      echo "Host IP: $host_ip"
+      LID_URL="ws://$host_ip:$lid_port"  
+      vsts_setvar LID_CONTAINER_URL "$LID_URL"
+
+      docker create -p $lid_port:5003   --memory 1g --cpus 4 --name lid_container mcr.microsoft.com/azure-cognitive-services/speechservices/language-detection:latest EULA=accept Billing=https://$SPEECHSDK_SPEECH_REGION.api.cognitive.microsoft.com/ ApiKey=$SPEECHSDK_SPEECH_KEY
+      docker start lid_container
+    displayName: Create and start LID Container
+  - bash: |
+      set -u -e -x -o pipefail
+      export ENABLE_PRIVATE_LINK_TESTS=true
+      npm run test:connection
+    displayName: Run tests
+    condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
+  - task: PublishTestResults@2
+    displayName: Publish test results
+    inputs:
+      testRunner: JUnit
+      testResultsFiles: 'test-javascript-junit.xml'
+      failTaskOnFailedTests: true
+    condition: eq(variables['SPEECHSDK_RUN_TESTS'], 'true')
+  - bash: |
+      set -u -e -x -o pipefail
+      
+      docker stop tts_container
+      docker stop sr_container
+      docker stop lid_container
+
+      docker logs tts_container > tts_container.log
+      ls -l tts_container.log
+
+      docker logs sr_container > sr_container.log
+      ls -l tts_container.log
+
+      docker logs lid_container > lid_container.log
+      ls -l tts_container.log
+
+      docker rm tts_container
+      docker rm sr_container
+      docker rm lid_container
+
+      DOCKER_LOG_DIR=$(Build.ArtifactStagingDirectory)/DockerLogs
+      mkdir -p $DOCKER_LOG_DIR
+      # Copy logs to the artifacts directory
+      cp tts_container.log $DOCKER_LOG_DIR/tts_container.log
+      cp sr_container.log $DOCKER_LOG_DIR/sr_container.log
+      cp lid_container.log $DOCKER_LOG_DIR/lid_container.log
+    displayName: Stop Containers and export logs
+    condition: and(succeededOrFailed(), eq(variables['SPEECHSDK_RUN_TESTS'], 'true'))
+  - task: ArchiveFiles@2
+    displayName: Archive Docker container logs
+    inputs:
+      rootFolderOrFile: '$(Build.ArtifactStagingDirectory)/DockerLogs'
+      includeRootFolder: false
+      archiveFile: '*.*'
+      replaceExistingArchive: false
+    condition: and(succeededOrFailed(), eq(variables['SPEECHSDK_RUN_TESTS'], 'true'))
+  - task: PublishBuildArtifacts@1  
+    retryCountOnTaskFailure: 5
+    inputs:  
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)/DockerLogs'  
+      ArtifactName: TestRunBackup
+    condition: and(succeededOrFailed(), eq(variables['SPEECHSDK_RUN_TESTS'], 'true'))
+    displayName: Publish Docker logs

--- a/ci/functions.sh
+++ b/ci/functions.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+#
+# To be sourced from depending scripts.
+
+find_free_port() {  
+  local port=1024  
+  while : ; do  
+      # Check if the port is in use using netstat  
+      if ! netstat -tuln | grep -q ":$port "; then  
+          echo $port  
+          return  
+      fi  
+      port=$((port + 1))  
+  done  
+}
+
+# Ensure now logging of commands to not confuse the agent...
+vsts_setvar() {
+  set +x
+  echo Setting Build Variable $1=$2
+  echo "##vso[task.setvariable variable=$1]$2"
+  export "$1"="$2"
+}

--- a/ci/get-docker-image.yml
+++ b/ci/get-docker-image.yml
@@ -1,0 +1,43 @@
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+#
+
+parameters:
+- name: DockerImages
+  type: string
+  # Space-separated base name of the images
+  default: ''
+
+steps:
+# Single-image case
+- ${{ if not(contains(parameters.DockerImages, ' ')) }}:
+  - task: Docker@1
+    displayName: (Docker) Pull image
+    inputs:
+      command: pull
+      arguments: ${{ parameters.DockerImages }}
+
+# Multiple-image case
+- ${{ if contains(parameters.DockerImages, ' ') }}:
+  - bash: |
+      set -u -e -o pipefail
+      
+      forPull=()
+      for i in ${{ parameters.DockerImages }}; do
+        forPull+=("$i")
+      done
+
+      # First do all the pulls in parallel, for up to 2 times.
+      maxAttempts=2
+      attempt=0
+      [[ ${#forPull[@]} = 0 ]] ||
+        while ((++attempt <= maxAttempts)); do
+          printf "%s\0" "${forPull[@]}" |
+            xargs --verbose --no-run-if-empty --max-args=1 --null --max-procs=4 \
+              docker pull &&
+                break ||
+                  continue # needed because of "set -e"
+      done
+      ((attempt <= maxAttempts)) || exitWithError "Could not pull all images"
+    displayName: (Docker) Pull images

--- a/ci/load-build-secrets.sh
+++ b/ci/load-build-secrets.sh
@@ -1,0 +1,47 @@
+
+export JSONSETTINGS_SCRIPT_FOLDER="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"  
+
+if [[ ! $(ls "$JSONSETTINGS_SCRIPT_FOLDER/secrets/test.subscriptions.regions.json") ]]; then
+  echo "WARNING: No subscriptions JSON found. Skipping all assignment and use of settings from JSON."
+else
+  function getSetting() {
+    set -euo pipefail
+    if [[ ! "${SPEECHSDK_GETSETTING_CMD:-}" ]]; then
+      if [[ $(which jq) ]]; then
+        # The jq tool is a much more appropriate and efficient means for this; use it if it's available
+        export SPEECHSDK_GETSETTING_CMD="cat \"${JSONSETTINGS_SCRIPT_FOLDER}/\$1\" | jq -jr \".\$2\""
+      else
+        echo "jq not found, quitting"
+        exit -1
+      fi
+    fi
+    eval "$SPEECHSDK_GETSETTING_CMD"
+  }
+
+  SPEECHSDK_SPEECH_KEY=$( getSetting './secrets/test.subscriptions.regions.json' 'UnifiedSpeechSubscription.Key' )
+  SPEECHSDK_SPEECH_REGION=$( getSetting './secrets/test.subscriptions.regions.json' 'UnifiedSpeechSubscription.Region' )
+  
+# Redaction: pipe anything that could contain known sensitive information like keys into global_redact
+  SPEECHSDK_GLOBAL_STRINGS_TO_REDACT=(
+    $SPEECHSDK_SPEECH_KEY
+  )
+
+  function redact_input_with {
+    # N.B. receiving stdin as first command in function. Avoid calling this repeatedly (e.g. once per line of large
+    # output) as there's a startup cost to invoking perl. Use stream redirection as needed, instead.
+    perl -MIO::Handle -lpe \
+      'BEGIN { 
+          STDOUT->autoflush(1); 
+          STDERR->autoflush(1); 
+          if (@ARGV) { 
+              $re = sprintf "(?:%s)", (join "|", map { quotemeta $_ } splice @ARGV); 
+              $re = qr/$re/ 
+          } 
+      } 
+      $re and s/$re/***/gi' $@
+  }
+
+  function global_redact {
+    redact_input_with "${SPEECHSDK_GLOBAL_STRINGS_TO_REDACT[@]}"
+  }
+fi

--- a/ci/version.cjs
+++ b/ci/version.cjs
@@ -28,7 +28,8 @@
 
     if (process.env.SYSTEM_COLLECTIONID === "26f8e8b1-373f-4f65-96fc-d17a59b38306" &&
          process.env.SYSTEM_DEFINITIONID === "198") {
-
+        
+        console.log("Running in Azure DevOps build pipeline")
         inAzureDevOps = true
 
         if (process.env.BUILD_SOURCEBRANCH.match("^refs/heads/release/")) {
@@ -38,6 +39,12 @@
              process.env.BUILD_REASON === "Manual")) {
             buildType = "int"
         }
+    } else if (process.env.CI === "true") {
+        console.log("Running in GitHub Actions")
+
+    } else if (process.env.CI === "false") {
+        console.log("Running in local dev environment")
+        buildType = "dev"
     }
 
     // Check our version constraints
@@ -67,6 +74,7 @@
     }
 
     if (inAzureDevOps) {
+        console.log("Setting Azure DevOps build variable SPEECHSDK_SEMVER2NOMETA to " + versionToUse);
         console.log("##vso[task.setvariable variable=SPEECHSDK_SEMVER2NOMETA]" + versionToUse);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsoft-cognitiveservices-speech-sdk",
-  "version": "1.41.0-alpha.0.1",
+  "version": "1.44.0-alpha.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsoft-cognitiveservices-speech-sdk",
-      "version": "1.41.0-alpha.0.1",
+      "version": "1.44.0-alpha.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/webrtc": "^0.0.37",
@@ -17,9 +17,11 @@
         "ws": "^7.5.6"
       },
       "devDependencies": {
+        "@azure/identity": "^4.9.1",
         "@types/bent": "^7.3.2",
         "@types/jest": "^27.0.0",
         "@types/node": "^12.12.30",
+        "@types/node-fetch": "^2.6.12",
         "@types/prettier": "<2.6.0",
         "@types/request": "^2.48.3",
         "@types/rimraf": "^3.0.0",
@@ -42,6 +44,7 @@
         "gulp-typescript": "^5.0.1",
         "jest": "^27.0.0",
         "jest-junit": "^12.0.0",
+        "node-fetch": "^2.6.7",
         "rimraf": "^3.0.2",
         "semver": "^6.3.0",
         "source-map-loader": "^3.0.1",
@@ -74,6 +77,255 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
+      "integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.3.tgz",
+      "integrity": "sha512-/wGw8fJ4mdpJ1Cum7s1S+VQyXt1ihwKLzfabS1O/RDADnmzVc01dHn44qD0BvGH6KlZNzOMW95tEpKqhkCChPA==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.9.1",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-client/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.1.tgz",
+      "integrity": "sha512-zHeoI3NCs53lLBbWNzQycjnYKsA1CVKlnzSNuSFcUDwBp8HHVObePxrM7HaX+Ha5Ks639H7chNC9HOaIhNS03w==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.8.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
+      "integrity": "sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.11.0.tgz",
+      "integrity": "sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.9.1.tgz",
+      "integrity": "sha512-986D7Cf1AOwYqSDtO/FnMAyk/Jc8qpftkGsxuehoh4F85MhQ4fICBGX/44+X1y78lN4Sqib3Bsoaoh/FvOGgmg==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^4.2.0",
+        "@azure/msal-node": "^3.5.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.4.tgz",
+      "integrity": "sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/logger/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.11.0.tgz",
+      "integrity": "sha512-0p5Ut3wORMP+975AKvaSPIO4UytgsfAvJ7RxaTx+nkP+Hpkmm93AuiMkBWKI2x9tApU/SLgIyPz/ZwLYUIWb5Q==",
+      "dev": true,
+      "dependencies": {
+        "@azure/msal-common": "15.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.5.1.tgz",
+      "integrity": "sha512-oxK0khbc4Bg1bKQnqDr7ikULhVL2OHgSrIq0Vlh4b6+hm4r0lr6zPMQE8ZvmacJuh+ZZGKBM5iIObhF1q1QimQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.5.1.tgz",
+      "integrity": "sha512-dkgMYM5B6tI88r/oqf5bYd93WkenQpaWwiszJDk7avVjso8cmuKRTW97dA1RMi6RhihZFLtY1VtWxU9+sW2T5g==",
+      "dev": true,
+      "dependencies": {
+        "@azure/msal-common": "15.5.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1218,6 +1470,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/prettier": {
       "version": "2.3.2",
       "dev": true,
@@ -1334,22 +1611,6 @@
         "typescript": "*"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -1405,22 +1666,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/debug": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.27.0",
       "dev": true,
@@ -1458,22 +1703,6 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
           "optional": true
         }
       }
@@ -1526,22 +1755,6 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
           "optional": true
         }
       }
@@ -2449,6 +2662,12 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "dev": true,
@@ -2460,6 +2679,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bytesish": {
@@ -2476,6 +2710,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2825,10 +3072,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "license": "MIT",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2886,6 +3134,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -3066,6 +3354,20 @@
         "node": "*"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexify": {
       "version": "3.7.1",
       "dev": true,
@@ -3097,6 +3399,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3197,15 +3508,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-abstract/node_modules/has-symbols": {
-      "version": "1.0.3",
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-module-lexer": {
@@ -3213,6 +3531,33 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
       "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
       "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.0.0",
@@ -3566,22 +3911,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/debug": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
@@ -4378,9 +4707,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
-      "license": "MIT"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -4430,13 +4763,24 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4448,6 +4792,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stdin": {
@@ -4621,6 +4978,18 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -5270,9 +5639,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.2",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5281,17 +5651,30 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -5610,6 +5993,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -5644,6 +6042,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-negated-glob": {
@@ -5830,6 +6246,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "dev": true,
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -6728,6 +7159,61 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dev": true,
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dev": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "dev": true,
@@ -6848,6 +7334,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "dev": true,
@@ -6857,6 +7379,12 @@
       "version": "4.6.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true
     },
     "node_modules/lodash.some": {
       "version": "4.6.0",
@@ -6921,6 +7449,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/memoizee": {
@@ -7037,8 +7574,9 @@
       "license": "MIT"
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mute-stdout": {
       "version": "2.0.0",
@@ -7074,6 +7612,52 @@
       "version": "1.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -7230,6 +7814,24 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.1.tgz",
+      "integrity": "sha512-zy1wx4+P3PfhXSEPJNtZmJXfhkkIaxU1VauWIrDZw1O7uJRDRJtKr9n3Ic4NgbA16KyOxOXO2ng9gYwCdXuSXA==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7830,6 +8432,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-async": {
@@ -8957,17 +9571,6 @@
         "has-bigints": "^1.0.2",
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/unbox-primitive/node_modules/has-symbols": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "microsoft-cognitiveservices-speech-sdk",
   "author": "Microsoft Corporation",
   "homepage": "https://docs.microsoft.com/azure/cognitive-services/speech-service/",
-  "version": "1.41.0-alpha.0.1",
+  "version": "1.44.0-alpha.0.1",
   "license": "MIT",
   "description": "Microsoft Cognitive Services Speech SDK for JavaScript",
   "keywords": [
@@ -47,9 +47,11 @@
     "REDIST.txt"
   ],
   "devDependencies": {
+    "@azure/identity": "^4.9.1",
     "@types/bent": "^7.3.2",
     "@types/jest": "^27.0.0",
     "@types/node": "^12.12.30",
+    "@types/node-fetch": "^2.6.12",
     "@types/prettier": "<2.6.0",
     "@types/request": "^2.48.3",
     "@types/rimraf": "^3.0.0",
@@ -72,6 +74,7 @@
     "gulp-typescript": "^5.0.1",
     "jest": "^27.0.0",
     "jest-junit": "^12.0.0",
+    "node-fetch": "^2.6.7",
     "rimraf": "^3.0.2",
     "semver": "^6.3.0",
     "source-map-loader": "^3.0.1",
@@ -84,6 +87,8 @@
   "scripts": {
     "build": "gulp compress --gulpfile gulpfile.cjs && gulp build --gulpfile gulpfile.cjs",
     "test": "npm run lint && npm run jest --coverage",
+    "test:connection": "node -e \"process.platform === 'win32' ? require('child_process').execSync('powershell -File ./scripts/run-connection-tests.ps1', {stdio: 'inherit'}) : require('child_process').execSync('./scripts/run-connection-tests.sh', {stdio: 'inherit'})\"",
+    "test:non-connection": "node -e \"process.platform === 'win32' ? require('child_process').execSync('powershell -File ./scripts/run-non-connection-tests.ps1', {stdio: 'inherit'}) : require('child_process').execSync('./scripts/run-non-connection-tests.sh', {stdio: 'inherit'})\"",
     "jest": "jest",
     "lint": "eslint -c .eslintrc.cjs --ext .ts src",
     "linttest": "eslint -c .eslintrc.cjs --ext .ts tests",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,53 @@
+# Test Scripts Documentation
+
+This folder contains scripts to help run different test configurations for the Speech SDK.
+
+## Connection Type Tests
+
+The Speech SDK tests include tests that verify different connection types using the `SpeechConnectionType` enum. These tests are controlled by the `RUN_CONNECTION_TYPE_TESTS` environment variable and are identifiable by their "Connection Tests" describe block names.
+
+### Available Scripts
+
+1. **Run Connection Type Tests Only**
+   - **Linux/Mac**: `./scripts/run-connection-tests.sh`
+   - **Windows**: `.\scripts\run-connection-tests.ps1`
+   - **npm**: `npm run test:connection`
+
+   This runs only the connection type tests by:
+   - Setting the `RUN_CONNECTION_TYPE_TESTS` environment variable to `true` to enable these tests
+   - Using Jest's `--testNamePattern="Connection Tests"` to filter for tests with "Connection Tests" in their describe blocks
+
+2. **Run All Non-Connection Type Tests**
+   - **Linux/Mac**: `./scripts/run-non-connection-tests.sh`
+   - **Windows**: `.\scripts\run-non-connection-tests.ps1`
+   - **npm**: `npm run test:non-connection`
+
+   This runs all tests except the connection type tests by:
+   - Setting `RUN_CONNECTION_TYPE_TESTS` to `false` (though this isn't strictly necessary given the filter)
+   - Using Jest's `--testNamePattern` with a regex that excludes any tests with "Connection Tests" in their describe blocks
+
+## How This Works
+
+The solution combines two filtering mechanisms:
+
+1. **Environment Variable Filtering**:
+   - The `SpeechConfigConnectionFactory.runConnectionTest()` method in `SpeechConfigConnectionFactories.ts` checks the `RUN_CONNECTION_TYPE_TESTS` environment variable.
+   - When this variable is not `true`, connection type tests are skipped.
+
+2. **Jest Name Pattern Filtering**:
+   - We use Jest's built-in filtering capabilities to focus on or exclude tests based on their describe block names.
+   - Connection type tests are identifiable by having "Connection Tests" in their describe blocks.
+
+This two-level filtering ensures that:
+- When running connection tests, only those tests run and other tests are excluded
+- When running non-connection tests, the connection tests are completely excluded
+
+## Additional Notes
+
+- Some connection type tests require additional environment variables to be set, such as:
+  - `SR_CONTAINER_URL`, `LID_CONTAINER_URL`, and `TTS_CONTAINER_URL` for container tests
+  - `RUN_PRIVAETE_LINK_TESTS` for private link tests
+
+- Make sure you have all necessary credentials and environment variables set up before running these tests.
+
+- The test filtering is based on the naming conventions in the test files, so if those conventions change, the filters may need to be updated.

--- a/scripts/run-connection-tests.ps1
+++ b/scripts/run-connection-tests.ps1
@@ -1,0 +1,8 @@
+# PowerShell script to run only the connection type tests
+
+# Set the environment variable to enable connection type tests
+$env:RUN_CONNECTION_TYPE_TESTS = "true"
+
+# Run Jest with the connection type tests enabled and filter to only run tests in describe blocks with "Connection Tests"
+Write-Host "Running connection type tests only..."
+npx jest --testNamePattern="Connection Tests"

--- a/scripts/run-connection-tests.sh
+++ b/scripts/run-connection-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Script to run only the connection type tests
+
+# Set the environment variable to enable connection type tests
+export RUN_CONNECTION_TYPE_TESTS=true
+
+# Run Jest with the connection type tests enabled and filter to only run tests in describe blocks with "Connection Tests"
+echo "Running connection type tests only..."
+npx jest --testNamePattern="Connection Tests"

--- a/scripts/run-non-connection-tests.ps1
+++ b/scripts/run-non-connection-tests.ps1
@@ -1,0 +1,8 @@
+# PowerShell script to run all tests except the connection type tests
+
+# Ensure the environment variable is not set to enable connection type tests
+$env:RUN_CONNECTION_TYPE_TESTS = "false"
+
+# Run Jest with a test name pattern that excludes "Connection Tests"
+Write-Host "Running all non-connection type tests..."
+npx jest --testNamePattern="^(?!.*Connection Tests).*$"

--- a/scripts/run-non-connection-tests.sh
+++ b/scripts/run-non-connection-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Script to run all tests except the connection type tests
+
+# Ensure the environment variable is not set to enable connection type tests
+export RUN_CONNECTION_TYPE_TESTS=false
+
+# Run Jest with a test name pattern that excludes "Connection Tests"
+echo "Running all non-connection type tests..."
+npx jest --testNamePattern="^(?!.*Connection Tests).*$"

--- a/src/common.browser/WebsocketMessageAdapter.ts
+++ b/src/common.browser/WebsocketMessageAdapter.ts
@@ -87,6 +87,7 @@ export class WebsocketMessageAdapter {
 
         // Add the connection ID to the headers
         this.privHeaders[HeaderNames.ConnectionId] = this.privConnectionId;
+        this.privHeaders.connectionId = this.privConnectionId;
 
         this.privLastErrorReceived = "";
     }
@@ -329,7 +330,7 @@ export class WebsocketMessageAdapter {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     private getAgent(): http.Agent {
         // eslint-disable-next-line @typescript-eslint/unbound-method
-        const agent: { proxyInfo: ProxyInfo } = new Agent.Agent(this.createConnection) as unknown as { proxyInfo: ProxyInfo } ;
+        const agent: { proxyInfo: ProxyInfo } = new Agent.Agent(this.createConnection) as unknown as { proxyInfo: ProxyInfo };
 
         if (this.proxyInfo !== undefined &&
             this.proxyInfo.HostName !== undefined &&

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -370,9 +370,9 @@ export abstract class ServiceRecognizerBase implements IDisposable {
 
     public async dispose(reason?: string): Promise<void> {
         this.privIsDisposed = true;
-        if (this.privConnectionConfigurationPromise !== undefined) {
+        if (this.privConnectionPromise !== undefined) {
             try {
-                const connection: IConnection = await this.privConnectionConfigurationPromise;
+                const connection: IConnection = await this.privConnectionPromise;
                 await connection.dispose(reason);
             } catch (error) {
                 // The connection is in a bad state. But we're trying to kill it, so...

--- a/src/common.speech/SpeechConnectionFactory.ts
+++ b/src/common.speech/SpeechConnectionFactory.ts
@@ -102,6 +102,7 @@ export class SpeechConnectionFactory extends ConnectionFactoryBase {
             headers[authInfo.headerName] = authInfo.token;
         }
         headers[HeaderNames.ConnectionId] = connectionId;
+        headers.connectionId = connectionId;
 
         const enableCompression: boolean = config.parameters.getProperty("SPEECH-EnableWebsocketCompression", "false") === "true";
 

--- a/src/sdk/SpeechTranslationConfig.ts
+++ b/src/sdk/SpeechTranslationConfig.ts
@@ -92,7 +92,7 @@ export abstract class SpeechTranslationConfig extends SpeechConfig {
      * @param {string} subscriptionKey - The subscription key. If a subscription key is not specified, an authorization token must be set.
      * @returns {SpeechConfig} A speech factory instance.
      */
-    public static fromHost(hostName: URL, subscriptionKey?: string): SpeechConfig {
+    public static fromHost(hostName: URL, subscriptionKey?: string): SpeechTranslationConfig {
         Contracts.throwIfNull(hostName, "hostName");
 
         const speechImpl: SpeechTranslationConfigImpl = new SpeechTranslationConfigImpl();

--- a/tests/CogSvcsTokenCredential.ts
+++ b/tests/CogSvcsTokenCredential.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/identity";
+// We'll use dynamic require instead of static import for fetch
+
+/**
+ * Represents a token credential for Cognitive Services that can be used to authenticate with Speech services.
+ * This implements the TokenCredential interface from @azure/identity.
+ */
+export class CogSvcsTokenCredential implements TokenCredential {
+    private subscriptionKey: string;
+    private region: string;
+    private cachedToken: string | null = null;
+    private tokenExpirationTime: number = 0;
+    
+    /**
+     * Creates a new instance of the CogSvcsTokenCredential class.
+     * @param subscriptionKey The Cognitive Services subscription key.
+     * @param region The region for the Cognitive Services resource.
+     */
+    constructor(subscriptionKey: string, region: string) {
+        this.subscriptionKey = subscriptionKey;
+        this.region = region;
+    }
+    
+    /**
+     * Gets a token for the specified resource.
+     * @param scopes The scopes for which the token is requested.
+     * @param options The options for the token request.
+     * @returns A promise that resolves to the access token.
+     */
+    async getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken> {
+        // Check if we have a cached token that's still valid
+        const now = Date.now();
+        if (this.cachedToken && now < this.tokenExpirationTime - 30000) { // 30-second buffer
+            return {
+                token: this.cachedToken,
+                expiresOnTimestamp: this.tokenExpirationTime
+            };
+        }
+        
+        try {
+            // Get a new token
+            const token = await this.fetchToken();
+            
+            // Cognitive Services tokens typically expire in 10 minutes (600 seconds)
+            const expiresIn = 600;
+            this.tokenExpirationTime = now + expiresIn * 1000;
+            this.cachedToken = token;
+            
+            return {
+                token: token,
+                expiresOnTimestamp: this.tokenExpirationTime
+            };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`Error getting Cognitive Services token: ${errorMessage}`);
+        }
+    }
+    
+    /**
+     * Fetches a token from the Cognitive Services token endpoint.
+     * @returns A promise that resolves to the token.
+     */
+    private async fetchToken(): Promise<string> {
+        try {
+            // Import fetch dynamically to handle various environments
+            const nodeFetch = require("node-fetch");
+            
+            const endpoint = `https://${this.region}.api.cognitive.microsoft.com/sts/v1.0/issueToken`;
+            const response = await nodeFetch(endpoint, {
+                method: 'POST',
+                headers: {
+                    'Ocp-Apim-Subscription-Key': this.subscriptionKey,
+                    'Content-Type': 'application/json'
+                }
+            });
+            
+            if (!response.ok) {
+                throw new Error(`Failed to get token: ${response.status} ${response.statusText}`);
+            }
+            
+            return await response.text();
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`Error getting Cognitive Services token: ${errorMessage}`);
+        }
+    }
+}

--- a/tests/Settings.ts
+++ b/tests/Settings.ts
@@ -6,7 +6,7 @@ import { SubscriptionsRegionsKeys } from "./SubscriptionRegion";
 
 export class Settings {
 
-    public static RetryCount: number = 1;
+    public static RetryCount: number = 0;
     // subscription
     public static SpeechSubscriptionKey: string = "<<YOUR_SUBSCRIPTION_KEY>>";
     public static SpeechRegion: string = "<<YOUR_REGION>>";

--- a/tests/Settings.ts
+++ b/tests/Settings.ts
@@ -6,7 +6,7 @@ import { SubscriptionsRegionsKeys } from "./SubscriptionRegion";
 
 export class Settings {
 
-    public static RetryCount: number = 0;
+    public static RetryCount: number = 3;
     // subscription
     public static SpeechSubscriptionKey: string = "<<YOUR_SUBSCRIPTION_KEY>>";
     public static SpeechRegion: string = "<<YOUR_REGION>>";

--- a/tests/SpeechConfigConnectionFactories.ts
+++ b/tests/SpeechConfigConnectionFactories.ts
@@ -1,0 +1,534 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { DefaultAzureCredential, TokenCredential } from "@azure/identity";
+// We'll use dynamic require instead of static import for fetch
+import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
+import { Settings } from "./Settings";
+import { SpeechConnectionType } from "./SpeechConnectionTypes";
+import { SpeechServiceType } from "./SpeechServiceTypes";
+import { ConfigLoader } from "./ConfigLoader";
+import { SubscriptionRegion, SubscriptionsRegionsKeys } from "./SubscriptionRegion";
+import { CogSvcsTokenCredential } from "./CogSvcsTokenCredential";
+
+/**
+ * Defines the speech configuration types that can be created by the factory.
+ * This allows us to use a generic approach similar to the C# implementation.
+ */
+type ConfigType = sdk.SpeechConfig | sdk.SpeechTranslationConfig;
+
+/**
+ * Helper class for creating speech configurations based on different connection types.
+ * This provides functionality similar to the C# implementation in Carbon's end-to-end tests.
+ */
+export class SpeechConfigConnectionFactory {
+    /**
+     * Gets a speech configuration of the specified type using the given connection type.
+     * This is a generic method that can create different types of speech configurations.
+     *
+     * @param connectionType The connection type to create a config for.
+     * @param serviceType The speech service type (SR, TTS, LID).
+     * @param isTranslationConfig Whether to create a SpeechTranslationConfig instead of SpeechConfig.
+     * @returns A Promise that resolves to the created speech config of the specified type.
+     */
+    public static async getSpeechConfig<T extends ConfigType>(
+        connectionType: SpeechConnectionType,
+        serviceType: SpeechServiceType = SpeechServiceType.SpeechRecognition,
+        isTranslationConfig: boolean = false
+    ): Promise<T> {
+        const config = await this.createConfig<T>(connectionType, serviceType, isTranslationConfig);
+        return config;
+    }
+
+    /**
+     * Gets a speech configuration specifically for text-to-speech
+     * Convenience method that calls getSpeechConfig with TextToSpeech serviceType
+     */
+    public static async getSpeechSynthesisConfig(
+        connectionType: SpeechConnectionType = SpeechConnectionType.Subscription
+    ): Promise<sdk.SpeechConfig> {
+        return this.getSpeechConfig(connectionType, SpeechServiceType.TextToSpeech, false);
+    }
+
+    /**
+     * Gets a speech configuration specifically for speech recognition
+     * Convenience method that calls getSpeechConfig with SpeechRecognition serviceType
+     */
+    public static async getSpeechRecognitionConfig(
+        connectionType: SpeechConnectionType = SpeechConnectionType.Subscription
+    ): Promise<sdk.SpeechConfig> {
+        return this.getSpeechConfig(connectionType, SpeechServiceType.SpeechRecognition, false);
+    }
+
+    /**
+     * Gets a speech configuration specifically for language identification
+     * Convenience method that calls getSpeechConfig with LanguageIdentification serviceType
+     */
+    public static async getLanguageIdentificationConfig(
+        connectionType: SpeechConnectionType = SpeechConnectionType.Subscription
+    ): Promise<sdk.SpeechConfig> {
+        return this.getSpeechConfig(connectionType, SpeechServiceType.LanguageIdentification, false);
+    }
+
+    /**
+     * Creates the appropriate configuration based on the connection type.
+     */
+    private static async createConfig<T extends ConfigType>(
+        connectionType: SpeechConnectionType,
+        serviceType: SpeechServiceType,
+        isTranslationConfig: boolean
+    ): Promise<T> {
+        switch (connectionType) {
+            case SpeechConnectionType.Subscription:
+                return this.buildSubscriptionConfig<T>(isTranslationConfig);
+
+            case SpeechConnectionType.LegacyCogSvcsTokenAuth:
+                const cogSvcsToken = await this.getToken(
+                    Settings.SpeechSubscriptionKey,
+                    Settings.SpeechRegion
+                );
+                return this.buildAuthorizationConfig<T>(cogSvcsToken, Settings.SpeechRegion, isTranslationConfig);
+
+            case SpeechConnectionType.LegacyEntraIdTokenAuth:
+                const aadToken = await this.getAadToken(
+                    SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION
+                );
+                return this.buildAuthorizationConfig<T>(
+                    aadToken,
+                    this.getSubscriptionRegion(SubscriptionsRegionsKeys.AAD_SPEECH_CLIENT_SECRET).Region,
+                    isTranslationConfig
+                );
+
+            case SpeechConnectionType.CloudFromHost:
+                const hostSuffix = this.getSpeechHostSuffix(serviceType);
+                return this.buildHostConfig<T>(
+                    new URL(`wss://${Settings.SpeechRegion}.${hostSuffix}`),
+                    Settings.SpeechSubscriptionKey,
+                    isTranslationConfig
+                );
+
+            case SpeechConnectionType.CloudFromEndpointWithKeyAuth:
+                return this.buildCloudEndpointKeyConfig<T>(isTranslationConfig);
+
+            case SpeechConnectionType.CloudFromEndpointWithCogSvcsTokenAuth:
+                return this.buildCloudEndpointConfigWithCogSvcsToken<T>(isTranslationConfig);
+
+            case SpeechConnectionType.CloudFromEndpointWithEntraIdTokenAuth:
+                return this.buildCloudEndpointConfigWithEntraId<T>(isTranslationConfig);
+
+            case SpeechConnectionType.ContainerFromHost:
+                return this.buildContainerSpeechConfig<T>(serviceType, isTranslationConfig);
+
+            case SpeechConnectionType.ContainerFromEndpoint:
+                return this.buildContainerEndpointSpeechConfig<T>(serviceType, isTranslationConfig);
+
+            case SpeechConnectionType.PrivateLinkWithKeyAuth:
+                return this.buildPrivateLinkWithKeyConfig<T>(undefined, isTranslationConfig);
+
+            case SpeechConnectionType.PrivateLinkWithCogSvcsTokenAuth:
+                return this.buildPrivateLinkEndpointWithCogSvcsToken<T>(isTranslationConfig);
+
+            case SpeechConnectionType.PrivateLinkWithEntraIdTokenAuth:
+                return this.buildPrivateLinkEndpointWithEntraId<T>(isTranslationConfig);
+
+            case SpeechConnectionType.LegacyPrivateLinkWithKeyAuth:
+                return this.buildLegacyPrivateLinkWithKeyConfig<T>(isTranslationConfig, serviceType);
+
+            default:
+                throw new Error(`Unsupported connection type: ${SpeechConnectionType[connectionType]}`);
+        }
+    }
+
+    /**
+     * Gets the appropriate host suffix based on the speech service type.
+     */
+    private static getSpeechHostSuffix(serviceType: SpeechServiceType): string {
+        switch (serviceType) {
+            case SpeechServiceType.TextToSpeech:
+                return "tts.speech.microsoft.com";
+            case SpeechServiceType.SpeechRecognition:
+            case SpeechServiceType.LanguageIdentification:
+            default:
+                return "stt.speech.microsoft.com";
+        }
+    }
+
+    /**
+     * Gets the appropriate container URL environment variable based on the service type.
+     */
+    private static getContainerUrlEnvVar(serviceType: SpeechServiceType): string {
+        switch (serviceType) {
+            case SpeechServiceType.TextToSpeech:
+                return "TTS_CONTAINER_URL";
+            case SpeechServiceType.LanguageIdentification:
+                return "LID_CONTAINER_URL";
+            case SpeechServiceType.SpeechRecognition:
+            default:
+                return "SR_CONTAINER_URL";
+        }
+    }
+
+    /**
+     * Gets a Cognitive Services token for the specified subscription key and region.
+     */
+    private static async getToken(subscriptionKey: string, region: string): Promise<string> {
+        try {
+            // Import fetch dynamically to handle various environments
+            const nodeFetch = require("node-fetch");
+
+            const endpoint = `https://${region}.api.cognitive.microsoft.com/sts/v1.0/issueToken`;
+            const response = await nodeFetch(endpoint, {
+                headers: {
+                    "Content-Type": "application/json",
+                    "Ocp-Apim-Subscription-Key": subscriptionKey,
+                },
+                method: "POST"
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to get token: ${response.status} ${response.statusText}`);
+            }
+
+            return await response.text();
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`Error getting token: ${errorMessage}`);
+        }
+    }
+
+    /**
+     * Gets an Azure AD token for the specified subscription key from the SubscriptionsRegionsMap.
+     * Uses the DefaultAzureCredential from @azure/identity to acquire tokens.
+     * 
+     * @param subscriptionKey The key in the SubscriptionsRegionsMap that contains AAD configuration
+     * @returns A promise that resolves to the access token
+     */
+    private static async getAadToken(subscriptionKey: string): Promise<string> {
+        try {
+            // Get the subscription region details
+            const subscriptionRegion = this.getSubscriptionRegion(subscriptionKey);
+
+            if (!subscriptionRegion.ResourceId) {
+                throw new Error(`No ResourceId found for subscription key: ${subscriptionKey}`);
+            }
+
+            const scope = "https://cognitiveservices.azure.com/.default";
+
+            // Create DefaultAzureCredential to handle various authentication scenarios
+            const credential = new DefaultAzureCredential();
+
+            // Get token from the credential
+            const tokenResponse = await credential.getToken(scope);
+
+            if (!tokenResponse || !tokenResponse.token) {
+                throw new Error("Failed to acquire token from Azure AD");
+            }
+
+            return "aad#" + subscriptionRegion.ResourceId + "#" + tokenResponse.token;
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`Error getting AAD token: ${errorMessage}`);
+        }
+    }
+
+    /**
+     * Gets the subscription region details from the config loader.
+     */
+    private static getSubscriptionRegion(key: string): SubscriptionRegion {
+        const configLoader = ConfigLoader.instance;
+        const subscriptionRegion = configLoader.getSubscriptionRegion(key);
+
+        if (!subscriptionRegion) {
+            throw new Error(`Could not find subscription region for key: ${key}`);
+        }
+
+        return subscriptionRegion;
+    }
+
+    /**
+     * Builds a speech config from a subscription key and region.
+     */
+    private static buildSubscriptionConfig<T extends ConfigType>(isTranslationConfig: boolean): T {
+        const subscriptionRegion = this.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+        const key = subscriptionRegion.Key;
+        const region = subscriptionRegion.Region;
+
+        if (isTranslationConfig) {
+            return sdk.SpeechTranslationConfig.fromSubscription(key, region) as unknown as T;
+        } else {
+            const config: T = sdk.SpeechConfig.fromSubscription(key, region) as unknown as T;
+            return config;
+        }
+    }
+
+    /**
+     * Builds a speech config from an authorization token and region.
+     */
+    private static buildAuthorizationConfig<T extends ConfigType>(
+        token: string,
+        region: string,
+        isTranslationConfig: boolean
+    ): T {
+        if (isTranslationConfig) {
+            return sdk.SpeechTranslationConfig.fromAuthorizationToken(token, region) as unknown as T;
+        } else {
+            return sdk.SpeechConfig.fromAuthorizationToken(token, region) as unknown as T;
+        }
+    }
+
+    /**
+     * Builds a speech config from a host URL and key.
+     */
+    private static buildHostConfig<T extends ConfigType>(
+        host: URL,
+        key: string,
+        isTranslationConfig: boolean
+    ): T {
+        if (isTranslationConfig) {
+            return sdk.SpeechTranslationConfig.fromHost(host, key) as unknown as T;
+        } else {
+            return sdk.SpeechConfig.fromHost(host, key) as unknown as T;
+        }
+    }
+
+    /**
+     * Builds a cloud endpoint config with key authentication.
+     */
+    private static buildCloudEndpointKeyConfig<T extends ConfigType>(isTranslationConfig: boolean): T {
+        const subscriptionRegion = this.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+        const key = subscriptionRegion.Key;
+        const endpoint = subscriptionRegion.Endpoint;
+
+        if (!endpoint) {
+            throw new Error("Endpoint is not defined for the subscription");
+        }
+
+        if (isTranslationConfig) {
+            return sdk.SpeechTranslationConfig.fromEndpoint(new URL(endpoint), key) as unknown as T;
+        } else {
+            return sdk.SpeechConfig.fromEndpoint(new URL(endpoint), key) as unknown as T;
+        }
+    }
+
+    /**
+     * Builds a cloud endpoint config with Cognitive Services token authentication.
+     */
+    private static buildCloudEndpointConfigWithCogSvcsToken<T extends ConfigType>(
+        isTranslationConfig: boolean
+    ): T {
+        const subscriptionRegion = this.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+        const endpoint = subscriptionRegion.Endpoint;
+
+        if (!endpoint) {
+            throw new Error("Endpoint is not defined for the subscription");
+        }
+
+        const credential = new CogSvcsTokenCredential(
+            subscriptionRegion.Key,
+            subscriptionRegion.Region
+        );
+
+        return this.buildEndpointWithTokenCredential<T>(credential, endpoint, isTranslationConfig);
+    }
+
+    /**
+     * Builds a cloud endpoint config with Entra ID token authentication.
+     */
+    private static buildCloudEndpointConfigWithEntraId<T extends ConfigType>(isTranslationConfig: boolean): T {
+        const subscriptionRegion = this.getSubscriptionRegion(SubscriptionsRegionsKeys.AAD_SPEECH_CLIENT_SECRET);
+        const endpoint = subscriptionRegion.Endpoint;
+
+        if (!endpoint) {
+            throw new Error("Endpoint is not defined for the AAD subscription");
+        }
+
+        const credential = new DefaultAzureCredential();
+
+        return this.buildEndpointWithTokenCredential<T>(credential, endpoint, isTranslationConfig);
+    }
+
+    /**
+     * Builds a container speech config.
+     */
+    private static buildContainerSpeechConfig<T extends ConfigType>(
+        serviceType: SpeechServiceType,
+        isTranslationConfig: boolean
+    ): T {
+        const containerEnvVar = this.getContainerUrlEnvVar(serviceType);
+        const containerUrl = process.env[containerEnvVar];
+
+        if (!containerUrl) {
+            throw new Error(`${containerEnvVar} environment variable is not set`);
+        }
+
+        return this.buildHostConfig<T>(new URL(containerUrl), Settings.SpeechSubscriptionKey, isTranslationConfig);
+    }
+
+    /**
+     * Builds a container endpoint speech config.
+     */
+    private static buildContainerEndpointSpeechConfig<T extends ConfigType>(
+        serviceType: SpeechServiceType,
+        isTranslationConfig: boolean
+    ): T {
+        const containerEnvVar = this.getContainerUrlEnvVar(serviceType);
+        const containerUrl = process.env[containerEnvVar];
+
+        if (!containerUrl) {
+            throw new Error(`${containerEnvVar} environment variable is not set`);
+        }
+
+        throw new Error("Containers do not yet support /stt/ or /tts/ routes.");
+    }
+
+    /**
+     * Builds a private link config with key authentication.
+     */
+    private static buildPrivateLinkWithKeyConfig<T extends ConfigType>(
+        path?: string,
+        isTranslationConfig: boolean = false
+    ): T {
+        if (!this.checkPrivateLinkTestsEnabled()) {
+            throw new Error("Private link testing is not enabled");
+        }
+
+        const subscriptionRegion = this.getSubscriptionRegion("PrivateLinkSpeechResource");
+        const key = subscriptionRegion.Key;
+        const endpoint = subscriptionRegion.Endpoint || "";
+
+        if (!endpoint) {
+            throw new Error("Endpoint is not defined for the subscription");
+        }
+
+        const finalEndpoint = path ? `${endpoint}${path}` : endpoint;
+
+        if (isTranslationConfig) {
+            return sdk.SpeechTranslationConfig.fromEndpoint(new URL(finalEndpoint), key) as unknown as T;
+        } else {
+            return sdk.SpeechConfig.fromEndpoint(new URL(finalEndpoint), key) as unknown as T;
+        }
+    }
+
+    /**
+     * Builds a legacy private link config with key authentication.
+     */
+    private static buildLegacyPrivateLinkWithKeyConfig<T extends ConfigType>(isTranslationConfig: boolean, serviceType: SpeechServiceType = SpeechServiceType.SpeechRecognition): T {
+        const pathSuffix = this.getPrivateLinkPathSuffix(serviceType);
+        return this.buildPrivateLinkWithKeyConfig<T>(pathSuffix, isTranslationConfig);
+    }
+
+    /**
+     * Builds a private link endpoint with Cognitive Services token.
+     */
+    private static buildPrivateLinkEndpointWithCogSvcsToken<T extends ConfigType>(isTranslationConfig: boolean): T {
+        if (!this.checkPrivateLinkTestsEnabled()) {
+            throw new Error("Private link testing is not enabled");
+        }
+
+        const subscriptionRegion = this.getSubscriptionRegion("PrivateLinkSpeechResource");
+        const endpoint = subscriptionRegion.Endpoint;
+
+        if (!endpoint) {
+            throw new Error("Endpoint is not defined for the private link subscription");
+        }
+
+        const credential = new CogSvcsTokenCredential(
+            subscriptionRegion.Key,
+            subscriptionRegion.Region
+        );
+
+        return this.buildEndpointWithTokenCredential<T>(credential, endpoint, isTranslationConfig);
+    }
+
+    /**
+     * Builds a private link endpoint with Entra ID token.
+     */
+    private static buildPrivateLinkEndpointWithEntraId<T extends ConfigType>(isTranslationConfig: boolean): T {
+        if (!this.checkPrivateLinkTestsEnabled()) {
+            throw new Error("Private link testing is not enabled");
+        }
+
+        const subscriptionRegion = this.getSubscriptionRegion("PrivateLinkSpeechResource");
+        const endpoint = subscriptionRegion.Endpoint;
+
+        if (!endpoint) {
+            throw new Error("Endpoint is not defined for the AAD private link subscription");
+        }
+
+        const credential: DefaultAzureCredential = new DefaultAzureCredential();
+
+        return this.buildEndpointWithTokenCredential<T>(credential, endpoint, isTranslationConfig);
+    }
+
+    /**
+     * Helper method to build an endpoint configuration with a token credential.
+     * @param cred The token credential to use for authentication.
+     * @param endpoint The endpoint URL string.
+     * @param isTranslationConfig Whether to create a SpeechTranslationConfig instead of SpeechConfig.
+     * @returns A speech configuration of the requested type.
+     */
+    private static buildEndpointWithTokenCredential<T extends ConfigType>(
+        cred: TokenCredential,
+        endpoint: string,
+        isTranslationConfig: boolean
+    ): T {
+        if (isTranslationConfig) {
+            return sdk.SpeechTranslationConfig.fromEndpoint(new URL(endpoint), "") as unknown as T;
+        } else {
+            return sdk.SpeechConfig.fromEndpoint(new URL(endpoint), "") as unknown as T;
+        }
+    }
+
+    /**
+     * Checks if private link tests are enabled.
+     */
+    private static checkPrivateLinkTestsEnabled(): boolean {
+        const plEnabled = process.env.ENABLE_PRIVATE_LINK_TESTS;
+        if (!plEnabled || plEnabled.toLowerCase() !== "true") {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Gets the appropriate path suffix for private link paths based on service type
+     */
+    private static getPrivateLinkPathSuffix(serviceType: SpeechServiceType): string {
+        switch (serviceType) {
+            case SpeechServiceType.TextToSpeech:
+                return "/tts/speech";
+            case SpeechServiceType.SpeechRecognition:
+            case SpeechServiceType.LanguageIdentification:
+            default:
+                return "/stt/speech";
+        }
+    }
+
+    /**
+     * For backward compatibility - these methods will be deprecated in favor of the generic approach.
+     */
+    public static runConnectionTest(connectionType: SpeechConnectionType): jest.It {
+        if (process.env.RUN_CONNECTION_TYPE_TESTS !== "true") {
+            return test.skip;
+        }
+
+        if ((process.env.SR_CONTAINER_URL === undefined || process.env.SR_CONTAINER_URL === "" ||
+            process.env.LID_CONTAINER_URL === undefined || process.env.LID_CONTAINER_URL === "" ||
+            process.env.TTS_CONTAINER_URL === undefined || process.env.TTS_CONTAINER_URL === "") &&
+            (connectionType === SpeechConnectionType.ContainerFromHost ||
+                connectionType === SpeechConnectionType.ContainerFromEndpoint)) {
+            return test.skip;
+        }
+
+        if (process.env.RUN_PRIVAETE_LINK_TESTS !== "true" &&
+            (connectionType === SpeechConnectionType.PrivateLinkWithKeyAuth ||
+                connectionType === SpeechConnectionType.LegacyPrivateLinkWithKeyAuth ||
+                connectionType === SpeechConnectionType.PrivateLinkWithCogSvcsTokenAuth ||
+                connectionType === SpeechConnectionType.PrivateLinkWithEntraIdTokenAuth ||
+                connectionType === SpeechConnectionType.LegacyPrivateLinkWithEntraIdTokenAuth)) {
+            return test.skip;
+        }
+
+        return test;
+    }
+}

--- a/tests/SpeechConnectionTypes.ts
+++ b/tests/SpeechConnectionTypes.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Defines the different connection types that can be used for speech recognition.
+ * This mirrors the C# implementation in Carbon's end-to-end tests.
+ */
+export enum SpeechConnectionType {
+    /**
+     * Connect using subscription key and region.
+     */
+    Subscription,
+
+    /**
+     * Connect using a cloud endpoint URL with key authentication.
+     */
+    CloudFromEndpointWithKeyAuth,
+
+    /**
+     * Connect using a cloud endpoint URL with Cognitive Services token authentication.
+     */
+    CloudFromEndpointWithCogSvcsTokenAuth,
+
+    /**
+     * Connect using a cloud endpoint URL with Entra ID (AAD) token authentication.
+     */
+    CloudFromEndpointWithEntraIdTokenAuth,
+
+    /**
+     * Connect using the legacy Cognitive Services token authentication.
+     */
+    LegacyCogSvcsTokenAuth,
+
+    /**
+     * Connect using the legacy Entra ID (AAD) token authentication.
+     */
+    LegacyEntraIdTokenAuth,
+
+    /**
+     * Connect using a host URL directly.
+     */
+    CloudFromHost,
+
+    /**
+     * Connect to a container using a host URL.
+     */
+    ContainerFromHost,
+
+    /**
+     * Connect to a container using an endpoint URL.
+     */
+    ContainerFromEndpoint,
+
+    /**
+     * Connect to a private link resource using key authentication.
+     */
+    PrivateLinkWithKeyAuth,
+
+    /**
+     * Connect to a private link resource using Cognitive Services token authentication.
+     */
+    PrivateLinkWithCogSvcsTokenAuth,
+
+    /**
+     * Connect to a private link resource using Entra ID (AAD) token authentication.
+     */
+    PrivateLinkWithEntraIdTokenAuth,
+
+    /**
+     * Connect to a private link resource using the legacy path with key authentication.
+     */
+    LegacyPrivateLinkWithKeyAuth,
+
+    /**
+     * Connect to a private link resource using the legacy path with Entra ID (AAD) token authentication.
+     */
+    LegacyPrivateLinkWithEntraIdTokenAuth,
+}

--- a/tests/SpeechServiceTypes.ts
+++ b/tests/SpeechServiceTypes.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Defines the speech service type used for creating appropriate connections.
+ */
+export enum SpeechServiceType {
+    /**
+     * Speech Recognition service type.
+     */
+    SpeechRecognition,
+
+    /**
+     * Text-to-Speech service type.
+     */
+    TextToSpeech,
+
+    /**
+     * Language Identification service type.
+     */
+    LanguageIdentification
+}

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -4,13 +4,12 @@
 import * as fs from "fs";
 import bent, { BentResponse } from "bent";
 import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
-import { ConsoleLoggingListener, WebsocketMessageAdapter } from "../src/common.browser/Exports";
+import { ConsoleLoggingListener } from "../src/common.browser/Exports";
 import { HeaderNames } from "../src/common.speech/HeaderNames";
 import { QueryParameterNames } from "../src/common.speech/QueryParameterNames";
 import {
     ConnectionStartEvent,
     Events,
-    EventType,
     InvalidOperationError,
     PlatformEvent
 } from "../src/common/Exports";
@@ -19,6 +18,10 @@ import {
     closeAsyncObjects,
     WaitForCondition
 } from "./Utilities";
+import { SpeechConfigConnectionFactory } from "./SpeechConfigConnectionFactories";
+import { SpeechConnectionType } from "./SpeechConnectionTypes";
+import { SpeechServiceType } from "./SpeechServiceTypes";
+import { SrvRecord } from "dns";
 
 
 let objsToClose: any[];
@@ -45,28 +48,28 @@ afterEach(async (): Promise<void> => {
     await closeAsyncObjects(objsToClose);
 });
 
-const BuildSpeechConfig: () => sdk.SpeechConfig = (): sdk.SpeechConfig => {
+const BuildSpeechConfig: (connectionType?: SpeechConnectionType) => Promise<sdk.SpeechConfig> = async (connectionType?: SpeechConnectionType): Promise<sdk.SpeechConfig> => {
 
-    let s: sdk.SpeechConfig;
-    if (undefined === Settings.SpeechEndpoint) {
-        s = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
-    } else {
-        s = sdk.SpeechConfig.fromEndpoint(new URL(Settings.SpeechEndpoint), Settings.SpeechSubscriptionKey);
-        s.setProperty(sdk.PropertyId.SpeechServiceConnection_Region, Settings.SpeechRegion);
+    if (undefined === connectionType) {
+        connectionType = SpeechConnectionType.Subscription;
     }
+
+    const s: sdk.SpeechConfig = await SpeechConfigConnectionFactory.getSpeechSynthesisConfig(connectionType);
+    expect(s).not.toBeUndefined();
+
+    console.info("SpeechConfig created " + SpeechConnectionType[connectionType]);
 
     if (undefined !== Settings.proxyServer) {
         s.setProxy(Settings.proxyServer, Settings.proxyPort);
     }
 
-    expect(s).not.toBeUndefined();
     return s;
 };
 
 const CheckSynthesisResult: (result: sdk.SpeechSynthesisResult, reason: sdk.ResultReason) =>
     void = (result: sdk.SpeechSynthesisResult, reason: sdk.ResultReason): void => {
         expect(result).not.toBeUndefined();
-
+        expect(result.errorDetails).toBeUndefined();
         expect(sdk.ResultReason[result.reason]).toEqual(sdk.ResultReason[reason]);
         switch (reason) {
             case sdk.ResultReason.SynthesizingAudio:
@@ -95,7 +98,7 @@ const CheckBinaryEqual: (arr1: ArrayBuffer, arr2: ArrayBuffer) => void =
 const ReadPullAudioOutputStream: (stream: sdk.PullAudioOutputStream, length?: number, done?: jest.DoneCallback) => void =
     (stream: sdk.PullAudioOutputStream, length?: number, done?: jest.DoneCallback): void => {
         const audioBuffer = new ArrayBuffer(1024);
-        stream.read(audioBuffer).then((bytesRead: number) => {
+        stream.read(audioBuffer).then((bytesRead: number): void => {
             if (bytesRead > 0) {
                 ReadPullAudioOutputStream(stream, length === undefined ? undefined : length - bytesRead, done);
             } else {
@@ -134,7 +137,7 @@ class PushAudioOutputStreamTestCallback extends sdk.PushAudioOutputStreamCallbac
     }
 }
 
-test("testGetVoicesAsyncAuthError", async () => {
+test("testGetVoicesAsyncAuthError", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: testGetVoicesAsyncAuthError");
     const speechConfig: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription("foo", Settings.SpeechRegion);
@@ -151,10 +154,10 @@ test("testGetVoicesAsyncAuthError", async () => {
     expect(voicesResult.errorDetails.endsWith("401: Unauthorized"));
 });
 
-test("testGetVoicesAsyncDefault", async () => {
+test("testGetVoicesAsyncDefault", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: testGetVoicesAsyncDefault");
-    const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
+    const speechConfig: sdk.SpeechConfig = await BuildSpeechConfig();
 
     const r: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig);
     objsToClose.push(r);
@@ -177,7 +180,7 @@ test("testGetVoicesAsyncDefault", async () => {
     }
 });
 
-test("testGetVoicesAsyncAuthWithToken", async () => {
+test("testGetVoicesAsyncAuthWithToken", (done: jest.DoneCallback): void => {
     // eslint-disable-next-line no-console
     console.info("Name: testGetVoicesAsyncAuthWithToken");
 
@@ -193,10 +196,8 @@ test("testGetVoicesAsyncAuthWithToken", async () => {
     sendRequest(path)
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment
         .then((resp: BentResponse): void => {
-            resp.text().then((token: string): void => {
-                authToken = token;
-            }).catch((): void => {});
-        }).catch((): void => {});
+            authToken = resp as unknown as string;
+        }).catch((error): void => done(error));
 
     WaitForCondition((): boolean => !!authToken, (): void => {
         const config: sdk.SpeechConfig = sdk.SpeechConfig.fromAuthorizationToken(authToken, Settings.SpeechRegion);
@@ -207,21 +208,23 @@ test("testGetVoicesAsyncAuthWithToken", async () => {
 
         objsToClose.push(s);
 
-        s.getVoicesAsync().then( (voicesResult: sdk.SynthesisVoicesResult): void => {
+        s.getVoicesAsync().then((voicesResult: sdk.SynthesisVoicesResult): void => {
             expect(voicesResult).not.toBeUndefined();
             expect(voicesResult.resultId).not.toBeUndefined();
             expect(voicesResult.voices.length).toBeGreaterThan(0);
             expect(voicesResult.reason).toEqual(sdk.ResultReason.VoicesListRetrieved);
+            done();
         }).catch((error: any): void => {
+            done(error);
             console.log(error as string);
         });
     });
-});
+}, 15000);
 
-test("testGetVoicesAsyncUS", async () => {
+test("testGetVoicesAsyncUS", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: testGetVoicesAsyncUS");
-    const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
+    const speechConfig: sdk.SpeechConfig = await BuildSpeechConfig();
 
     const r: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig);
     objsToClose.push(r);
@@ -233,8 +236,8 @@ test("testGetVoicesAsyncUS", async () => {
     expect(voicesResult.resultId).not.toBeUndefined();
     expect(voicesResult.voices.length).toBeGreaterThan(0);
     expect(voicesResult.reason).toEqual(sdk.ResultReason.VoicesListRetrieved);
-    expect(voicesResult.voices.filter((item: any) => item.locale !== locale).length).toEqual(0);
-    const ava: sdk.VoiceInfo = voicesResult.voices.find((item: sdk.VoiceInfo) => item.shortName === "en-US-AvaNeural");
+    expect(voicesResult.voices.filter((item: any): boolean => item.locale !== locale).length).toEqual(0);
+    const ava: sdk.VoiceInfo = voicesResult.voices.find((item: sdk.VoiceInfo): boolean => item.shortName === "en-US-AvaNeural");
     expect(ava).not.toBeUndefined();
     expect(ava.voiceTag.TailoredScenarios).not.toBeUndefined();
     expect(ava.voiceTag.TailoredScenarios[0]).toEqual("Chat");
@@ -242,10 +245,10 @@ test("testGetVoicesAsyncUS", async () => {
     expect(ava.voiceType).toEqual(sdk.SynthesisVoiceType.OnlineNeural);
 });
 
-Settings.testIfDOMCondition("testSpeechSynthesizer1", () => {
+Settings.testIfDOMCondition("testSpeechSynthesizer1", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: testSpeechSynthesizer1");
-    const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
+    const speechConfig: sdk.SpeechConfig = await BuildSpeechConfig();
 
     const config: sdk.AudioConfig = sdk.AudioConfig.fromDefaultSpeakerOutput();
 
@@ -257,10 +260,10 @@ Settings.testIfDOMCondition("testSpeechSynthesizer1", () => {
     expect(r instanceof sdk.SpeechSynthesizer);
 });
 
-test("testSetAndGetParameters", () => {
+test("testSetAndGetParameters", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: testSetAndGetParameters");
-    const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
+    const speechConfig: sdk.SpeechConfig = await BuildSpeechConfig();
     speechConfig.speechSynthesisLanguage = "zh-CN";
     speechConfig.speechSynthesisVoiceName = "zh-CN-HuihuiRUS";
     speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Audio16Khz128KBitRateMonoMp3;
@@ -276,431 +279,582 @@ test("testSetAndGetParameters", () => {
         .toEqual(sdk.SpeechSynthesisOutputFormat[sdk.SpeechSynthesisOutputFormat.Audio16Khz128KBitRateMonoMp3]);
 });
 
-describe("Service based tests", () => {
+describe("Service based tests", (): void => {
 
-    test("testSpeechSynthesizerEvent1", (done: jest.DoneCallback) => {
+    describe.each([
+        SpeechConnectionType.Subscription,
+        SpeechConnectionType.LegacyCogSvcsTokenAuth,
+        SpeechConnectionType.LegacyEntraIdTokenAuth,
+        SpeechConnectionType.CloudFromHost,
+        SpeechConnectionType.ContainerFromHost,
+        SpeechConnectionType.LegacyPrivateLinkWithKeyAuth,
+        SpeechConnectionType.LegacyPrivateLinkWithEntraIdTokenAuth
+    ])("Speech Synthesis Connection Tests", (connectionType: SpeechConnectionType): void => {
+
+        const runTest: jest.It = SpeechConfigConnectionFactory.runConnectionTest(connectionType);
+
+        runTest("Speech Synthesizer Events " + SpeechConnectionType[connectionType], (done: jest.DoneCallback): void => {
+            // eslint-disable-next-line no-console
+            console.info("Name: Speech Synthesizer Events " + SpeechConnectionType[connectionType]);
+            BuildSpeechConfig(connectionType).then((speechConfig: sdk.SpeechConfig): void => {
+                objsToClose.push(speechConfig);
+                speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
+
+                const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, undefined);
+                objsToClose.push(s);
+
+                expect(s).not.toBeUndefined();
+
+                let audioLength: number = 0;
+                let startEventCount: number = 0;
+                let synthesizingEventCount: number = 0;
+                let completeEventCount: number = 0;
+
+                s.synthesisStarted = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
+                    // eslint-disable-next-line no-console
+                    console.info("Synthesis started.");
+                    try {
+                        CheckSynthesisResult(e.result, sdk.ResultReason.SynthesizingAudioStarted);
+                    } catch (e) {
+                        done(e);
+                    }
+                    startEventCount += 1;
+                };
+
+                s.synthesizing = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
+                    // eslint-disable-next-line no-console
+                    console.info("Audio received with length of " + e.result.audioData.byteLength.toString());
+                    audioLength += e.result.audioData.byteLength - 44;
+                    try {
+                        CheckSynthesisResult(e.result, sdk.ResultReason.SynthesizingAudio);
+                    } catch (e) {
+                        done(e);
+                    }
+                    synthesizingEventCount += 1;
+                };
+
+                s.synthesisCompleted = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
+                    // eslint-disable-next-line no-console
+                    console.info("Audio received with length of " + e.result.audioData.byteLength.toString());
+                    try {
+                        CheckSynthesisResult(e.result, sdk.ResultReason.SynthesizingAudioCompleted);
+                        expect(e.result.audioData.byteLength - 44).toEqual(audioLength);
+                    } catch (e) {
+                        done(e);
+                    }
+                    completeEventCount += 1;
+                };
+
+                s.wordBoundary = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisWordBoundaryEventArgs): void => {
+                    try {
+                        expect(e).not.toBeUndefined();
+                    } catch (e) {
+                        done(e);
+                    }
+                };
+
+                s.speakTextAsync("hello world.", undefined, (e: string): void => {
+                    done(e);
+                });
+
+                WaitForCondition((): boolean => completeEventCount !== 0, (): void => {
+                    expect(startEventCount).toEqual(1);
+                    expect(synthesizingEventCount).toBeGreaterThan(0);
+                    done();
+                });
+            }).catch((error: string): void => {
+                done(error);
+            });
+        }, 15000);
+
+        runTest("Speech Synthesizer Speak Twice " + SpeechConnectionType[connectionType], (done: jest.DoneCallback): void => {
+            // eslint-disable-next-line no-console
+            console.info("Name: Speech Synthesizer Speak Twice " + SpeechConnectionType[connectionType]);
+            BuildSpeechConfig(connectionType).then((speechConfig: sdk.SpeechConfig): void => {
+                objsToClose.push(speechConfig);
+                speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
+
+                const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, undefined);
+                objsToClose.push(s);
+
+                expect(s).not.toBeUndefined();
+
+                s.speakTextAsync("hello world 1.", (result: sdk.SpeechSynthesisResult): void => {
+                    // eslint-disable-next-line no-console
+                    console.info("speaking finished, turn 1");
+                    CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                    // To seconds
+                    expect(result.audioDuration / 1000 / 1000 / 10).toBeCloseTo(result.audioData.byteLength / 32000, 2);
+                }, (e: string): void => {
+                    done(e);
+                });
+
+                s.speakTextAsync("hello world 2.", (result: sdk.SpeechSynthesisResult): void => {
+                    // eslint-disable-next-line no-console
+                    console.info("speaking finished, turn 2");
+                    CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                    expect(result.audioDuration / 1000 / 1000 / 10).toBeCloseTo(result.audioData.byteLength / 32000, 2);
+                    done();
+                }, (e: string): void => {
+                    done(e);
+                });
+            }).catch((error: string): void => {
+                done(error);
+            });
+        });
+    });
+
+    test("testSpeechSynthesizerEvent1", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizerEvent1");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
-        speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
+            speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, undefined);
-        objsToClose.push(s);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, undefined);
+            objsToClose.push(s);
 
-        expect(s).not.toBeUndefined();
+            expect(s).not.toBeUndefined();
 
-        let audioLength: number = 0;
-        let startEventCount: number = 0;
-        let synthesizingEventCount: number = 0;
-        let completeEventCount: number = 0;
+            let audioLength: number = 0;
+            let startEventCount: number = 0;
+            let synthesizingEventCount: number = 0;
+            let completeEventCount: number = 0;
 
-        s.synthesisStarted = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
-            // eslint-disable-next-line no-console
-            console.info("Synthesis started.");
-            try {
-                CheckSynthesisResult(e.result, sdk.ResultReason.SynthesizingAudioStarted);
-            } catch (e) {
+            s.synthesisStarted = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
+                // eslint-disable-next-line no-console
+                console.info("Synthesis started.");
+                try {
+                    CheckSynthesisResult(e.result, sdk.ResultReason.SynthesizingAudioStarted);
+                } catch (e) {
+                    done(e);
+                }
+                startEventCount += 1;
+            };
+
+            s.synthesizing = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
+                // eslint-disable-next-line no-console
+                console.info("Audio received with length of " + e.result.audioData.byteLength.toString());
+                audioLength += e.result.audioData.byteLength - 44;
+                try {
+                    CheckSynthesisResult(e.result, sdk.ResultReason.SynthesizingAudio);
+                } catch (e) {
+                    done(e);
+                }
+                synthesizingEventCount += 1;
+            };
+
+            s.synthesisCompleted = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
+                // eslint-disable-next-line no-console
+                console.info("Audio received with length of " + e.result.audioData.byteLength.toString());
+                try {
+                    CheckSynthesisResult(e.result, sdk.ResultReason.SynthesizingAudioCompleted);
+                    expect(e.result.audioData.byteLength - 44).toEqual(audioLength);
+                } catch (e) {
+                    done(e);
+                }
+                completeEventCount += 1;
+            };
+
+            s.wordBoundary = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisWordBoundaryEventArgs): void => {
+                try {
+                    expect(e).not.toBeUndefined();
+                } catch (e) {
+                    done(e);
+                }
+            };
+
+            s.speakTextAsync("hello world.", undefined, (e: string): void => {
                 done(e);
-            }
-            startEventCount += 1;
-        };
+            });
 
-        s.synthesizing = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
-            // eslint-disable-next-line no-console
-            console.info("Audio received with length of " + e.result.audioData.byteLength);
-            audioLength += e.result.audioData.byteLength - 44;
-            try {
-                CheckSynthesisResult(e.result, sdk.ResultReason.SynthesizingAudio);
-            } catch (e) {
-                done(e);
-            }
-            synthesizingEventCount += 1;
-        };
-
-        s.synthesisCompleted = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
-            // eslint-disable-next-line no-console
-            console.info("Audio received with length of " + e.result.audioData.byteLength);
-            try {
-                CheckSynthesisResult(e.result, sdk.ResultReason.SynthesizingAudioCompleted);
-                expect(e.result.audioData.byteLength - 44).toEqual(audioLength);
-            } catch (e) {
-                done(e);
-            }
-            completeEventCount += 1;
-        };
-
-        s.wordBoundary = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisWordBoundaryEventArgs): void => {
-            try {
-                expect(e).not.toBeUndefined();
-            } catch (e) {
-                done(e);
-            }
-        };
-
-        s.speakTextAsync("hello world.", undefined, (e: string): void => {
-            done(e);
-        });
-
-        WaitForCondition((): boolean => {
-            return completeEventCount !== 0;
-        }, (): void => {
-            expect(startEventCount).toEqual(1);
-            expect(synthesizingEventCount).toBeGreaterThan(0);
-            done();
+            WaitForCondition((): boolean => completeEventCount !== 0, (): void => {
+                expect(startEventCount).toEqual(1);
+                expect(synthesizingEventCount).toBeGreaterThan(0);
+                done();
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test("testSpeechSynthesizerSpeakTwice", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizerSpeakTwice", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizerSpeakTwice");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
-        speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
+            speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, undefined);
-        objsToClose.push(s);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, undefined);
+            objsToClose.push(s);
 
-        expect(s).not.toBeUndefined();
+            expect(s).not.toBeUndefined();
 
-        s.speakTextAsync("hello world 1.", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking finished, turn 1");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            // To seconds
-            expect(result.audioDuration / 1000 / 1000 / 10).toBeCloseTo(result.audioData.byteLength / 32000, 2);
-        }, (e: string): void => {
-            done(e);
-        });
+            s.speakTextAsync("hello world 1.", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking finished, turn 1");
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                // To seconds
+                expect(result.audioDuration / 1000 / 1000 / 10).toBeCloseTo(result.audioData.byteLength / 32000, 2);
+            }, (e: string): void => {
+                done(e);
+            });
 
-        s.speakTextAsync("hello world 2.", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking finished, turn 2");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            expect(result.audioDuration / 1000 / 1000 / 10).toBeCloseTo(result.audioData.byteLength / 32000, 2);
-            done();
-        }, (e: string): void => {
-            done(e);
+            s.speakTextAsync("hello world 2.", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking finished, turn 2");
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                expect(result.audioDuration / 1000 / 1000 / 10).toBeCloseTo(result.audioData.byteLength / 32000, 2);
+                done();
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test("testSpeechSynthesizerToFile", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizerToFile", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizerToFile");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
-        speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
+            speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
 
-        const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromAudioFileOutput("test.wav");
-        expect(audioConfig).not.toBeUndefined();
+            const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromAudioFileOutput("test.wav");
+            expect(audioConfig).not.toBeUndefined();
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
 
-        expect(s).not.toBeUndefined();
+            expect(s).not.toBeUndefined();
 
-        let audioLength: number = 0;
+            let audioLength: number = 0;
 
-        s.speakTextAsync("hello world 1.", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking finished, turn 1");
-            audioLength += result.audioData.byteLength;
-        }, (e: string): void => {
-            done(e);
-        });
+            s.speakTextAsync("hello world 1.", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking finished, turn 1");
+                audioLength += result.audioData.byteLength;
+            }, (e: string): void => {
+                done(e);
+            });
 
-        s.speakTextAsync("hello world 2.", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking finished, turn 2");
-            audioLength += result.audioData.byteLength;
-            s.close();
-            // wait 2 seconds before checking file size, as the async file writing might not be finished right now.
-            setTimeout(() => {
-                const fileLength = fs.statSync("test.wav").size;
-                expect(fileLength).toEqual(audioLength - 44);
-                done();
-            }, 2000);
-        }, (e: string): void => {
-            done(e);
+            s.speakTextAsync("hello world 2.", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking finished, turn 2");
+                audioLength += result.audioData.byteLength;
+                s.close();
+                // wait 2 seconds before checking file size, as the async file writing might not be finished right now.
+                setTimeout(() => {
+                    const fileLength = fs.statSync("test.wav").size;
+                    expect(fileLength).toEqual(audioLength - 44);
+                    done();
+                }, 2000);
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test("testSpeechSynthesizer: synthesis to file in turn.", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizer: synthesis to file in turn.", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizer synthesis to file in turn.");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Audio16Khz32KBitRateMonoMp3;
-        objsToClose.push(speechConfig);
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Audio16Khz32KBitRateMonoMp3;
+            objsToClose.push(speechConfig);
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
-        expect(s).not.toBeUndefined();
-        objsToClose.push(s);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+            expect(s).not.toBeUndefined();
+            objsToClose.push(s);
 
-        s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking finished.");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            // wait 2 seconds before checking file size, as the async file writing might not be finished right now.
-            setTimeout(() => {
-                const fileLength = fs.statSync("test1.mp3").size;
-                expect(fileLength).toEqual(result.audioData.byteLength);
-                done();
-            }, 2000);
-        }, (e: string): void => {
-            done(e);
-        }, "test1.mp3");
+            s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking finished.");
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                // wait 2 seconds before checking file size, as the async file writing might not be finished right now.
+                setTimeout((): void => {
+                    const fileLength = fs.statSync("test1.mp3").size;
+                    expect(fileLength).toEqual(result.audioData.byteLength);
+                    done();
+                }, 2000);
+            }, (e: string): void => {
+                done(e);
+            }, "test1.mp3");
+        }).catch((error: string): void => {
+            done(error);
+        });
     });
 
-    test("testSpeechSynthesizerWordBoundary", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizerWordBoundary", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizerWordBoundary");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
-        objsToClose.push(s);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+            objsToClose.push(s);
 
-        expect(s).not.toBeUndefined();
+            expect(s).not.toBeUndefined();
 
-        let wordBoundaryCount: number = 0;
+            let wordBoundaryCount: number = 0;
 
-        s.wordBoundary = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisWordBoundaryEventArgs): void => {
-            try {
-                expect(e).not.toBeUndefined();
-                expect(e.audioOffset).not.toBeUndefined();
-                expect(e.text).not.toBeUndefined();
-                expect(e.textOffset).not.toBeUndefined();
-                expect(e.wordLength).not.toBeUndefined();
-            } catch (e) {
+            s.wordBoundary = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisWordBoundaryEventArgs): void => {
+                try {
+                    expect(e).not.toBeUndefined();
+                    expect(e.audioOffset).not.toBeUndefined();
+                    expect(e.text).not.toBeUndefined();
+                    expect(e.textOffset).not.toBeUndefined();
+                    expect(e.wordLength).not.toBeUndefined();
+                } catch (e) {
+                    done(e);
+                }
+                wordBoundaryCount += 1;
+            };
+
+            s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
+                expect(wordBoundaryCount).toBeGreaterThan(0);
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                done();
+            }, (e: string): void => {
                 done(e);
-            }
-            wordBoundaryCount += 1;
-        };
-
-        s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
-            expect(wordBoundaryCount).toBeGreaterThan(0);
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            done();
-        }, (e: string): void => {
-            done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test("testSpeechSynthesizerWordBoundaryMathXml", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizerWordBoundaryMathXml", (done: jest.DoneCallback): void => {
         // tslint:disable-next-line:no-console
         console.info("Name: testSpeechSynthesizerWordBoundaryMathXml");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
-        objsToClose.push(s);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+            objsToClose.push(s);
 
-        expect(s).not.toBeUndefined();
+            expect(s).not.toBeUndefined();
 
-        let wordBoundaryCount: number = 0;
-        const expectedSsmlOffsets: number[] = [206, 211, 214, 217, 225, 227];
-        const expectedBoundary: sdk.SpeechSynthesisBoundaryType[] =
-            [sdk.SpeechSynthesisBoundaryType.Word,
-            sdk.SpeechSynthesisBoundaryType.Word,
-            sdk.SpeechSynthesisBoundaryType.Word,
-            sdk.SpeechSynthesisBoundaryType.Word,
-            sdk.SpeechSynthesisBoundaryType.Punctuation,
-            sdk.SpeechSynthesisBoundaryType.Word];
+            let wordBoundaryCount: number = 0;
+            const expectedSsmlOffsets: number[] = [206, 211, 214, 217, 225, 227];
+            const expectedBoundary: sdk.SpeechSynthesisBoundaryType[] =
+                [sdk.SpeechSynthesisBoundaryType.Word,
+                sdk.SpeechSynthesisBoundaryType.Word,
+                sdk.SpeechSynthesisBoundaryType.Word,
+                sdk.SpeechSynthesisBoundaryType.Word,
+                sdk.SpeechSynthesisBoundaryType.Punctuation,
+                sdk.SpeechSynthesisBoundaryType.Word];
 
-        s.wordBoundary = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisWordBoundaryEventArgs): void => {
-            try {
-                expect(e).not.toBeUndefined();
-                expect(e.audioOffset).not.toBeUndefined();
-                expect(e.text).not.toBeUndefined();
-                expect(e.textOffset).not.toBeUndefined();
-                expect(e.wordLength).not.toBeUndefined();
-                expect(e.textOffset).toEqual(expectedSsmlOffsets[wordBoundaryCount]);
-                expect(e.boundaryType).toEqual(expectedBoundary[wordBoundaryCount]);
-            } catch (e) {
-                done(e);
-            }
-            wordBoundaryCount += 1;
-        };
+            s.wordBoundary = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisWordBoundaryEventArgs): void => {
+                try {
+                    expect(e).not.toBeUndefined();
+                    expect(e.audioOffset).not.toBeUndefined();
+                    expect(e.text).not.toBeUndefined();
+                    expect(e.textOffset).not.toBeUndefined();
+                    expect(e.wordLength).not.toBeUndefined();
+                    expect(e.textOffset).toEqual(expectedSsmlOffsets[wordBoundaryCount]);
+                    expect(e.boundaryType).toEqual(expectedBoundary[wordBoundaryCount]);
+                } catch (e) {
+                    done(e);
+                }
+                wordBoundaryCount += 1;
+            };
 
-        const ssml: string =
-            `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='http://www.w3.org/2001/mstts' xmlns:emo='http://www.w3.org/2009/10/emotionml' xml:lang='en-US'>
+            const ssml: string =
+                `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='http://www.w3.org/2001/mstts' xmlns:emo='http://www.w3.org/2009/10/emotionml' xml:lang='en-US'>
 <voice name='en-US-JennyNeural'>This is an equation: <math xmlns="http://www.w3.org/1998/Math/MathML"><msqrt><mn>2</mn></msqrt></math></voice></speak>`;
 
-        s.speakSsmlAsync(ssml, (result: sdk.SpeechSynthesisResult): void => {
-            expect(wordBoundaryCount).toBeGreaterThan(0);
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            done();
-        }, (e: string): void => {
-            done(e);
+            s.speakSsmlAsync(ssml, (result: sdk.SpeechSynthesisResult): void => {
+                expect(wordBoundaryCount).toBeGreaterThan(0);
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                done();
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test.skip("testSpeechSynthesizerSentenceBoundary", (done: jest.DoneCallback) => {
+    test.skip("testSpeechSynthesizerSentenceBoundary", (done: jest.DoneCallback): void => {
         // tslint:disable-next-line:no-console
         console.info("Name: testSpeechSynthesizerWordBoundaryMathXml");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
-        speechConfig.setProperty(sdk.PropertyId.SpeechServiceResponse_RequestSentenceBoundary, "true");
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
+            speechConfig.setProperty(sdk.PropertyId.SpeechServiceResponse_RequestSentenceBoundary, "true");
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
-        objsToClose.push(s);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+            objsToClose.push(s);
 
-        expect(s).not.toBeUndefined();
+            expect(s).not.toBeUndefined();
 
-        let wordBoundaryCount: number = 0;
-        const expectedSsmlOffsets: number[] = [206, 212, 216, 206, 257, 261, 268, 257, 310, 314, 320, 310, 359, 365, 372, 359, 412, 418, 425, 412, 467, 473, 477, 467];
-        const expectedBoundary: sdk.SpeechSynthesisBoundaryType[] =
-            [sdk.SpeechSynthesisBoundaryType.Word,
-            sdk.SpeechSynthesisBoundaryType.Word,
-            sdk.SpeechSynthesisBoundaryType.Word,
-            sdk.SpeechSynthesisBoundaryType.Word,
-            sdk.SpeechSynthesisBoundaryType.Punctuation,
-            sdk.SpeechSynthesisBoundaryType.Word];
+            let wordBoundaryCount: number = 0;
+            const expectedSsmlOffsets: number[] = [206, 212, 216, 206, 257, 261, 268, 257, 310, 314, 320, 310, 359, 365, 372, 359, 412, 418, 425, 412, 467, 473, 477, 467];
+            const expectedBoundary: sdk.SpeechSynthesisBoundaryType[] =
+                [sdk.SpeechSynthesisBoundaryType.Word,
+                sdk.SpeechSynthesisBoundaryType.Word,
+                sdk.SpeechSynthesisBoundaryType.Word,
+                sdk.SpeechSynthesisBoundaryType.Word,
+                sdk.SpeechSynthesisBoundaryType.Punctuation,
+                sdk.SpeechSynthesisBoundaryType.Word];
 
-        s.wordBoundary = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisWordBoundaryEventArgs): void => {
-            try {
-                expect(e).not.toBeUndefined();
-                expect(e.audioOffset).not.toBeUndefined();
-                expect(e.text).not.toBeUndefined();
-                expect(e.textOffset).not.toBeUndefined();
-                expect(e.wordLength).not.toBeUndefined();
-                expect(e.textOffset).toEqual(expectedSsmlOffsets[wordBoundaryCount]);
-                // expect(e.boundaryType).toEqual(expectedBoundary[wordBoundaryCount]);
-            } catch (e) {
-                done(e);
-            }
-            wordBoundaryCount += 1;
-        };
+            s.wordBoundary = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisWordBoundaryEventArgs): void => {
+                try {
+                    expect(e).not.toBeUndefined();
+                    expect(e.audioOffset).not.toBeUndefined();
+                    expect(e.text).not.toBeUndefined();
+                    expect(e.textOffset).not.toBeUndefined();
+                    expect(e.wordLength).not.toBeUndefined();
+                    expect(e.textOffset).toEqual(expectedSsmlOffsets[wordBoundaryCount]);
+                    // expect(e.boundaryType).toEqual(expectedBoundary[wordBoundaryCount]);
+                } catch (e) {
+                    done(e);
+                }
+                wordBoundaryCount += 1;
+            };
 
-        const ssml: string =
-            `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='http://www.w3.org/2001/mstts' xmlns:emo='http://www.w3.org/2009/10/emotionml' xml:lang='en-US'>
+            const ssml: string =
+                `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='http://www.w3.org/2001/mstts' xmlns:emo='http://www.w3.org/2009/10/emotionml' xml:lang='en-US'>
 <voice name='de-DE-ConradNeural'>Hallo Welt.</voice><voice name='da-DK-JeppeNeural'>Hei maailma.</voice>
 <voice name='nb-NO-IselinNeural'>Hei Verden.</voice><voice name='lt-LT-OnaNeural'>Labas pasauli.</voice>
 <voice name='ar-QA-MoazNeural'>مرحبا بالعالم.</voice><voice name='de-DE-ConradNeural'>Hallo Welt.</voice></speak>`;
 
-        s.speakSsmlAsync(ssml.split("\n").join(""), (result: sdk.SpeechSynthesisResult): void => {
-            try {
-                expect(wordBoundaryCount).toBeGreaterThan(0);
-                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-                done();
-            } catch (e) {
+            s.speakSsmlAsync(ssml.split("\n").join(""), (result: sdk.SpeechSynthesisResult): void => {
+                try {
+                    expect(wordBoundaryCount).toBeGreaterThan(0);
+                    CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }, (e: string): void => {
                 done(e);
-            }
-        }, (e: string): void => {
-            done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test("testSpeechSynthesizerBookmark", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizerBookmark", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizerBookmark");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
-        objsToClose.push(s);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+            objsToClose.push(s);
 
-        expect(s).not.toBeUndefined();
+            expect(s).not.toBeUndefined();
 
-        let bookmarkCount: number = 0;
+            let bookmarkCount: number = 0;
 
-        s.bookmarkReached = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisBookmarkEventArgs): void => {
-            try {
-                expect(e).not.toBeUndefined();
-                expect(e.audioOffset).not.toBeUndefined();
-                if (bookmarkCount === 0) {
-                    expect(e.text).toEqual("bookmark");
+            s.bookmarkReached = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisBookmarkEventArgs): void => {
+                try {
+                    expect(e).not.toBeUndefined();
+                    expect(e.audioOffset).not.toBeUndefined();
+                    if (bookmarkCount === 0) {
+                        expect(e.text).toEqual("bookmark");
+                    }
+                } catch (e) {
+                    done(e);
                 }
-            } catch (e) {
-                done(e);
-            }
-            bookmarkCount += 1;
-        };
+                bookmarkCount += 1;
+            };
 
-        const ssml: string =
-            `<speak version='1.0' xml:lang='en-US' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='http://www.w3.org/2001/mstts'>
+            const ssml: string =
+                `<speak version='1.0' xml:lang='en-US' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='http://www.w3.org/2001/mstts'>
  <voice name='en-US-GuyNeural'><bookmark mark='bookmark'/> one. <bookmark mark='书签'/> two. three. four.</voice></speak>`;
-        s.speakSsmlAsync(ssml, (result: sdk.SpeechSynthesisResult): void => {
-            expect(bookmarkCount).toEqual(2);
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            done();
-        }, (e: string): void => {
-            done(e);
+            s.speakSsmlAsync(ssml, (result: sdk.SpeechSynthesisResult): void => {
+                expect(bookmarkCount).toEqual(2);
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                done();
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test("testSpeechSynthesizerViseme", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizerViseme", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizerViseme");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
-        objsToClose.push(s);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+            objsToClose.push(s);
 
-        expect(s).not.toBeUndefined();
+            expect(s).not.toBeUndefined();
 
-        let visemeCount: number = 0;
+            let visemeCount: number = 0;
 
-        s.visemeReceived = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisVisemeEventArgs): void => {
-            try {
-                expect(e).not.toBeUndefined();
-                expect(e.audioOffset).not.toBeUndefined();
-                expect(e.visemeId).not.toBeUndefined();
-                expect(e.animation).not.toBeUndefined();
-            } catch (e) {
-                done(e);
-            }
-            visemeCount += 1;
-        };
+            s.visemeReceived = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisVisemeEventArgs): void => {
+                try {
+                    expect(e).not.toBeUndefined();
+                    expect(e.audioOffset).not.toBeUndefined();
+                    expect(e.visemeId).not.toBeUndefined();
+                    expect(e.animation).not.toBeUndefined();
+                } catch (e) {
+                    done(e);
+                }
+                visemeCount += 1;
+            };
 
-        const ssml: string =
-            `<speak version='1.0' xml:lang='en-US' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='http://www.w3.org/2001/mstts'>
+            const ssml: string =
+                `<speak version='1.0' xml:lang='en-US' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='http://www.w3.org/2001/mstts'>
 <voice name='en-US-JennyNeural'><mstts:viseme type='svg'/>I want to avoid monotony.</voice></speak>`;
-        s.speakSsmlAsync(ssml, (result: sdk.SpeechSynthesisResult): void => {
-            expect(visemeCount).toBeGreaterThan(0);
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            done();
-        }, (e: string): void => {
-            done(e);
+            s.speakSsmlAsync(ssml, (result: sdk.SpeechSynthesisResult): void => {
+                expect(visemeCount).toBeGreaterThan(0);
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                done();
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test("testSpeechSynthesizer: synthesis with SSML.", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizer: synthesis with SSML.", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizer synthesis with SSML.");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
-        speechConfig.speechSynthesisVoiceName = "en-US-AvaNeural";
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
+            speechConfig.speechSynthesisVoiceName = "en-US-AvaNeural";
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
-        expect(s).not.toBeUndefined();
-        objsToClose.push(s);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+            expect(s).not.toBeUndefined();
+            objsToClose.push(s);
 
-        let r: sdk.SpeechSynthesisResult;
-        s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking text finished.");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            r = result;
-        }, (e: string): void => {
-            done(e);
-        });
+            let r: sdk.SpeechSynthesisResult;
+            s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking text finished.");
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                r = result;
+            }, (e: string): void => {
+                done(e);
+            });
 
-        const ssml: string =
-            `<speak version='1.0' xml:lang='en-US' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='http://www.w3.org/2001/mstts'>
+            const ssml: string =
+                `<speak version='1.0' xml:lang='en-US' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='http://www.w3.org/2001/mstts'>
 <voice name='Microsoft Server Speech Text to Speech Voice (en-US, AvaNeural)'>hello world.</voice></speak>`;
-        s.speakSsmlAsync(ssml, (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking ssml finished.");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            CheckBinaryEqual(r.audioData, result.audioData);
-            done();
-        }, (e: string): void => {
-            done(e);
+            s.speakSsmlAsync(ssml, (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking ssml finished.");
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                CheckBinaryEqual(r.audioData, result.audioData);
+                done();
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    Settings.testIfDOMCondition("testSpeechSynthesizer: synthesis with invalid key.", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("testSpeechSynthesizer: synthesis with invalid key.", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizer synthesis with invalid key.");
         const speechConfig: sdk.SpeechConfig = sdk.SpeechConfig.fromSubscription("invalidKey", Settings.SpeechRegion);
@@ -735,129 +889,141 @@ describe("Service based tests", () => {
         });
     });
 
-    test("testSpeechSynthesizer: synthesis with invalid voice name.", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizer: synthesis with invalid voice name.", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizer synthesis with invalid voice name.");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
-        speechConfig.speechSynthesisVoiceName = "invalid";
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
+            speechConfig.speechSynthesisVoiceName = "invalid";
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
-        expect(s).not.toBeUndefined();
-        objsToClose.push(s);
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+            expect(s).not.toBeUndefined();
+            objsToClose.push(s);
 
-        s.SynthesisCanceled = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
-            try {
-                CheckSynthesisResult(e.result, sdk.ResultReason.Canceled);
-                expect(e.result.errorDetails).toContain("voice");
-                const cancellationDetail: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(e.result);
+            s.SynthesisCanceled = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
+                try {
+                    CheckSynthesisResult(e.result, sdk.ResultReason.Canceled);
+                    expect(e.result.errorDetails).toContain("voice");
+                    const cancellationDetail: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(e.result);
+                    expect(cancellationDetail.ErrorCode).toEqual(sdk.CancellationErrorCode.BadRequestParameters);
+                    expect(cancellationDetail.reason).toEqual(sdk.CancellationReason.Error);
+                    expect(cancellationDetail.errorDetails).toEqual(e.result.errorDetails);
+                } catch (e) {
+                    done(e);
+                }
+            };
+
+            s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
+                CheckSynthesisResult(result, sdk.ResultReason.Canceled);
+                expect(result.errorDetails).toContain("voice");
+                const cancellationDetail: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(result);
                 expect(cancellationDetail.ErrorCode).toEqual(sdk.CancellationErrorCode.BadRequestParameters);
                 expect(cancellationDetail.reason).toEqual(sdk.CancellationReason.Error);
-                expect(cancellationDetail.errorDetails).toEqual(e.result.errorDetails);
-            } catch (e) {
+                expect(cancellationDetail.errorDetails).toEqual(result.errorDetails);
+            }, (e: string): void => {
                 done(e);
-            }
-        };
+            });
 
-        s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
-            CheckSynthesisResult(result, sdk.ResultReason.Canceled);
-            expect(result.errorDetails).toContain("voice");
-            const cancellationDetail: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(result);
-            expect(cancellationDetail.ErrorCode).toEqual(sdk.CancellationErrorCode.BadRequestParameters);
-            expect(cancellationDetail.reason).toEqual(sdk.CancellationReason.Error);
-            expect(cancellationDetail.errorDetails).toEqual(result.errorDetails);
-        }, (e: string): void => {
-            done(e);
-        });
-
-        s.speakTextAsync("today is a nice day.", (result: sdk.SpeechSynthesisResult): void => {
-            CheckSynthesisResult(result, sdk.ResultReason.Canceled);
-            expect(result.errorDetails).toContain("voice");
-            const cancellationDetail: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(result);
-            expect(cancellationDetail.ErrorCode).toEqual(sdk.CancellationErrorCode.BadRequestParameters);
-            expect(cancellationDetail.reason).toEqual(sdk.CancellationReason.Error);
-            expect(cancellationDetail.errorDetails).toEqual(result.errorDetails);
-            done();
-        }, (e: string): void => {
-            done(e);
+            s.speakTextAsync("today is a nice day.", (result: sdk.SpeechSynthesisResult): void => {
+                CheckSynthesisResult(result, sdk.ResultReason.Canceled);
+                expect(result.errorDetails).toContain("voice");
+                const cancellationDetail: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(result);
+                expect(cancellationDetail.ErrorCode).toEqual(sdk.CancellationErrorCode.BadRequestParameters);
+                expect(cancellationDetail.reason).toEqual(sdk.CancellationReason.Error);
+                expect(cancellationDetail.errorDetails).toEqual(result.errorDetails);
+                done();
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test("testSpeechSynthesizer: synthesis to pull audio output stream.", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizer: synthesis to pull audio output stream.", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizer synthesis to pull audio output stream.");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
 
-        const stream = sdk.AudioOutputStream.createPullStream();
-        const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromStreamOutput(stream);
-        expect(audioConfig).not.toBeUndefined();
+            const stream = sdk.AudioOutputStream.createPullStream();
+            const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromStreamOutput(stream);
+            expect(audioConfig).not.toBeUndefined();
 
-        setTimeout(() => {
-            ReadPullAudioOutputStream(stream, undefined, done);
-        }, 0);
+            setTimeout(() => {
+                ReadPullAudioOutputStream(stream, undefined, done);
+            }, 0);
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
-        expect(s).not.toBeUndefined();
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
+            expect(s).not.toBeUndefined();
 
-        s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking text finished.");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            s.close();
-        }, (e: string): void => {
-            done(e);
+            s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking text finished.");
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                s.close();
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test("testSpeechSynthesizer: synthesis to pull audio output stream 2.", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizer: synthesis to pull audio output stream 2.", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizer synthesis to pull audio output stream 2.");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
-        speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
+            speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
 
-        const stream = sdk.AudioOutputStream.createPullStream();
-        const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromStreamOutput(stream);
-        expect(audioConfig).not.toBeUndefined();
+            const stream = sdk.AudioOutputStream.createPullStream();
+            const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromStreamOutput(stream);
+            expect(audioConfig).not.toBeUndefined();
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
-        expect(s).not.toBeUndefined();
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
+            expect(s).not.toBeUndefined();
 
-        s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking text finished.");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            s.close();
-            ReadPullAudioOutputStream(stream, result.audioData.byteLength - 44, done);
-        }, (e: string): void => {
-            done(e);
+            s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking text finished.");
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                s.close();
+                ReadPullAudioOutputStream(stream, result.audioData.byteLength - 44, done);
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    Settings.testIfDOMCondition("testSpeechSynthesizer: synthesis to push audio output stream.", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("testSpeechSynthesizer: synthesis to push audio output stream.", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizer synthesis to push audio output stream.");
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
 
-        const stream = new PushAudioOutputStreamTestCallback();
-        const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromStreamOutput(stream);
-        expect(audioConfig).not.toBeUndefined();
+            const stream = new PushAudioOutputStreamTestCallback();
+            const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromStreamOutput(stream);
+            expect(audioConfig).not.toBeUndefined();
 
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
-        expect(s).not.toBeUndefined();
+            const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
+            expect(s).not.toBeUndefined();
 
-        s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking text finished.");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            s.close();
-            expect(stream.length).toEqual(result.audioData.byteLength);
-            expect(stream.isClosed).toEqual(true);
-            done();
-        }, (e: string): void => {
-            done(e);
+            s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking text finished.");
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                s.close();
+                expect(stream.length).toEqual(result.audioData.byteLength);
+                expect(stream.isClosed).toEqual(true);
+                done();
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
@@ -912,65 +1078,68 @@ describe("Service based tests", () => {
         });
     });
 
-    test("test Speech Synthesizer: Language Auto Detection", (done: jest.DoneCallback) => {
+    test("test Speech Synthesizer: Language Auto Detection", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: test Speech Synthesizer, Language Auto Detection");
 
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
-        objsToClose.push(speechConfig);
-        const autoDetectSourceLanguageConfig: sdk.AutoDetectSourceLanguageConfig = sdk.AutoDetectSourceLanguageConfig.fromOpenRange();
-        objsToClose.push(autoDetectSourceLanguageConfig);
+        BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
+            objsToClose.push(speechConfig);
+            const autoDetectSourceLanguageConfig: sdk.AutoDetectSourceLanguageConfig = sdk.AutoDetectSourceLanguageConfig.fromOpenRange();
+            objsToClose.push(autoDetectSourceLanguageConfig);
 
-        const s: sdk.SpeechSynthesizer = sdk.SpeechSynthesizer.FromConfig(speechConfig, autoDetectSourceLanguageConfig, null);
-        objsToClose.push(s);
-        expect(s).not.toBeUndefined();
+            const s: sdk.SpeechSynthesizer = sdk.SpeechSynthesizer.FromConfig(speechConfig, autoDetectSourceLanguageConfig, null);
+            objsToClose.push(s);
+            expect(s).not.toBeUndefined();
 
-        const con: sdk.Connection = sdk.Connection.fromSynthesizer(s);
+            const con: sdk.Connection = sdk.Connection.fromSynthesizer(s);
 
-        con.messageSent = (args: sdk.ConnectionMessageEventArgs): void => {
-            if (args.message.path === "synthesis.context" && args.message.isTextMessage) {
-                try {
-                    expect(args.message.TextMessage).toContain(`\"autoDetection\":true`);
-                } catch (error) {
-                    done(error);
+            con.messageSent = (args: sdk.ConnectionMessageEventArgs): void => {
+                if (args.message.path === "synthesis.context" && args.message.isTextMessage) {
+                    try {
+                        expect(args.message.TextMessage).toContain("\"autoDetection\":true");
+                    } catch (error) {
+                        done(error);
+                    }
                 }
-            }
-        };
+            };
 
-        s.SynthesisCanceled = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
-            done();
-        };
+            s.SynthesisCanceled = (o: sdk.SpeechSynthesizer, e: sdk.SpeechSynthesisEventArgs): void => {
+                done();
+            };
 
-        // we will get very short audio as the en-US voices are not mix-lingual.
-        s.speakTextAsync("你好世界。", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking finished, turn 1");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            expect(result.audioData.byteLength).toBeGreaterThan(64 << 7); // longer than 1s
-        }, (e: string): void => {
-            done(e);
-        });
+            // we will get very short audio as the en-US voices are not mix-lingual.
+            s.speakTextAsync("你好世界。", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking finished, turn 1");
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                expect(result.audioData.byteLength).toBeGreaterThan(64 << 7); // longer than 1s
+            }, (e: string): void => {
+                done(e);
+            });
 
-        s.speakTextAsync("今天天气很好。", (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("speaking finished, turn 2");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            expect(result.audioData.byteLength).toBeGreaterThan(64 << 7); // longer than 1s
-            done();
-        }, (e: string): void => {
-            done(e);
+            s.speakTextAsync("今天天气很好。", (result: sdk.SpeechSynthesisResult): void => {
+                // eslint-disable-next-line no-console
+                console.info("speaking finished, turn 2");
+                CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+                expect(result.audioData.byteLength).toBeGreaterThan(64 << 7); // longer than 1s
+                done();
+            }, (e: string): void => {
+                done(e);
+            });
+        }).catch((error: string): void => {
+            done(error);
         });
     });
 
-    test("testSpeechSynthesizerUsingCustomVoice", (done: jest.DoneCallback) => {
+    test("testSpeechSynthesizerUsingCustomVoice", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizerUsingCustomVoice");
 
         let uri: string;
         Events.instance.attachListener({
-            onEvent: (event: PlatformEvent) => {
+            onEvent: (event: PlatformEvent): void => {
                 if (event instanceof ConnectionStartEvent) {
-                    const connectionEvent: ConnectionStartEvent = event as ConnectionStartEvent;
+                    const connectionEvent: ConnectionStartEvent = event;
                     uri = connectionEvent.uri;
                 }
             },
@@ -998,15 +1167,15 @@ describe("Service based tests", () => {
     });
 
     // WebRTC PeerConnection is not implemented in jest, which is only available in browser.
-    test.skip("testAvatarSynthesizerDemo", async () => {
-        const speechConfig: sdk.SpeechConfig = BuildSpeechConfig();
+    test.skip("testAvatarSynthesizerDemo", async (): Promise<void> => {
+        const speechConfig: sdk.SpeechConfig = await BuildSpeechConfig();
         const videoFormat: sdk.AvatarVideoFormat = new sdk.AvatarVideoFormat(
-            /*codec*/ "h264",
-            /*bitrate*/ 2000000,
-            /*width*/ 1920,
-            /*height*/ 1080);
+            /* codec */ "h264",
+            /* bitrate */ 2000000,
+            /* width */ 1920,
+            /* height */ 1080);
         const avatarConfig: sdk.AvatarConfig = new sdk.AvatarConfig(
-            /*character*/ "lisa", /*style*/ "casual-sitting", videoFormat);
+            /* character */ "lisa", /* style */ "casual-sitting", videoFormat);
         const avatarSynthesizer: sdk.AvatarSynthesizer = new sdk.AvatarSynthesizer(speechConfig, avatarConfig);
         avatarSynthesizer.avatarEventReceived = (o: sdk.AvatarSynthesizer, e: sdk.AvatarEventArgs): void => {
             // eslint-disable-next-line no-console
@@ -1022,10 +1191,10 @@ describe("Service based tests", () => {
         let peerConnection: RTCPeerConnection;
         try {
             peerConnection = new RTCPeerConnection(
-                {iceServers: [iceServer]},
+                { iceServers: [iceServer] },
             );
         } catch (error) {
-            throw new Error("Failed to create RTCPeerConnection, error: " + error);
+            throw new Error("Failed to create RTCPeerConnection, error: " + error.toString());
         }
 
         const webrtcConnectionResult: sdk.SynthesisResult = await avatarSynthesizer.startAvatarAsync(peerConnection);

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -69,7 +69,6 @@ const BuildSpeechConfig: (connectionType?: SpeechConnectionType) => Promise<sdk.
 const CheckSynthesisResult: (result: sdk.SpeechSynthesisResult, reason: sdk.ResultReason) =>
     void = (result: sdk.SpeechSynthesisResult, reason: sdk.ResultReason): void => {
         expect(result).not.toBeUndefined();
-        expect(result.errorDetails).toBeUndefined();
         expect(sdk.ResultReason[result.reason]).toEqual(sdk.ResultReason[reason]);
         switch (reason) {
             case sdk.ResultReason.SynthesizingAudio:

--- a/tests/TranslationRecognizerBasicsTests.ts
+++ b/tests/TranslationRecognizerBasicsTests.ts
@@ -8,32 +8,34 @@ import {
 } from "../src/common.browser/Exports";
 import { ServiceRecognizerBase } from "../src/common.speech/Exports";
 import {
-    Events,
-    EventType
+    Deferred,
+    Events
 } from "../src/common/Exports";
 
+import { AudioStreamFormatImpl } from "../src/sdk/Audio/AudioStreamFormat";
 import { ByteBufferAudioFile } from "./ByteBufferAudioFile";
 import { Settings } from "./Settings";
 import { validateTelemetry } from "./TelemetryUtil";
 import {
     closeAsyncObjects,
     RepeatingPullStream,
-    WaitForCondition
+    WaitForCondition,
 } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
+import { SpeechConfigConnectionFactory } from "./SpeechConfigConnectionFactories";
+import { SpeechConnectionType } from "./SpeechConnectionTypes";
 
-import { AudioStreamFormatImpl } from "../src/sdk/Audio/AudioStreamFormat";
-
+import { SpeechServiceType } from "./SpeechServiceTypes";
 
 let objsToClose: any[];
 
-beforeAll(() => {
+beforeAll((): void => {
     // Override inputs, if necessary
     Settings.LoadSettings();
     Events.instance.attachListener(new ConsoleLoggingListener(sdk.LogLevel.Debug));
 });
 
-beforeEach(() => {
+beforeEach((): void => {
     objsToClose = [];
     // eslint-disable-next-line no-console
     console.info("------------------Starting test case: " + expect.getState().currentTestName + "-------------------------");
@@ -49,11 +51,11 @@ afterEach(async (): Promise<void> => {
     await closeAsyncObjects(objsToClose);
 });
 
-const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechTranslationConfig, audioConfig?: sdk.AudioConfig) => sdk.TranslationRecognizer = (speechConfig?: sdk.SpeechTranslationConfig, audioConfig?: sdk.AudioConfig): sdk.TranslationRecognizer => {
+const BuildRecognizerFromWaveFile = async (speechConfig?: sdk.SpeechTranslationConfig, audioConfig?: sdk.AudioConfig): Promise<sdk.TranslationRecognizer> => {
 
     let s: sdk.SpeechTranslationConfig = speechConfig;
     if (s === undefined) {
-        s = BuildSpeechConfig();
+        s = await BuildSpeechConfig();
         // Since we're not going to return it, mark it for closure.
         objsToClose.push(s);
     }
@@ -77,10 +79,24 @@ const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechTranslationConfig, 
     return r;
 };
 
-const BuildSpeechConfig: () => sdk.SpeechTranslationConfig = (): sdk.SpeechTranslationConfig => {
-    const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
-    expect(s).not.toBeUndefined();
-    return s;
+const BuildSpeechConfig = async (connectionType?: SpeechConnectionType): Promise<sdk.SpeechTranslationConfig> => {
+    if (undefined === connectionType) {
+        const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
+        expect(s).not.toBeUndefined();
+        return s;
+    } else {
+        const s: sdk.SpeechTranslationConfig = await SpeechConfigConnectionFactory.getSpeechConfig(connectionType, SpeechServiceType.SpeechRecognition, true);
+        expect(s).not.toBeUndefined();
+
+        // eslint-disable-next-line no-console
+        console.info("SpeechTranslationConfig created " + s.speechRecognitionLanguage + " " + SpeechConnectionType[connectionType]);
+
+        if (undefined !== Settings.proxyServer) {
+            s.setProxy(Settings.proxyServer, Settings.proxyPort);
+        }
+
+        return s;
+    }
 };
 
 const FIRST_EVENT_ID: number = 1;
@@ -90,11 +106,11 @@ const Canceled: string = "Canceled";
 
 let eventIdentifier: number;
 
-test("TranslationRecognizerMicrophone", () => {
+test("TranslationRecognizerMicrophone", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: TranslationRecognizerMicrophone");
 
-    const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
+    const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
     objsToClose.push(s);
     expect(s).not.toBeUndefined();
     s.addTargetLanguage("en-US");
@@ -106,27 +122,27 @@ test("TranslationRecognizerMicrophone", () => {
     expect(r instanceof sdk.Recognizer).toEqual(true);
 });
 
-test("TranslationRecognizerWavFile", () => {
+test("TranslationRecognizerWavFile", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: TranslationRecognizerWavFile");
-    const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+    const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
     objsToClose.push(r);
 });
 
-test("GetSourceLanguage", () => {
+test("GetSourceLanguage", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: GetSourceLanguage");
-    const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+    const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
     objsToClose.push(r);
     expect(r.speechRecognitionLanguage).not.toBeUndefined();
     expect(r.speechRecognitionLanguage).not.toBeNull();
     expect(r.speechRecognitionLanguage).toEqual(r.properties.getProperty(sdk.PropertyId[sdk.PropertyId.SpeechServiceConnection_RecoLanguage]));
 });
 
-test("GetParameters", () => {
+test("GetParameters", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: GetParameters");
-    const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+    const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
     objsToClose.push(r);
 
     expect(r.properties).not.toBeUndefined();
@@ -137,27 +153,124 @@ test("GetParameters", () => {
     expect(r.targetLanguages[0]).toEqual(r.properties.getProperty(sdk.PropertyId.SpeechServiceConnection_TranslationToLanguages));
 });
 
-describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
+describe.each([
+    SpeechConnectionType.Subscription,
+    SpeechConnectionType.LegacyCogSvcsTokenAuth,
+    SpeechConnectionType.LegacyEntraIdTokenAuth,
+    SpeechConnectionType.CloudFromHost,
+    SpeechConnectionType.LegacyPrivateLinkWithKeyAuth,
+    SpeechConnectionType.LegacyPrivateLinkWithEntraIdTokenAuth
+])("Translation Recognizer Basics Connection Tests", (connectionType: SpeechConnectionType): void => {
 
-    beforeEach(() => {
+    const runTest: jest.It = SpeechConfigConnectionFactory.runConnectionTest(connectionType);
+
+    runTest("StartContinuousRecognitionAsync with Multiple Connection Types " + SpeechConnectionType[connectionType], async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
-        console.info("forceNodeWebSocket: " + forceNodeWebSocket);
+        console.info("Name: StartContinuousRecognitionAsync with Multiple Connection Types " + SpeechConnectionType[connectionType]);
+
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig(connectionType);
+        objsToClose.push(s);
+
+        s.addTargetLanguage("de-DE");
+        s.speechRecognitionLanguage = "en-US";
+
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        r.canceled = (o: sdk.TranslationRecognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.reject(error);
+            }
+        };
+
+        r.startContinuousRecognitionAsync((): void => {
+            // Just long enough to start the connection, but not as long as recognition takes.
+            const end: number = Date.now() + 1000;
+
+            WaitForCondition((): boolean => end <= Date.now(), (): void => {
+                r.stopContinuousRecognitionAsync((): void => {
+                    done.resolve();
+                }, (error: string): Deferred<void> => done.reject(error));
+            });
+        }, (error: string): Deferred<void> => done.reject(error));
+
+        await done.promise;
+    }, 15000);
+
+    runTest("StartStopContinuousRecognitionAsync with Multiple Connection Types " + SpeechConnectionType[connectionType], async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
+        // eslint-disable-next-line no-console
+        console.info("Name: StartStopContinuousRecognitionAsync with Multiple Connection Types " + SpeechConnectionType[connectionType]);
+
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig(connectionType);
+        objsToClose.push(s);
+
+        s.addTargetLanguage("de-DE");
+        s.speechRecognitionLanguage = "en-US";
+
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        const rEvents: { [id: string]: string } = {};
+
+        r.recognized = ((o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs): void => {
+            const result: string = e.result.translations.get("de", "");
+            rEvents["Result@" + Date.now().toString()] = result;
+            try {
+                expect(e.result.properties).not.toBeUndefined();
+                expect(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
+            } catch (error) {
+                done.reject(error);
+            }
+        });
+
+        r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+            try {
+                expect(e.errorDetails).toBeUndefined();
+            } catch (error) {
+                done.reject(error);
+            }
+        };
+
+        r.startContinuousRecognitionAsync();
+
+        WaitForCondition((): boolean => Object.keys(rEvents).length > 0, (): void => {
+            try {
+                expect(rEvents[Object.keys(rEvents)[0]]).toEqual("Wie ist das Wetter?");
+                r.stopContinuousRecognitionAsync((): Deferred<void> => done.resolve(), (error: string) => done.reject(error));
+            } catch (error) {
+                done.reject(error);
+            }
+        });
+
+        await done.promise;
+    }, 15000);
+});
+
+describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): void => {
+
+    beforeEach((): void => {
+        // eslint-disable-next-line no-console
+        console.info("forceNodeWebSocket: " + forceNodeWebSocket.toString());
         WebsocketMessageAdapter.forceNpmWebSocket = forceNodeWebSocket;
     });
-    afterAll(() => {
+    afterAll((): void => {
         WebsocketMessageAdapter.forceNpmWebSocket = false;
     });
 
-    describe("Counts Telemetry", () => {
-        afterAll(() => {
+    describe("Counts Telemetry", (): void => {
+        afterAll((): void => {
             ServiceRecognizerBase.telemetryData = undefined;
         });
 
         // telemetry counts aren't lining up - investigate
-        test.skip("RecognizeOnceAsync1", (done: jest.DoneCallback) => {
+        test.skip("RecognizeOnceAsync1", async (done: jest.DoneCallback): Promise<void> => {
             // eslint-disable-next-line no-console
             console.info("Name: RecognizeOnceAsync1");
-            const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+            const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
             objsToClose.push(r);
 
             let telemetryEvents: number = 0;
@@ -195,7 +308,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                 }
             };
 
-            r.sessionStopped = (s: sdk.SpeechRecognizer, e: sdk.SpeechRecognitionEventArgs) => {
+            r.sessionStopped = (s: sdk.SpeechRecognizer, e: sdk.SpeechRecognitionEventArgs): void => {
                 try {
                     expect(telemetryEvents).toEqual(1);
                     done();
@@ -205,7 +318,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
             };
 
             r.recognizeOnceAsync(
-                (res: sdk.TranslationRecognitionResult) => {
+                (res: sdk.TranslationRecognitionResult): void => {
                     expect(res).not.toBeUndefined();
                     expect(res.errorDetails).toBeUndefined();
                     expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
@@ -213,13 +326,14 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                     expect("Wie ist das Wetter?").toEqual(res.translations.get("de", ""));
                     expect(res.text).toEqual("What's the weather like?");
                 },
-                (error: string) => {
+                (error: string): void => {
                     done(error);
                 });
         });
     });
 
-    test("Validate Event Ordering", (done: jest.DoneCallback) => {
+    test("Validate Event Ordering", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: Validate Event Ordering");
         const SpeechStartDetectedEvent = "SpeechStartDetectedEvent";
@@ -227,49 +341,49 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
         const SessionStartedEvent = "SessionStartedEvent";
         const SessionStoppedEvent = "SessionStoppedEvent";
 
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
         objsToClose.push(r);
 
         const eventsMap: { [id: string]: number; } = {};
         eventIdentifier = 1;
 
-        r.recognized = (o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs) => {
+        r.recognized = (o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs): void => {
             eventsMap[Recognized] = eventIdentifier++;
         };
 
-        r.recognizing = (o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs) => {
+        r.recognizing = (o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[Recognizing + "-" + Date.now().toPrecision(4)] = now;
             eventsMap[Recognizing] = now;
         };
 
-        r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs) => {
+        r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
             eventsMap[Canceled] = eventIdentifier++;
             try {
                 expect(e.errorDetails).toBeUndefined();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
         // TODO eventType should be renamed and be a function getEventType()
-        r.speechStartDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs) => {
+        r.speechStartDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[SpeechStartDetectedEvent + "-" + Date.now().toPrecision(4)] = now;
             eventsMap[SpeechStartDetectedEvent] = now;
         };
-        r.speechEndDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs) => {
+        r.speechEndDetected = (o: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[SpeechEndDetectedEvent + "-" + Date.now().toPrecision(4)] = now;
             eventsMap[SpeechEndDetectedEvent] = now;
         };
 
-        r.sessionStarted = (o: sdk.Recognizer, e: sdk.SessionEventArgs) => {
+        r.sessionStarted = (o: sdk.Recognizer, e: sdk.SessionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[SessionStartedEvent + "-" + Date.now().toPrecision(4)] = now;
             eventsMap[SessionStartedEvent] = now;
         };
-        r.sessionStopped = (o: sdk.Recognizer, e: sdk.SessionEventArgs) => {
+        r.sessionStopped = (o: sdk.Recognizer, e: sdk.SessionEventArgs): void => {
             const now: number = eventIdentifier++;
             eventsMap[SessionStoppedEvent + "-" + Date.now().toPrecision(4)] = now;
             eventsMap[SessionStoppedEvent] = now;
@@ -283,7 +397,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
         // Recognized
         // SessionEnded
 
-        r.recognizeOnceAsync((res: sdk.TranslationRecognitionResult) => {
+        r.recognizeOnceAsync((res: sdk.TranslationRecognitionResult): void => {
             try {
                 expect(res).not.toBeUndefined();
                 expect(res.errorDetails).toBeUndefined();
@@ -330,48 +444,52 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                 // make sure events we don't expect, don't get raised
                 // The canceled event comes *after* the callback.
                 expect(Canceled in eventsMap).toBeFalsy();
-                done();
+                done.resolve();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
-        }, (error: string) => {
-            done(error);
+        }, (error: string): void => {
+            done.reject(error);
         });
+
+        await done.promise;
     });
 
-    test("StartContinuousRecognitionAsync", (done: jest.DoneCallback) => {
+    test("StartContinuousRecognitionAsync", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: StartContinuousRecognitionAsync");
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
         objsToClose.push(r);
 
         r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
             try {
                 expect(e.errorDetails).toBeUndefined();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
-        r.startContinuousRecognitionAsync(() => {
+        r.startContinuousRecognitionAsync((): void => {
 
             // Just long enough to start the connection, but not as long as recognition takes.
             const end: number = Date.now() + 1000;
 
-            WaitForCondition(() => {
-                return end <= Date.now();
-            }, () => {
-                r.stopContinuousRecognitionAsync(() => {
-                    done();
-                }, (error: string) => done(error));
+            WaitForCondition((): boolean => end <= Date.now(), (): void => {
+                r.stopContinuousRecognitionAsync((): void => {
+                    done.resolve();
+                }, (error: string): Deferred<void> => done.reject(error));
             });
-        }, (error: string) => done(error));
+        }, (error: string): Deferred<void> => done.reject(error));
+
+        await done.promise;
     });
 
-    test("StopContinuousRecognitionAsync", (done: jest.DoneCallback) => {
+    test("StopContinuousRecognitionAsync", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: StopContinuousRecognitionAsync");
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
         objsToClose.push(r);
 
         r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
@@ -379,36 +497,37 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                 expect(e.errorDetails).toBeUndefined();
                 expect(e.reason).not.toEqual(sdk.CancellationReason.Error);
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
-        r.startContinuousRecognitionAsync(() => {
+        r.startContinuousRecognitionAsync((): void => {
             const end: number = Date.now() + 1000;
 
-            WaitForCondition(() => {
-                return end <= Date.now();
-            }, () => {
-                r.stopContinuousRecognitionAsync(() => done(), (error: string) => done(error));
+            WaitForCondition((): boolean => end <= Date.now(), (): void => {
+                r.stopContinuousRecognitionAsync((): Deferred<void> => done.resolve(), (error: string): Deferred<void> => done.reject(error));
             });
-        }, (error: string) => done(error));
+        }, (error: string): Deferred<void> => done.reject(error));
+
+        await done.promise;
     });
 
-    test("StartStopContinuousRecognitionAsync", (done: jest.DoneCallback) => {
+    test("StartStopContinuousRecognitionAsync", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: StartStopContinuousRecognitionAsync");
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
         objsToClose.push(r);
 
-        const rEvents: { [id: string]: string; } = {};
+        const rEvents: { [id: string]: string } = {};
 
-        r.recognized = ((o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs) => {
+        r.recognized = ((o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs): void => {
             const result: string = e.result.translations.get("de", "");
-            rEvents["Result@" + Date.now()] = result;
+            rEvents["Result@" + Date.now().toString()] = result;
             try {
                 expect(e.result.properties).not.toBeUndefined();
                 expect(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         });
 
@@ -416,25 +535,26 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
             try {
                 expect(e.errorDetails).toBeUndefined();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
         r.startContinuousRecognitionAsync();
 
-        WaitForCondition((): boolean => {
-            return Object.keys(rEvents).length > 0;
-        }, () => {
+        WaitForCondition((): boolean => Object.keys(rEvents).length > 0, (): void => {
             try {
                 expect(rEvents[Object.keys(rEvents)[0]]).toEqual("Wie ist das Wetter?");
+                r.stopContinuousRecognitionAsync((): Deferred<void> => done.resolve(), (error: string): Deferred<void> => done.reject(error));
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
-            r.stopContinuousRecognitionAsync(() => done(), (error: string) => done(error));
         });
+
+        await done.promise;
     });
-    
-    test("InitialSilenceTimeout (pull)", (done: jest.DoneCallback) => {
+
+    test("InitialSilenceTimeout (pull)", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: InitialSilenceTimeout (pull)");
         let p: sdk.PullAudioInputStream;
@@ -455,7 +575,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
 
-        testInitialSilenceTimeout(config, done, (): void => {
+        await testInitialSilenceTimeout(config, done, (): void => {
             const elapsed: number = Date.now() - startTime;
 
             // We should have sent 5 seconds of audio unthrottled and then 2x the time reco took until we got a response.
@@ -463,9 +583,12 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
             expect(bytesSent).toBeLessThanOrEqual(expectedBytesSent);
 
         });
+
+        await done.promise;
     }, 20000);
 
-    test("InitialSilenceTimeout (push)", (done: jest.DoneCallback) => {
+    test("InitialSilenceTimeout (push)", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: InitialSilenceTimeout (push)");
         const p: sdk.PushAudioInputStream = sdk.AudioInputStream.createPushStream();
@@ -475,10 +598,12 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
         p.write(bigFileBuffer.buffer);
         p.close();
 
-        testInitialSilenceTimeout(config, done);
+        await testInitialSilenceTimeout(config, done);
+        await done.promise;
     }, 15000);
 
-    Settings.testIfDOMCondition("InitialSilenceTimeout (File)", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("InitialSilenceTimeout (File)", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: InitialSilenceTimeout (File)");
         const audioFormat: AudioStreamFormatImpl = sdk.AudioStreamFormat.getDefaultInputFormat() as AudioStreamFormatImpl;
@@ -487,11 +612,12 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         const config: sdk.AudioConfig = sdk.AudioConfig.fromWavFileInput(bigFile);
 
-        testInitialSilenceTimeout(config, done);
+        await testInitialSilenceTimeout(config, done);
+        await done.promise;
     }, 15000);
 
-    const testInitialSilenceTimeout = (config: sdk.AudioConfig, done: jest.DoneCallback, addedChecks?: () => void): void => {
-        const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+    const testInitialSilenceTimeout = async (config: sdk.AudioConfig, done: Deferred<void>, addedChecks?: () => void): Promise<void> => {
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
         objsToClose.push(s);
 
         s.addTargetLanguage("de-DE");
@@ -505,11 +631,11 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
 
         let numReports: number = 0;
 
-        r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs) => {
-            done(e.errorDetails);
+        r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+            done.reject(e.errorDetails);
         };
 
-        r.recognized = (o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs) => {
+        r.recognized = (o: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs): void => {
             try {
                 const res: sdk.SpeechRecognitionResult = e.result;
                 expect(res).not.toBeUndefined();
@@ -519,46 +645,48 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                 const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
                 expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
             } catch (error) {
-                done(error);
+                done.reject(error);
             } finally {
                 numReports++;
             }
-
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.TranslationRecognitionResult) => {
-                const res: sdk.TranslationRecognitionResult = p2;
-                numReports++;
+            (p2: sdk.TranslationRecognitionResult): void => {
+                try {
+                    const res: sdk.TranslationRecognitionResult = p2;
+                    numReports++;
 
-                expect(res).not.toBeUndefined();
-                expect(sdk.ResultReason.NoMatch).toEqual(res.reason);
-                expect(res.errorDetails).toBeUndefined();
-                expect(res.text).toBeUndefined();
+                    expect(res).not.toBeUndefined();
+                    expect(sdk.ResultReason.NoMatch).toEqual(res.reason);
+                    expect(res.errorDetails).toBeUndefined();
+                    expect(res.text).toBeUndefined();
 
-                const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
-                expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
+                    const nmd: sdk.NoMatchDetails = sdk.NoMatchDetails.fromResult(res);
+                    expect(nmd.reason).toEqual(sdk.NoMatchReason.InitialSilenceTimeout);
+                } catch (error) {
+                    done.reject(error);
+                }
             },
-            (error: string) => {
-                fail(error);
-            });
+            (error: string): Deferred<void> => done.reject(error));
 
-        WaitForCondition(() => (numReports === 2), () => {
+        WaitForCondition((): boolean => (numReports === 2), (): void => {
             try {
                 if (!!addedChecks) {
                     addedChecks();
                 }
-                done();
+                done.resolve();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         });
     };
 
-    test.skip("emptyFile", (done: jest.DoneCallback) => {
+    test.skip("emptyFile", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: emptyFile");
-        const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
         objsToClose.push(s);
 
         const blob: Blob[] = [];
@@ -579,33 +707,32 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                 expect(cancelDetails.reason).toEqual(sdk.CancellationReason.Error);
 
                 if (true === oneCalled) {
-                    done();
+                    done.resolve();
                 } else {
                     oneCalled = true;
                 }
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
         r.recognizeOnceAsync(
-            (p2: sdk.SpeechRecognitionResult) => {
+            (p2: sdk.SpeechRecognitionResult): void => {
                 if (true === oneCalled) {
-                    done();
+                    done.resolve();
                 } else {
                     oneCalled = true;
                 }
-
             },
-            (error: string) => {
-                done(error);
-            });
+            (error: string): Deferred<void> => done.reject(error));
+
+        await done.promise;
     });
 
-    test("Audio Config is optional", () => {
+    test("Audio Config is optional", async (): Promise<void> => {
         // eslint-disable-next-line no-console
         console.info("Name: Audio Config is optional");
-        const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
         objsToClose.push(s);
         s.addTargetLanguage("de-DE");
         s.speechRecognitionLanguage = Settings.WaveFileLanguage;
@@ -617,7 +744,8 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
 
     });
 
-    Settings.testIfDOMCondition("Default mic is used when audio config is not specified. (once)", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Default mic is used when audio config is not specified. (once)", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: Default mic is used when audio config is not specified. (once)");
         const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
@@ -628,19 +756,22 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
         const r: sdk.TranslationRecognizer = new sdk.TranslationRecognizer(s);
         expect(r instanceof sdk.Recognizer).toEqual(true);
         // Node.js doesn't have a microphone natively. So we'll take the specific message that indicates that microphone init failed as evidence it was attempted.
-        r.recognizeOnceAsync(() => done("RecognizeOnceAsync returned success when it should have failed"),
+        r.recognizeOnceAsync((): Deferred<void> => done.reject("RecognizeOnceAsync returned success when it should have failed"),
             (error: string): void => {
                 try {
                     expect(error).not.toBeUndefined();
                     expect(error).toEqual("Error: Browser does not support Web Audio API (AudioContext is not available).");
-                    done();
+                    done.resolve();
                 } catch (error) {
-                    done(error);
+                    done.reject(error);
                 }
             });
+
+        await done.promise;
     });
 
-    Settings.testIfDOMCondition("Default mic is used when audio config is not specified. (Cont)", (done: jest.DoneCallback) => {
+    Settings.testIfDOMCondition("Default mic is used when audio config is not specified. (Cont)", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: Default mic is used when audio config is not specified. (Cont)");
         const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
@@ -651,48 +782,54 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
         const r: sdk.TranslationRecognizer = new sdk.TranslationRecognizer(s);
         expect(r instanceof sdk.Recognizer).toEqual(true);
 
-        r.startContinuousRecognitionAsync(() => done("startContinuousRecognitionAsync returned success when it should have failed"),
+        r.startContinuousRecognitionAsync(() => done.reject("startContinuousRecognitionAsync returned success when it should have failed"),
             (error: string): void => {
                 try {
                     expect(error).not.toBeUndefined();
                     expect(error).toEqual("Error: Browser does not support Web Audio API (AudioContext is not available).");
-                    done();
+                    done.resolve();
                 } catch (error) {
-                    done(error);
+                    done.reject(error);
                 }
             });
+
+        await done.promise;
     });
 
-    test("Connection Errors Propogate Async", (done: jest.DoneCallback) => {
+    test("Connection Errors Propogate Async", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: Connection Errors Propogate Async");
         const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription("badKey", Settings.SpeechRegion);
         objsToClose.push(s);
         s.addTargetLanguage("en-US");
 
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile(s);
 
         r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs) => {
             try {
                 expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
                 expect(sdk.CancellationErrorCode[e.errorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.ConnectionFailure]);
-                done();
+                done.resolve();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
         r.startContinuousRecognitionAsync();
+
+        await done.promise;
     }, 15000);
 
-    test("Connection Errors Propogate Sync", (done: jest.DoneCallback) => {
+    test("Connection Errors Propogate Sync", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: Connection Errors Propogate Sync");
         const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription("badKey", Settings.SpeechRegion);
         objsToClose.push(s);
         s.addTargetLanguage("en-US");
 
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile(s);
 
         let doneCount: number = 0;
         r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs) => {
@@ -702,7 +839,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                 expect(e.errorDetails).toContain("1006");
                 doneCount++;
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
@@ -714,22 +851,24 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                 expect(e.errorDetails).toContain("1006");
                 doneCount++;
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
 
-            WaitForCondition(() => (doneCount === 2), done);
-
+            WaitForCondition(() => (doneCount === 2), () => done.resolve());
         });
+
+        await done.promise;
     }, 15000);
 
-    test("Silence After Speech", (done: jest.DoneCallback) => {
+    test("Silence After Speech", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: Silence After Speech");
         // Pump valid speech and then silence until at least one speech end cycle hits.
         const p: sdk.PushAudioInputStream = sdk.AudioInputStream.createPushStream();
         const bigFileBuffer: Uint8Array = new Uint8Array(32 * 1024 * 30); // ~30 seconds.
         const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
-        const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
         s.addTargetLanguage("de-DE");
         s.speechRecognitionLanguage = "en-US";
         objsToClose.push(s);
@@ -757,7 +896,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                     noMatchCount++;
                 }
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
@@ -778,7 +917,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                 expect(e.reason).toEqual(sdk.CancellationReason.EndOfStream);
                 canceled = true;
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
@@ -792,28 +931,31 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                     try {
                         expect(speechEnded).toEqual(noMatchCount);
                         expect(noMatchCount).toEqual(2);
-                        done();
+                        done.resolve();
                     } catch (error) {
-                        done(error);
+                        done.reject(error);
                     }
                 }, (error: string) => {
-                    done(error);
+                    done.reject(error);
                 });
             });
         },
             (err: string) => {
-                done(err);
+                done.reject(err);
             });
+
+        await done.promise;
     }, 35000);
 
-    test("Silence Then Speech", (done: jest.DoneCallback) => {
+    test("Silence Then Speech", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: Silence Then Speech");
         // Pump valid speech and then silence until at least one speech end cycle hits.
         const p: sdk.PushAudioInputStream = sdk.AudioInputStream.createPushStream();
         const bigFileBuffer: Uint8Array = new Uint8Array(32 * 1024 * 30); // ~30 seconds.
         const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
-        const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
         objsToClose.push(s);
         s.speechRecognitionLanguage = "en-US";
         s.addTargetLanguage("de-DE");
@@ -836,14 +978,14 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
             try {
                 switch (e.reason) {
                     case sdk.CancellationReason.Error:
-                        done(e.errorDetails);
+                        done.reject(e.errorDetails);
                         break;
                     case sdk.CancellationReason.EndOfStream:
                         canceled = true;
                         break;
                 }
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
@@ -874,7 +1016,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                     noMatchCount++;
                 }
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
@@ -885,32 +1027,35 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean) => {
                         // TODO: investigate speech end in translation
                         // expect(speechEnded).toEqual(noMatchCount + 1);
                         expect(noMatchCount).toBeGreaterThanOrEqual(2);
-                        done();
+                        done.resolve();
                     } catch (error) {
-                        done(error);
+                        done.reject(error);
                     }
                 }, (error: string) => {
-                    done(error);
+                    done.reject(error);
                 });
             });
         },
             (err: string) => {
-                done(err);
+                done.reject(err);
             });
+
+        await done.promise;
     }, 35000);
 });
 
-test("Multiple Phrase Latency Reporting", (done: jest.DoneCallback) => {
+test("Multiple Phrase Latency Reporting", async (): Promise<void> => {
+    const done: Deferred<void> = new Deferred<void>();
     // eslint-disable-next-line no-console
     console.info("Name: Multiple Phrase Latency Reporting");
 
-    const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+    const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
     objsToClose.push(s);
     s.addTargetLanguage("de-DE");
     s.speechRecognitionLanguage = "en-US";
 
     let numSpeech: number = 0;
-    
+
     const pullStreamSource: RepeatingPullStream = new RepeatingPullStream(Settings.WaveFile);
     const p: sdk.PullAudioInputStream = pullStreamSource.PullStream;
 
@@ -941,7 +1086,7 @@ test("Multiple Phrase Latency Reporting", (done: jest.DoneCallback) => {
         try {
             expect(e.errorDetails).toBeUndefined();
         } catch (error) {
-            done(error);
+            done.reject(error);
         }
     };
 
@@ -959,19 +1104,21 @@ test("Multiple Phrase Latency Reporting", (done: jest.DoneCallback) => {
             }
 
         } catch (error) {
-            done(error);
+            done.reject(error);
         }
     };
 
     r.startContinuousRecognitionAsync(
         undefined,
         (error: string) => {
-            done(error);
+            done.reject(error);
         });
 
     WaitForCondition(() => (recoCount === 16), () => {
         r.stopContinuousRecognitionAsync(() => {
-            done();
+            done.resolve();
         });
     });
+
+    await done.promise;
 }, 120000);

--- a/tests/TranslationRecognizerTests.ts
+++ b/tests/TranslationRecognizerTests.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/common.browser/Exports";
 import { TranslationHypothesis, TranslationPhrase } from "../src/common.speech/Exports";
 import {
+    Deferred,
     Events,
 } from "../src/common/Exports";
 
@@ -18,6 +19,9 @@ import {
     RepeatingPullStream
 } from "./Utilities";
 import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
+import { SpeechConfigConnectionFactory } from "./SpeechConfigConnectionFactories";
+import { SpeechConnectionType } from "./SpeechConnectionTypes";
+import { SpeechServiceType } from "./SpeechServiceTypes";
 
 
 let objsToClose: any[];
@@ -44,11 +48,11 @@ afterEach(async (): Promise<void> => {
     await closeAsyncObjects(objsToClose);
 });
 
-const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechTranslationConfig, fileName?: string) => sdk.TranslationRecognizer = (speechConfig?: sdk.SpeechTranslationConfig, fileName?: string): sdk.TranslationRecognizer => {
+const BuildRecognizerFromWaveFile = async (speechConfig?: sdk.SpeechTranslationConfig, fileName?: string): Promise<sdk.TranslationRecognizer> => {
 
     let s: sdk.SpeechTranslationConfig = speechConfig;
     if (s === undefined) {
-        s = BuildSpeechConfig();
+        s = await BuildSpeechConfig();
         // Since we're not going to return it, mark it for closure.
         objsToClose.push(s);
     }
@@ -67,21 +71,34 @@ const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechTranslationConfig, 
     return r;
 };
 
-const BuildSpeechConfig: () => sdk.SpeechTranslationConfig = (): sdk.SpeechTranslationConfig => {
-    const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
-    expect(s).not.toBeUndefined();
+const BuildSpeechConfig = async (connectionType?: SpeechConnectionType): Promise<sdk.SpeechTranslationConfig> => {
+    if (undefined === connectionType) {
+        const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
+        expect(s).not.toBeUndefined();
 
-    if (undefined !== Settings.proxyServer) {
-        s.setProxy(Settings.proxyServer, Settings.proxyPort);
+        if (undefined !== Settings.proxyServer) {
+            s.setProxy(Settings.proxyServer, Settings.proxyPort);
+        }
+
+        return s;
+    } else {
+        const s: sdk.SpeechTranslationConfig = await SpeechConfigConnectionFactory.getSpeechConfig(connectionType, SpeechServiceType.SpeechRecognition, true);
+        expect(s).not.toBeUndefined();
+
+        console.info("SpeechTranslationConfig created " + s.speechRecognitionLanguage + " " + SpeechConnectionType[connectionType]);
+
+        if (undefined !== Settings.proxyServer) {
+            s.setProxy(Settings.proxyServer, Settings.proxyPort);
+        }
+
+        return s;
     }
-
-    return s;
 };
 
-test("GetTargetLanguages", (): void => {
+test("GetTargetLanguages", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: GetTargetLanguages");
-    const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+    const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
     objsToClose.push(r);
 
     expect(r.targetLanguages).not.toBeUndefined();
@@ -90,18 +107,18 @@ test("GetTargetLanguages", (): void => {
     expect(r.targetLanguages[0]).toEqual(r.properties.getProperty(sdk.PropertyId[sdk.PropertyId.SpeechServiceConnection_TranslationToLanguages]));
 });
 
-test.skip("GetOutputVoiceNameNoSetting", (): void => {
+test.skip("GetOutputVoiceNameNoSetting", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: GetOutputVoiceNameNoSetting");
-    const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+    const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
     objsToClose.push(r);
     expect(r.voiceName).not.toBeUndefined();
 });
 
-test("GetParameters", (): void => {
+test("GetParameters", async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("Name: GetParameters");
-    const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile();
+    const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile();
     objsToClose.push(r);
 
     expect(r.properties).not.toBeUndefined();
@@ -123,67 +140,79 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
         WebsocketMessageAdapter.forceNpmWebSocket = false;
     });
 
-    test("Translate Multiple Targets", (done: jest.DoneCallback): void => {
+    test("Translate Multiple Targets", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: Translate Multiple Targets");
-        const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
         objsToClose.push(s);
         s.addTargetLanguage("fr-FR");
 
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile(s);
         objsToClose.push(r);
 
         r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
             try {
                 expect(e.errorDetails).toBeUndefined();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
         r.recognizeOnceAsync(
             (res: sdk.TranslationRecognitionResult): void => {
-                expect(res).not.toBeUndefined();
-                expect(res.errorDetails).toBeUndefined();
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
-                expect("Wie ist das Wetter?").toEqual(res.translations.get("de", ""));
-                expect(res.translations.get("fr", "")).toContain("Quel temps fait-il");
-                expect(res.translations.languages).toEqual(["fr", "de"]);
-                expect(r.targetLanguages.length).toEqual(res.translations.languages.length);
-                r.removeTargetLanguage("de-DE");
-                expect(r.targetLanguages.includes("de-DE")).toBeFalsy();
-                r.addTargetLanguage("es-MX");
-                expect(r.targetLanguages.includes("es-MX")).toBeTruthy();
-                r.recognizeOnceAsync(
-                    (secondRes: sdk.TranslationRecognitionResult): void => {
-                        expect(secondRes).not.toBeUndefined();
-                        expect(secondRes.errorDetails).toBeUndefined();
-                        expect(sdk.ResultReason[secondRes.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
-                        expect(secondRes.translations.get("fr", "")).toContain("Quel temps fait-il");
-                        expect(secondRes.translations.languages.includes("es")).toBeTruthy();
-                        expect(secondRes.translations.languages.includes("fr")).toBeTruthy();
-                        expect(secondRes.translations.languages.includes("de")).toBeFalsy();
-                        expect("¿Cómo es el clima?").toEqual(secondRes.translations.get("es", ""));
-                        done();
-                    },
-                    (error: string): void => {
-                        done(error);
-                    });
+                try {
+                    expect(res).not.toBeUndefined();
+                    expect(res.errorDetails).toBeUndefined();
+                    expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
+                    expect("Wie ist das Wetter?").toEqual(res.translations.get("de", ""));
+                    expect(res.translations.get("fr", "")).toContain("Quel temps fait-il");
+                    expect(res.translations.languages).toEqual(["fr", "de"]);
+                    expect(r.targetLanguages.length).toEqual(res.translations.languages.length);
+                    r.removeTargetLanguage("de-DE");
+                    expect(r.targetLanguages.includes("de-DE")).toBeFalsy();
+                    r.addTargetLanguage("es-MX");
+                    expect(r.targetLanguages.includes("es-MX")).toBeTruthy();
+                    r.recognizeOnceAsync(
+                        (secondRes: sdk.TranslationRecognitionResult): void => {
+                            try {
+                                expect(secondRes).not.toBeUndefined();
+                                expect(secondRes.errorDetails).toBeUndefined();
+                                expect(sdk.ResultReason[secondRes.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
+                                expect(secondRes.translations.get("fr", "")).toContain("Quel temps fait-il");
+                                expect(secondRes.translations.languages.includes("es")).toBeTruthy();
+                                expect(secondRes.translations.languages.includes("fr")).toBeTruthy();
+                                expect(secondRes.translations.languages.includes("de")).toBeFalsy();
+                                expect("¿Cómo es el clima?").toEqual(secondRes.translations.get("es", ""));
+                                done.resolve();
+                            } catch (error) {
+                                done.reject(error);
+                            }
+                        },
+                        (error: string): void => {
+                            done.reject(error);
+                        });
+                } catch (error) {
+                    done.reject(error);
+                }
             },
             (error: string): void => {
-                done(error);
+                done.reject(error);
             });
+
+        await done.promise;
     }, 30000);
 
-    test("Translate Bad Language", (done: jest.DoneCallback): void => {
+    test("Translate Bad Language", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: Translate Bad Language");
-        const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
         objsToClose.push(s);
 
         s.addTargetLanguage("zz");
 
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile(s);
         objsToClose.push(r);
 
         expect(r).not.toBeUndefined();
@@ -193,35 +222,42 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
         r.synthesizing = ((o: sdk.Recognizer, e: sdk.TranslationSynthesisEventArgs): void => {
             try {
                 if (e.result.reason === sdk.ResultReason.Canceled) {
-                    done(sdk.ResultReason[e.result.reason]);
+                    done.reject(sdk.ResultReason[e.result.reason]);
                 }
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         });
 
         r.recognizeOnceAsync(
             (res: sdk.TranslationRecognitionResult): void => {
-                expect(res).not.toBeUndefined();
-                expect(res.errorDetails).not.toBeUndefined();
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
-                expect(res.text).toEqual("What's the weather like?");
-                done();
+                try {
+                    expect(res).not.toBeUndefined();
+                    expect(res.errorDetails).not.toBeUndefined();
+                    expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
+                    expect(res.text).toEqual("What's the weather like?");
+                    done.resolve();
+                } catch (error) {
+                    done.reject(error);
+                }
             },
             (error: string): void => {
-                done(error);
+                done.reject(error);
             });
+
+        await done.promise;
     });
 
-    test("RecognizeOnce Bad Language", (done: jest.DoneCallback): void => {
+    test("RecognizeOnce Bad Language", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: RecognizeOnce Bad Language");
-        const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
         objsToClose.push(s);
         s.speechRecognitionLanguage = "BadLanguage";
         s.addTargetLanguage("en-US");
 
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile(s);
         objsToClose.push(r);
         let doneCount: number = 0;
 
@@ -232,7 +268,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
                 expect(e.errorDetails).toContain("1007");
                 doneCount++;
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
@@ -244,14 +280,17 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
                 expect(e.errorDetails).toContain("1007");
                 doneCount++;
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         });
 
-        WaitForCondition((): boolean => (doneCount === 2), done);
+        WaitForCondition((): boolean => (doneCount === 2), () => done.resolve());
+
+        await done.promise;
     }, 15000);
 
-    test("fromEndPoint with Subscription key", (done: jest.DoneCallback): void => {
+    test("fromEndPoint with Subscription key", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: fromEndPoint with Subscription key");
 
@@ -262,32 +301,39 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
 
         s.addTargetLanguage("de-DE");
         s.speechRecognitionLanguage = "en-US";
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile(s);
         objsToClose.push(r);
 
         r.canceled = (o: sdk.TranslationRecognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
             try {
                 expect(e.errorDetails).toBeUndefined();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
         r.recognizeOnceAsync(
             (res: sdk.TranslationRecognitionResult): void => {
-                expect(res).not.toBeUndefined();
-                expect(res.errorDetails).toBeUndefined();
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
-                expect(res.translations.get("de", undefined) !== undefined).toEqual(true);
-                expect("Wie ist das Wetter?").toEqual(res.translations.get("de", ""));
-                expect(res.text).toEqual("What's the weather like?");
-                done();
+                try {
+                    expect(res).not.toBeUndefined();
+                    expect(res.errorDetails).toBeUndefined();
+                    expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
+                    expect(res.translations.get("de", undefined) !== undefined).toEqual(true);
+                    expect("Wie ist das Wetter?").toEqual(res.translations.get("de", ""));
+                    expect(res.text).toEqual("What's the weather like?");
+                    done.resolve();
+                } catch (error) {
+                    done.reject(error);
+                }
             },
             (error: string): void => {
-                done(error);
+                done.reject(error);
             });
+
+        await done.promise;
     }, 12000);
 
-    test("fromV2EndPoint with Subscription key", (done: jest.DoneCallback): void => {
+    test("fromV2EndPoint with Subscription key", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: fromV2EndPoint with Subscription key");
 
@@ -300,36 +346,202 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
         s.addTargetLanguage(targetLanguage);
         s.speechRecognitionLanguage = "en-US";
 
-        const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
+        const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile(s);
         objsToClose.push(r);
 
         r.canceled = (o: sdk.TranslationRecognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
             try {
                 expect(e.errorDetails).toBeUndefined();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
         r.recognizeOnceAsync(
             (res: sdk.TranslationRecognitionResult): void => {
-                expect(res).not.toBeUndefined();
-                expect(res.errorDetails).toBeUndefined();
-                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
-                expect(res.translations.get(targetLanguage, undefined) !== undefined).toEqual(true);
-                expect("Wie ist das Wetter?").toEqual(res.translations.get(targetLanguage, ""));
-                expect(res.text).toEqual("What's the weather like?");
-                done();
+                try {
+                    expect(res).not.toBeUndefined();
+                    expect(res.errorDetails).toBeUndefined();
+                    expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
+                    expect(res.translations.get(targetLanguage, undefined) !== undefined).toEqual(true);
+                    expect("Wie ist das Wetter?").toEqual(res.translations.get(targetLanguage, ""));
+                    expect(res.text).toEqual("What's the weather like?");
+                    done.resolve();
+                } catch (error) {
+                    done.reject(error);
+                }
             },
             (error: string): void => {
-                done(error);
+                done.reject(error);
             });
+
+        await done.promise;
     }, 12000);
 
-    test("Multi-Turn offset verification", (done: jest.DoneCallback): void => {
+    describe.each([
+        SpeechConnectionType.Subscription,
+        SpeechConnectionType.LegacyCogSvcsTokenAuth,
+        SpeechConnectionType.LegacyEntraIdTokenAuth,
+        SpeechConnectionType.CloudFromHost,
+        SpeechConnectionType.LegacyPrivateLinkWithKeyAuth,
+        SpeechConnectionType.LegacyPrivateLinkWithEntraIdTokenAuth
+    ])("Translation Recognition Connection Tests", (connectionType: SpeechConnectionType): void => {
+
+        const runTest: jest.It = SpeechConfigConnectionFactory.runConnectionTest(connectionType);
+
+        runTest("RecognizeOnce with Multiple Connection Types " + SpeechConnectionType[connectionType], async (): Promise<void> => {
+            const done: Deferred<void> = new Deferred<void>();
+            // eslint-disable-next-line no-console
+            console.info("Name: RecognizeOnce with Multiple Connection Types " + SpeechConnectionType[connectionType]);
+
+            const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig(connectionType);
+            objsToClose.push(s);
+
+            const targetLanguage = "de";
+            s.addTargetLanguage(targetLanguage);
+            s.speechRecognitionLanguage = "en-US";
+
+            const r: sdk.TranslationRecognizer = await BuildRecognizerFromWaveFile(s);
+            objsToClose.push(r);
+
+            r.canceled = (o: sdk.TranslationRecognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+                try {
+                    expect(e.errorDetails).toBeUndefined();
+                } catch (error) {
+                    done.reject(error);
+                }
+            };
+
+            r.recognizeOnceAsync(
+                (res: sdk.TranslationRecognitionResult): void => {
+                    try {
+                        expect(res).not.toBeUndefined();
+                        expect(res.errorDetails).toBeUndefined();
+                        expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.TranslatedSpeech]);
+                        expect(res.translations.get(targetLanguage, undefined) !== undefined).toEqual(true);
+                        expect("Wie ist das Wetter?").toEqual(res.translations.get(targetLanguage, ""));
+                        expect(res.text).toEqual("What's the weather like?");
+                        done.resolve();
+                    } catch (error) {
+                        done.reject(error);
+                    }
+                },
+                (error: string): void => {
+                    done.reject(error);
+                });
+
+            await done.promise;
+        }, 15000);
+
+        runTest("Multi-Turn offset verification " + SpeechConnectionType[connectionType], async (): Promise<void> => {
+            const done: Deferred<void> = new Deferred<void>();
+            // eslint-disable-next-line no-console
+            console.info("Name: Multi-Turn offset verification " + SpeechConnectionType[connectionType]);
+
+            const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig(connectionType);
+            objsToClose.push(s);
+
+            s.addTargetLanguage("de-DE");
+            s.speechRecognitionLanguage = "en-US";
+
+            const pullStreamSource: RepeatingPullStream = new RepeatingPullStream(Settings.WaveFile);
+            const p: sdk.PullAudioInputStream = pullStreamSource.PullStream;
+
+            const config: sdk.AudioConfig = sdk.AudioConfig.fromStreamInput(p);
+
+            const r: sdk.TranslationRecognizer = new sdk.TranslationRecognizer(s, config);
+            objsToClose.push(r);
+
+            expect(r).not.toBeUndefined();
+            expect(r instanceof sdk.Recognizer);
+
+            let recoCount: number = 0;
+            let lastOffset: number = 0;
+
+            r.speechEndDetected = (r: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
+                try {
+                    expect(e.offset).toBeGreaterThan(lastOffset);
+                } catch (error) {
+                    done.reject(error);
+                }
+                recoCount++;
+                pullStreamSource.StartRepeat();
+            };
+
+            r.speechStartDetected = (r: sdk.Recognizer, e: sdk.RecognitionEventArgs): void => {
+                try {
+                    expect(e.offset).toBeGreaterThan(lastOffset);
+                } catch (error) {
+                    done.reject(error);
+                }
+            };
+
+            r.canceled = (o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+                try {
+                    expect(e.errorDetails).toBeUndefined();
+                } catch (error) {
+                    done.reject(error);
+                }
+            };
+
+            r.recognizing = (r: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs): void => {
+                try {
+                    expect(e.result).not.toBeUndefined();
+                    expect(e.offset).toBeGreaterThan(lastOffset);
+
+                    // Use some implementation details from the SDK to test the JSON has been exported correctly.
+                    let simpleResult: TranslationHypothesis = TranslationHypothesis.fromJSON(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult), 0);
+                    expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
+                    simpleResult = TranslationHypothesis.fromJSON(e.result.json, 0);
+                    expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+                } catch (error) {
+                    done.reject(error);
+                }
+            };
+
+            r.recognized = (r: sdk.Recognizer, e: sdk.TranslationRecognitionEventArgs): void => {
+                try {
+                    const res: sdk.SpeechRecognitionResult = e.result;
+                    expect(res).not.toBeUndefined();
+                    expect(e.offset).toBeGreaterThan(lastOffset);
+
+                    // Use some implementation details from the SDK to test the JSON has been exported correctly.
+                    let simpleResult: TranslationPhrase = TranslationPhrase.fromJSON(e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult), 0);
+                    expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
+                    simpleResult = TranslationPhrase.fromJSON(e.result.json, 0);
+                    expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
+
+                    lastOffset = e.offset;
+                } catch (error) {
+                    done.reject(error);
+                }
+            };
+
+            r.startContinuousRecognitionAsync(
+                undefined,
+                (error: string): void => {
+                    done.reject(error);
+                });
+
+            WaitForCondition((): boolean => (recoCount === 3), (): void => {
+                r.stopContinuousRecognitionAsync((): void => {
+                    done.resolve();
+                }, (error: string): void => {
+                    done.reject(error);
+                });
+            });
+
+            await done.promise;
+        }, 1000 * 60 * 2);
+    });
+
+    test("Multi-Turn offset verification", async (): Promise<void> => {
+        const done: Deferred<void> = new Deferred<void>();
         // eslint-disable-next-line no-console
         console.info("Name: Multiple Phrase Latency Reporting");
 
-        const s: sdk.SpeechTranslationConfig = BuildSpeechConfig();
+        const s: sdk.SpeechTranslationConfig = await BuildSpeechConfig();
         objsToClose.push(s);
         s.addTargetLanguage("de-DE");
         s.speechRecognitionLanguage = "en-US";
@@ -352,7 +564,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
             try {
                 expect(e.offset).toBeGreaterThan(lastOffset);
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
             recoCount++;
             pullStreamSource.StartRepeat();
@@ -362,7 +574,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
             try {
                 expect(e.offset).toBeGreaterThan(lastOffset);
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
@@ -370,7 +582,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
             try {
                 expect(e.errorDetails).toBeUndefined();
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
@@ -386,7 +598,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
                 simpleResult = TranslationHypothesis.fromJSON(e.result.json, 0);
                 expect(simpleResult.Offset).toBeGreaterThanOrEqual(lastOffset);
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
@@ -405,22 +617,24 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
 
                 lastOffset = e.offset;
             } catch (error) {
-                done(error);
+                done.reject(error);
             }
         };
 
         r.startContinuousRecognitionAsync(
             undefined,
             (error: string): void => {
-                done(error);
+                done.reject(error);
             });
 
         WaitForCondition((): boolean => (recoCount === 3), (): void => {
             r.stopContinuousRecognitionAsync((): void => {
-                done();
+                done.resolve();
             }, (error: string): void => {
-                done(error);
+                done.reject(error);
             });
         });
+
+        await done.promise;
     }, 1000 * 60 * 2);
 });

--- a/tests/Utilities.ts
+++ b/tests/Utilities.ts
@@ -1,22 +1,30 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
+import { Timeout } from "../src/common/Timeout";
 import {
     WaveFileAudioInput
 } from "./WaveFileAudioInputStream";
 
-export function WaitForCondition(condition: () => boolean, after: () => void): void {
+export const WaitForCondition = (condition: () => boolean, after: () => void): void => {
     if (condition() === true) {
         after();
     } else {
-        setTimeout(() => WaitForCondition(condition, after), 500);
+        setTimeout((): void => WaitForCondition(condition, after), 500);
     }
-}
+};
 
-export function sleep(ms: number): Promise<void> {
-    return new Promise((resolve: (_: void) => void) => setTimeout(resolve, ms));
-}
+export const WaitForConditionAsync = async (condition: () => boolean, after: () => Promise<void>): Promise<void> => {
+    if (condition() === true) {
+        await after();
+    } else {
+        setTimeout((): Promise<void> => WaitForConditionAsync(condition, after), 500);
+    }
+};
 
+export const sleep = (ms: number): Promise<void> => new Promise((resolve: (_: void) => void): Timeout => setTimeout(resolve, ms));
+
+// This one is already an arrow function, so it stays the same
 export const WaitForPromise = (condition: () => boolean, rejectMessage: string, timeout: number = 60 * 1000): Promise<void> => {
     return new Promise(async (resolve: (value: void) => void, reject: (reason: string) => void): Promise<void> => {
         const endTime: number = Date.now() + timeout;
@@ -33,7 +41,7 @@ export const WaitForPromise = (condition: () => boolean, rejectMessage: string, 
     });
 };
 
-export async function closeAsyncObjects(objsToClose: any[]): Promise<void> {
+export const closeAsyncObjects = async (objsToClose: any[]): Promise<void> => {
     for (const current of objsToClose) {
         if (typeof current.close === "function") {
             if (current.close.length === 2) {
@@ -45,7 +53,7 @@ export async function closeAsyncObjects(objsToClose: any[]): Promise<void> {
             }
         }
     }
-}
+};
 
 export class RepeatingPullStream {
     private bytesSent: number = 0x0;
@@ -58,7 +66,7 @@ export class RepeatingPullStream {
         this.pullStream = sdk.AudioInputStream.createPullStream(
             {
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
-                close: (): void => {},
+                close: (): void => { },
                 read: (buffer: ArrayBuffer): number => {
 
                     if (!!this.sendSilence) {


### PR DESCRIPTION
Adds tests for various connection & auth types for SR, TTS, S2S, and LID.

Adds "connectionId" to query string on connection to match service side telemetry mappings.

Changes close / dispose path to destroy any connection, not only connections that have had their pre-audio messages sent. This should resolve many hangs when tests fail.