### PR TITLE
Move the Speech Recognizer to use the V2 endpoint by default.

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -27,7 +27,15 @@ module.exports = {
                 "(.+)\\.js": "$1"
             },
             transform: {
-                "^.+\\.ts$": "ts-jest",
+                "^.+\\.ts$": ["ts-jest", {
+                    // Match source map configuration with project's tsconfig and gulp build
+                    sourceMap: true, 
+                    inlineSourceMap: false,
+                    // Enable pathMapping to ensure correct line number reporting
+                    pathMapping: {
+                        '^(.*)\\.js$': '$1.ts'
+                    }
+                }]
             },
             testRegex: "tests/.*Tests\\.ts$",
             testPathIgnorePatterns: ["/lib/", "/node_modules/", "/src/"],
@@ -35,7 +43,18 @@ module.exports = {
             testEnvironment: "jsdom",
             collectCoverage: false,
             setupFilesAfterEnv: [configFile],
-            testTimeout : 20000
+            testTimeout : 20000,
+            globals: {
+                'ts-jest': {
+                    // Ensure ts-jest respects the project's tsconfig settings
+                    tsconfig: 'tsconfig.json',
+                    diagnostics: {
+                        // Improve error reporting
+                        warnOnly: true,
+                        pretty: true
+                    }
+                }
+            }
         },
         {
             displayName: "node",
@@ -43,7 +62,15 @@ module.exports = {
                 "(.+)\\.js": "$1"
             },
             transform: {
-                "^.+\\.ts$": "ts-jest",
+                "^.+\\.ts$": ["ts-jest", {
+                    // Match source map configuration with project's tsconfig and gulp build
+                    sourceMap: true, 
+                    inlineSourceMap: false,
+                    // Enable pathMapping to ensure correct line number reporting
+                    pathMapping: {
+                        '^(.*)\\.js$': '$1.ts'
+                    }
+                }]
             },
             testRegex: "tests/.*Tests\\.ts$",
             testPathIgnorePatterns: ["/lib/", "/node_modules/", "/src/"],
@@ -51,7 +78,18 @@ module.exports = {
             testEnvironment: "node",
             collectCoverage: false,
             setupFilesAfterEnv: [configFile],
-            testTimeout : 30000
+            testTimeout : 30000,
+            globals: {
+                'ts-jest': {
+                    // Ensure ts-jest respects the project's tsconfig settings
+                    tsconfig: 'tsconfig.json',
+                    diagnostics: {
+                        // Improve error reporting
+                        warnOnly: true,
+                        pretty: true
+                    }
+                }
+            }
         }
     ],
     reporters: [ "default", "jest-junit" ],

--- a/src/common.speech/IntentServiceRecognizer.ts
+++ b/src/common.speech/IntentServiceRecognizer.ts
@@ -48,6 +48,7 @@ export class IntentServiceRecognizer extends ServiceRecognizerBase {
         super(authentication, connectionFactory, audioSource, recognizerConfig, recognizer);
         this.privIntentRecognizer = recognizer;
         this.privIntentDataSent = false;
+        recognizerConfig.recognitionEndpointVersion = "1";
     }
 
     public setIntents(addedIntents: { [id: string]: AddedLmIntent }, umbrellaIntent: AddedLmIntent): void {

--- a/src/common.speech/RecognizerConfig.ts
+++ b/src/common.speech/RecognizerConfig.ts
@@ -66,7 +66,11 @@ export class RecognizerConfig {
     }
 
     public get recognitionEndpointVersion(): string {
-        return this.parameters.getProperty(PropertyId.SpeechServiceConnection_RecognitionEndpointVersion, undefined);
+        return this.parameters.getProperty(PropertyId.SpeechServiceConnection_RecognitionEndpointVersion, "2");
+    }
+
+    public set recognitionEndpointVersion(version: string) {
+        this.parameters.setProperty(PropertyId.SpeechServiceConnection_RecognitionEndpointVersion, version);
     }
 
     public get sourceLanguageModels(): { language: string; endpoint: string }[] {
@@ -77,10 +81,10 @@ export class RecognizerConfig {
                 const customProperty = language + PropertyId.SpeechServiceConnection_EndpointId.toString();
                 const modelId: string = this.parameters.getProperty(customProperty, undefined);
                 if (modelId !== undefined) {
-                    models.push( { language, endpoint: modelId });
+                    models.push({ language, endpoint: modelId });
                     modelsExist = true;
                 } else {
-                    models.push( { language, endpoint: "" } );
+                    models.push({ language, endpoint: "" });
                 }
             }
         }

--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -415,6 +415,12 @@ export abstract class ServiceRecognizerBase implements IDisposable {
         this.privConnectionConfigurationPromise = undefined;
         this.privRecognizerConfig.recognitionMode = recoMode;
 
+        if (this.privRecognizerConfig.recognitionEndpointVersion === "2") {
+            const phraseDetection: PhraseDetectionContext = this.privSpeechContext.getContext().phraseDetection || {};
+            phraseDetection.mode = recoMode;
+            this.privSpeechContext.getContext().phraseDetection = phraseDetection;
+        }
+
         // Set language ID (if configured)
         this.setLanguageIdJson();
 

--- a/src/sdk/SpeechConfig.ts
+++ b/src/sdk/SpeechConfig.ts
@@ -7,8 +7,8 @@ import {
     OutputFormatPropertyName,
     ServicePropertiesPropertyName
 } from "../common.speech/Exports.js";
-import {IStringDictionary} from "../common/Exports.js";
-import {Contracts} from "./Contracts.js";
+import { IStringDictionary } from "../common/Exports.js";
+import { Contracts } from "./Contracts.js";
 import {
     OutputFormat,
     ProfanityOption,
@@ -104,6 +104,9 @@ export abstract class SpeechConfig {
 
         const speechImpl: SpeechConfigImpl = new SpeechConfigImpl();
         speechImpl.setProperty(PropertyId.SpeechServiceConnection_Host, hostName.protocol + "//" + hostName.hostname + (hostName.port === "" ? "" : ":" + hostName.port));
+
+        // Containers do not yet have /stt/speech/universal/v2 routes.
+        speechImpl.setProperty(PropertyId.SpeechServiceConnection_RecognitionEndpointVersion, "1");
 
         if (undefined !== subscriptionKey) {
             speechImpl.setProperty(PropertyId.SpeechServiceConnection_Key, subscriptionKey);

--- a/tests/IntentRecognizerTests.ts
+++ b/tests/IntentRecognizerTests.ts
@@ -348,7 +348,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
             try {
                 const res: sdk.IntentRecognitionResult = e.result;
                 expect(res).not.toBeUndefined();
-                expect(res.reason).toEqual(sdk.ResultReason.RecognizedIntent);
+                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedIntent]);
                 expect(res.intentId).toEqual(Settings.LuisValidIntentId);
                 expect(res.properties).not.toBeUndefined();
                 expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();
@@ -397,7 +397,7 @@ describe.each([false])("Service based tests", (forceNodeWebSocket: boolean): voi
                 const res: sdk.IntentRecognitionResult = p2;
                 expect(res).not.toBeUndefined();
                 expect(res.errorDetails).toBeUndefined();
-                expect(res.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
+                expect(sdk.ResultReason[res.reason]).toEqual(sdk.ResultReason[sdk.ResultReason.RecognizedSpeech]);
                 expect(res.intentId).toBeUndefined();
                 expect(res.properties).not.toBeUndefined();
                 expect(res.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult)).not.toBeUndefined();

--- a/tests/SpeechConfigConnectionFactories.ts
+++ b/tests/SpeechConfigConnectionFactories.ts
@@ -91,11 +91,7 @@ export class SpeechConfigConnectionFactory {
 
             case SpeechConnectionType.LegacyEntraIdTokenAuth:
                 const aadToken = await this.getAadToken(
-<<<<<<< HEAD
-                    SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION
-=======
                     SubscriptionsRegionsKeys.AAD_SPEECH_CLIENT_SECRET
->>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
                 );
                 return this.buildAuthorizationConfig<T>(
                     aadToken,
@@ -138,12 +134,9 @@ export class SpeechConfigConnectionFactory {
             case SpeechConnectionType.LegacyPrivateLinkWithKeyAuth:
                 return this.buildLegacyPrivateLinkWithKeyConfig<T>(isTranslationConfig, serviceType);
 
-<<<<<<< HEAD
-=======
             case SpeechConnectionType.LegacyPrivateLinkWithEntraIdTokenAuth:
                 return this.buildLegacyPrivateLinkEndpointWithEntraId<T>(isTranslationConfig, serviceType);
 
->>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
             default:
                 throw new Error(`Unsupported connection type: ${SpeechConnectionType[connectionType]}`);
         }
@@ -426,8 +419,6 @@ export class SpeechConfigConnectionFactory {
         const pathSuffix = this.getPrivateLinkPathSuffix(serviceType);
         return this.buildPrivateLinkWithKeyConfig<T>(pathSuffix, isTranslationConfig);
     }
-<<<<<<< HEAD
-=======
     /**
      * Builds a private link endpoint with Entra ID token.
      */
@@ -460,7 +451,6 @@ export class SpeechConfigConnectionFactory {
 
         return config;
     }
->>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
 
     /**
      * Builds a private link endpoint with Cognitive Services token.
@@ -541,19 +531,11 @@ export class SpeechConfigConnectionFactory {
     private static getPrivateLinkPathSuffix(serviceType: SpeechServiceType): string {
         switch (serviceType) {
             case SpeechServiceType.TextToSpeech:
-<<<<<<< HEAD
-                return "/tts/speech";
-            case SpeechServiceType.SpeechRecognition:
-            case SpeechServiceType.LanguageIdentification:
-            default:
-                return "/stt/speech";
-=======
                 return "/tts/cognitiveservices/websocket/v1";
             case SpeechServiceType.SpeechRecognition:
             case SpeechServiceType.LanguageIdentification:
             default:
                 return "/stt/speech/universal/v2";
->>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
         }
     }
 

--- a/tests/SpeechConfigConnectionFactories.ts
+++ b/tests/SpeechConfigConnectionFactories.ts
@@ -91,7 +91,11 @@ export class SpeechConfigConnectionFactory {
 
             case SpeechConnectionType.LegacyEntraIdTokenAuth:
                 const aadToken = await this.getAadToken(
+<<<<<<< HEAD
                     SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION
+=======
+                    SubscriptionsRegionsKeys.AAD_SPEECH_CLIENT_SECRET
+>>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
                 );
                 return this.buildAuthorizationConfig<T>(
                     aadToken,
@@ -134,6 +138,12 @@ export class SpeechConfigConnectionFactory {
             case SpeechConnectionType.LegacyPrivateLinkWithKeyAuth:
                 return this.buildLegacyPrivateLinkWithKeyConfig<T>(isTranslationConfig, serviceType);
 
+<<<<<<< HEAD
+=======
+            case SpeechConnectionType.LegacyPrivateLinkWithEntraIdTokenAuth:
+                return this.buildLegacyPrivateLinkEndpointWithEntraId<T>(isTranslationConfig, serviceType);
+
+>>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
             default:
                 throw new Error(`Unsupported connection type: ${SpeechConnectionType[connectionType]}`);
         }
@@ -416,6 +426,41 @@ export class SpeechConfigConnectionFactory {
         const pathSuffix = this.getPrivateLinkPathSuffix(serviceType);
         return this.buildPrivateLinkWithKeyConfig<T>(pathSuffix, isTranslationConfig);
     }
+<<<<<<< HEAD
+=======
+    /**
+     * Builds a private link endpoint with Entra ID token.
+     */
+    private static async buildLegacyPrivateLinkEndpointWithEntraId<T extends ConfigType>(isTranslationConfig: boolean, serviceType: SpeechServiceType): Promise<T> {
+        if (!this.checkPrivateLinkTestsEnabled()) {
+            throw new Error("Private link testing is not enabled");
+        }
+
+        const pathSuffix = this.getPrivateLinkPathSuffix(serviceType);
+
+        const subscriptionRegion = this.getSubscriptionRegion("PrivateLinkSpeechResource");
+        const endpoint = subscriptionRegion.Endpoint + pathSuffix;
+
+        if (!endpoint) {
+            throw new Error("Endpoint is not defined for the AAD private link subscription");
+        }
+
+        const aadToken = await this.getAadToken(
+            SubscriptionsRegionsKeys.AAD_SPEECH_CLIENT_SECRET
+        );
+
+        let config: T;
+        if (isTranslationConfig) {
+            config = sdk.SpeechTranslationConfig.fromEndpoint(new URL(endpoint), undefined) as unknown as T;
+            config.authorizationToken = aadToken;
+        } else {
+            config = sdk.SpeechConfig.fromEndpoint(new URL(endpoint), aadToken) as unknown as T;
+            config.authorizationToken = aadToken;
+        }
+
+        return config;
+    }
+>>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
 
     /**
      * Builds a private link endpoint with Cognitive Services token.
@@ -496,11 +541,19 @@ export class SpeechConfigConnectionFactory {
     private static getPrivateLinkPathSuffix(serviceType: SpeechServiceType): string {
         switch (serviceType) {
             case SpeechServiceType.TextToSpeech:
+<<<<<<< HEAD
                 return "/tts/speech";
             case SpeechServiceType.SpeechRecognition:
             case SpeechServiceType.LanguageIdentification:
             default:
                 return "/stt/speech";
+=======
+                return "/tts/cognitiveservices/websocket/v1";
+            case SpeechServiceType.SpeechRecognition:
+            case SpeechServiceType.LanguageIdentification:
+            default:
+                return "/stt/speech/universal/v2";
+>>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
         }
     }
 

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -293,7 +293,11 @@ test("BadWavFileProducesError", async (): Promise<void> => {
 
     r.recognizeOnceAsync((): void => {
         done.reject("Should not have been able to process the file");
+<<<<<<< HEAD
      }, (error: string): void => {
+=======
+    }, (error: string): void => {
+>>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
         try {
             console.info("Error: " + error);
             expect(error).not.toBeUndefined();
@@ -902,6 +906,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean): void
                     // session events are first and last event
                     const LAST_RECORDED_EVENT_ID: number = --eventIdentifier;
                     expect(LAST_RECORDED_EVENT_ID).toBeGreaterThan(FIRST_EVENT_ID);
+<<<<<<< HEAD
 
                     expect(SessionStartedEvent in eventsMap).toEqual(true);
 
@@ -916,14 +921,32 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean): void
                             .toBeLessThan(eventsMap[SessionStoppedEvent]);
                     }
 
+=======
+                    expect(SessionStartedEvent in eventsMap).toEqual(true);
+                    expect(eventsMap[SessionStartedEvent]).toEqual(FIRST_EVENT_ID);
+                    expect(SessionStoppedEvent in eventsMap).toEqual(true);
+                    expect(LAST_RECORDED_EVENT_ID).toEqual(eventsMap[SessionStoppedEvent]);
+
+                    // end events come after start events.
+                    if (SessionStoppedEvent in eventsMap) {
+                        expect(eventsMap[SessionStartedEvent])
+                            .toBeLessThan(eventsMap[SessionStoppedEvent]);
+                    }
+
+>>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
                     expect(eventsMap[SpeechStartDetectedEvent])
                         .toBeLessThan(eventsMap[SpeechEndDetectedEvent]);
                     expect((FIRST_EVENT_ID + 1)).toEqual(eventsMap[SpeechStartDetectedEvent]);
 
                     // make sure, first end of speech, then final result
                     expect((LAST_RECORDED_EVENT_ID - 1)).toEqual(eventsMap[Canceled]);
+<<<<<<< HEAD
                     expect((LAST_RECORDED_EVENT_ID - 2)).toEqual(eventsMap[SpeechEndDetectedEvent]);
                     expect((LAST_RECORDED_EVENT_ID - 3)).toEqual(eventsMap[Recognized]);
+=======
+                    expect((LAST_RECORDED_EVENT_ID - 3)).toEqual(eventsMap[Recognized]);
+                    expect((LAST_RECORDED_EVENT_ID - 2)).toEqual(eventsMap[SpeechEndDetectedEvent]);
+>>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
 
                     // recognition events come after session start but before session end events
                     expect(eventsMap[SessionStartedEvent])
@@ -2042,8 +2065,8 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean): void
         r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
             try {
                 expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
-                expect(sdk.CancellationErrorCode[e.errorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.ConnectionFailure]);
-                expect(e.errorDetails).toContain("1006");
+                expect(sdk.CancellationErrorCode[e.errorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.BadRequestParameters]);
+                expect(e.errorDetails).toContain("1007");
                 doneCount++;
             } catch (error) {
                 done.reject(error);
@@ -2054,8 +2077,8 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean): void
             try {
                 const e: sdk.CancellationDetails = sdk.CancellationDetails.fromResult(result);
                 expect(sdk.CancellationReason[e.reason]).toEqual(sdk.CancellationReason[sdk.CancellationReason.Error]);
-                expect(sdk.CancellationErrorCode[e.ErrorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.ConnectionFailure]);
-                expect(e.errorDetails).toContain("1006");
+                expect(sdk.CancellationErrorCode[e.ErrorCode]).toEqual(sdk.CancellationErrorCode[sdk.CancellationErrorCode.BadRequestParameters]);
+                expect(e.errorDetails).toContain("1007");
 
                 doneCount++;
             } catch (error) {

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -293,11 +293,7 @@ test("BadWavFileProducesError", async (): Promise<void> => {
 
     r.recognizeOnceAsync((): void => {
         done.reject("Should not have been able to process the file");
-<<<<<<< HEAD
-     }, (error: string): void => {
-=======
     }, (error: string): void => {
->>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
         try {
             console.info("Error: " + error);
             expect(error).not.toBeUndefined();
@@ -906,22 +902,6 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean): void
                     // session events are first and last event
                     const LAST_RECORDED_EVENT_ID: number = --eventIdentifier;
                     expect(LAST_RECORDED_EVENT_ID).toBeGreaterThan(FIRST_EVENT_ID);
-<<<<<<< HEAD
-
-                    expect(SessionStartedEvent in eventsMap).toEqual(true);
-
-                    expect(eventsMap[SessionStartedEvent]).toEqual(FIRST_EVENT_ID);
-
-                    expect(SessionStoppedEvent in eventsMap).toEqual(true);
-                    expect(LAST_RECORDED_EVENT_ID).toEqual(eventsMap[SessionStoppedEvent]);
-
-                    // end events come after start events.
-                    if (SessionStoppedEvent in eventsMap) {
-                        expect(eventsMap[SessionStartedEvent])
-                            .toBeLessThan(eventsMap[SessionStoppedEvent]);
-                    }
-
-=======
                     expect(SessionStartedEvent in eventsMap).toEqual(true);
                     expect(eventsMap[SessionStartedEvent]).toEqual(FIRST_EVENT_ID);
                     expect(SessionStoppedEvent in eventsMap).toEqual(true);
@@ -933,20 +913,14 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean): void
                             .toBeLessThan(eventsMap[SessionStoppedEvent]);
                     }
 
->>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
                     expect(eventsMap[SpeechStartDetectedEvent])
                         .toBeLessThan(eventsMap[SpeechEndDetectedEvent]);
                     expect((FIRST_EVENT_ID + 1)).toEqual(eventsMap[SpeechStartDetectedEvent]);
 
                     // make sure, first end of speech, then final result
                     expect((LAST_RECORDED_EVENT_ID - 1)).toEqual(eventsMap[Canceled]);
-<<<<<<< HEAD
-                    expect((LAST_RECORDED_EVENT_ID - 2)).toEqual(eventsMap[SpeechEndDetectedEvent]);
-                    expect((LAST_RECORDED_EVENT_ID - 3)).toEqual(eventsMap[Recognized]);
-=======
                     expect((LAST_RECORDED_EVENT_ID - 3)).toEqual(eventsMap[Recognized]);
                     expect((LAST_RECORDED_EVENT_ID - 2)).toEqual(eventsMap[SpeechEndDetectedEvent]);
->>>>>>> 330e184 (Add tests for various connection types to TranslationRecognizer, SpechSynthsizer, SpeechRecognizer and LID. (#905))
 
                     // recognition events come after session start but before session end events
                     expect(eventsMap[SessionStartedEvent])


### PR DESCRIPTION
Behavior Change: The V2 endpoints do not return silence timeouts for status, but instead return empty recognition results where the status is Success.