### PR TITLE
Add speech context setters

### DIFF
--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -51,6 +51,7 @@ import { RecognizerConfig } from "./RecognizerConfig.js";
 import { SpeechConnectionMessage } from "./SpeechConnectionMessage.Internal.js";
 import { Segmentation, SegmentationMode } from "./ServiceMessages/PhraseDetection/Segmentation.js";
 import { CustomLanguageMappingEntry, PhraseDetectionContext, RecognitionMode, SpeechStartEventSensitivity } from "./ServiceMessages/PhraseDetection/PhraseDetectionContext.js";
+import { ProfanityHandlingMode } from "./ServiceMessages/PhraseDetection/Enrichment.js";
 import { NextAction as NextTranslationAction } from "./ServiceMessages/Translation/OnSuccess.js";
 import { Mode } from "./ServiceMessages/Translation/InterimResults.js";
 import { LanguageIdDetectionMode, LanguageIdDetectionPriority } from "./ServiceMessages/LanguageId/LanguageIdContext.js";
@@ -357,10 +358,25 @@ export abstract class ServiceRecognizerBase implements IDisposable {
 
     protected setPostProcessingOptionJson(): void {
         const postProcessingOption: string = this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceResponse_PostProcessingOption, undefined);
-        if (postProcessingOption !== undefined) {
-            const phraseDetection: PhraseDetectionContext = this.privSpeechContext.getContext().phraseDetection || {};
-            phraseDetection.enrichment = phraseDetection.enrichment || {};
+        const phraseDetection: PhraseDetectionContext = this.privSpeechContext.getContext().phraseDetection || {};
+        phraseDetection.enrichment = phraseDetection.enrichment || {};
 
+        // Clear stale postprocessing fields for the current mode before applying new value.
+        // This prevents leftover fields when switching between truetext/non-truetext/absent across turns.
+        const modeObj = this.recognitionMode === RecognitionMode.Conversation
+            ? phraseDetection.enrichment.conversation
+            : this.recognitionMode === RecognitionMode.Interactive
+                ? phraseDetection.enrichment.interactive
+                : phraseDetection.enrichment.dictation;
+        if (modeObj) {
+            delete modeObj.postprocessingoption;
+            delete modeObj.punctuationMode;
+            delete modeObj.disfluencyMode;
+            delete modeObj.intermediatePunctuationMode;
+            delete (modeObj as Record<string, unknown>).intermediatedisfluencymode;
+        }
+
+        if (postProcessingOption !== undefined) {
             if (postProcessingOption.toLowerCase() === "truetext") {
                 // Client-side expansion for "truetext" - set specific properties
                 switch (this.recognitionMode) {
@@ -386,11 +402,8 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                         (phraseDetection.enrichment.dictation as Record<string, unknown>).intermediatedisfluencymode = DisfluencyMode.Removed;
                         break;
                 }
-                // Don't set postprocessingoption - we've expanded "truetext" into specific settings
             } else {
                 // Service-side handling for all other strings
-                // Pass the developer-provided value directly to the service.
-                // Input validation is handled on the service side.
                 switch (this.recognitionMode) {
                     case RecognitionMode.Conversation:
                         phraseDetection.enrichment.conversation = phraseDetection.enrichment.conversation || {};
@@ -406,9 +419,86 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                         break;
                 }
             }
-
-            this.privSpeechContext.getContext().phraseDetection = phraseDetection;
         }
+
+        this.privSpeechContext.getContext().phraseDetection = phraseDetection;
+    }
+
+    protected setLanguageJson(): void {
+        const phraseDetection: PhraseDetectionContext = this.privSpeechContext.getContext().phraseDetection || {};
+
+        if (this.privRecognizerConfig.autoDetectSourceLanguages !== undefined) {
+            // Auto-detect is configured — language is managed by the language ID subsystem, clear any stale value
+            delete phraseDetection.language;
+        } else {
+            const language: string = this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceConnection_RecoLanguage, undefined);
+            if (language !== undefined) {
+                phraseDetection.language = language;
+            } else {
+                delete phraseDetection.language;
+            }
+        }
+
+        this.privSpeechContext.getContext().phraseDetection = phraseDetection;
+    }
+
+    protected setInitialSilenceTimeoutJson(): void {
+        const phraseDetection: PhraseDetectionContext = this.privSpeechContext.getContext().phraseDetection || {};
+        const value: string = this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceConnection_InitialSilenceTimeoutMs, undefined);
+
+        if (value !== undefined) {
+            phraseDetection.initialSilenceTimeout = parseInt(value, 10);
+        } else {
+            delete phraseDetection.initialSilenceTimeout;
+        }
+
+        this.privSpeechContext.getContext().phraseDetection = phraseDetection;
+    }
+
+    protected setEndSilenceTimeoutJson(): void {
+        const phraseDetection: PhraseDetectionContext = this.privSpeechContext.getContext().phraseDetection || {};
+        const value: string = this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceConnection_EndSilenceTimeoutMs, undefined);
+
+        if (value !== undefined) {
+            phraseDetection.trailingSilenceTimeout = parseInt(value, 10);
+        } else {
+            delete phraseDetection.trailingSilenceTimeout;
+        }
+
+        this.privSpeechContext.getContext().phraseDetection = phraseDetection;
+    }
+
+    protected setProfanityOptionJson(): void {
+        const phraseDetection: PhraseDetectionContext = this.privSpeechContext.getContext().phraseDetection || {};
+        const value: string = this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceResponse_ProfanityOption, undefined);
+
+        if (value !== undefined) {
+            phraseDetection.enrichment = phraseDetection.enrichment || {};
+            phraseDetection.enrichment.profanity = value as ProfanityHandlingMode;
+        } else {
+            if (phraseDetection.enrichment) {
+                delete phraseDetection.enrichment.profanity;
+            }
+        }
+
+        this.privSpeechContext.getContext().phraseDetection = phraseDetection;
+    }
+
+    protected setStableIntermediateThresholdJson(): void {
+        const value: string = this.privRecognizerConfig.parameters.getProperty(PropertyId.SpeechServiceResponse_StablePartialResultThreshold, undefined);
+        // Deep-merge into existing phraseOutput — setLanguageIdJson may have already initialized it
+        const phraseOutput = this.privSpeechContext.getContext().phraseOutput || {};
+
+        if (value !== undefined) {
+            phraseOutput.interimResults = phraseOutput.interimResults || {};
+            phraseOutput.interimResults.stableThreshold = parseInt(value, 10);
+        } else {
+            if (phraseOutput.interimResults) {
+                delete phraseOutput.interimResults.stableThreshold;
+            }
+        }
+
+        this.privSpeechContext.getContext().phraseOutput = phraseOutput;
     }
 
     public get isSpeakerDiarizationEnabled(): boolean {
@@ -502,10 +592,15 @@ export abstract class ServiceRecognizerBase implements IDisposable {
             this.setupTranslationWithLanguageId();
         }
 
+        this.setLanguageJson();
+        this.setInitialSilenceTimeoutJson();
+        this.setEndSilenceTimeoutJson();
         this.setSpeechSegmentationTimeoutJson();
         this.setOutputDetailLevelJson();
         this.setSpeechStartEventSensitivityJson();
+        this.setProfanityOptionJson();
         this.setPostProcessingOptionJson();
+        this.setStableIntermediateThresholdJson();
 
         this.privSuccessCallback = successCallback;
         this.privErrorCallback = errorCallBack;

--- a/tests/SpeechContextSetterE2ETests.ts
+++ b/tests/SpeechContextSetterE2ETests.ts
@@ -20,9 +20,9 @@
  *   - The test audio files in tests/input/audio/
  *
  * INPUT → OUTPUT SUMMARY:
- *   ┌──────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
- *   │  SDK Property (INPUT)                        │  speech.context JSON field (OUTPUT)                         │
- *   ├──────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
+ *   ┌──────────────────────────────────────────────┬────────────────────────────────────────────────────────────┐
+ *   │  SDK Property (INPUT)                        │  speech.context JSON field (OUTPUT)                        │
+ *   ├──────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
  *   │  speechRecognitionLanguage = "en-US"         │  phraseDetection.language = "en-US"                        │
  *   │  InitialSilenceTimeoutMs = "5000"            │  phraseDetection.initialSilenceTimeout = 5000              │
  *   │  EndSilenceTimeoutMs = "2000"                │  phraseDetection.trailingSilenceTimeout = 2000             │
@@ -34,7 +34,7 @@
  *   │                                              │    .disfluencyMode = "Removed"                             │
  *   │                                              │    (postprocessingoption must NOT be set)                  │
  *   │  StablePartialResultThreshold = "3"          │  phraseOutput.interimResults.stableThreshold = 3           │
- *   └──────────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘
+ *   └──────────────────────────────────────────────┴────────────────────────────────────────────────────────────┘
  */
 
 import * as sdk from "../microsoft.cognitiveservices.speech.sdk";

--- a/tests/SpeechContextSetterE2ETests.ts
+++ b/tests/SpeechContextSetterE2ETests.ts
@@ -1,0 +1,458 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * End-to-end wire-inspection tests for the speech.context setter methods.
+ *
+ * PURPOSE:
+ *   These tests verify that when you set SDK properties on a SpeechConfig,
+ *   the corresponding fields actually appear in the speech.context JSON message
+ *   sent over the WebSocket to the Speech service.
+ *
+ * HOW THEY WORK:
+ *   1. Create a SpeechConfig and set specific properties (e.g., language, timeout)
+ *   2. Create a SpeechRecognizer with a known WAV audio file
+ *   3. Intercept the "speech.context" message that the SDK sends over the wire
+ *   4. Parse the JSON and verify it contains the expected fields
+ *
+ * WHAT YOU NEED:
+ *   - A valid Speech service subscription key and region configured in test settings
+ *   - The test audio files in tests/input/audio/
+ *
+ * INPUT → OUTPUT SUMMARY:
+ *   ┌──────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
+ *   │  SDK Property (INPUT)                        │  speech.context JSON field (OUTPUT)                         │
+ *   ├──────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
+ *   │  speechRecognitionLanguage = "en-US"         │  phraseDetection.language = "en-US"                        │
+ *   │  InitialSilenceTimeoutMs = "5000"            │  phraseDetection.initialSilenceTimeout = 5000              │
+ *   │  EndSilenceTimeoutMs = "2000"                │  phraseDetection.trailingSilenceTimeout = 2000             │
+ *   │  ProfanityOption = "Raw"                     │  phraseDetection.enrichment.profanity = "Raw"              │
+ *   │  PostProcessingOption = "someValue"          │  phraseDetection.enrichment.interactive                    │
+ *   │                                              │    .postprocessingoption = "someValue"                     │
+ *   │  PostProcessingOption = "truetext"           │  phraseDetection.enrichment.interactive                    │
+ *   │                                              │    .punctuationMode = "Implicit"                           │
+ *   │                                              │    .disfluencyMode = "Removed"                             │
+ *   │                                              │    (postprocessingoption must NOT be set)                  │
+ *   │  StablePartialResultThreshold = "3"          │  phraseOutput.interimResults.stableThreshold = 3           │
+ *   └──────────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘
+ */
+
+import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
+import { ConsoleLoggingListener } from "../src/common.browser/Exports";
+import { Events } from "../src/common/Exports";
+import { Settings } from "./Settings";
+import { closeAsyncObjects, WaitForCondition } from "./Utilities";
+import { WaveFileAudioInput } from "./WaveFileAudioInputStream";
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let objsToClose: any[];
+
+beforeAll((): void => {
+    Settings.LoadSettings();
+    Events.instance.attachListener(new ConsoleLoggingListener(sdk.LogLevel.Debug));
+});
+
+beforeEach((): void => {
+    objsToClose = [];
+    // eslint-disable-next-line no-console
+    console.info("------------------Starting test case: " + expect.getState().currentTestName + "-------------------------");
+    // eslint-disable-next-line no-console
+    console.info("Start Time: " + new Date(Date.now()).toLocaleString());
+});
+
+jest.retryTimes(Settings.RetryCount);
+
+afterEach(async (): Promise<void> => {
+    // eslint-disable-next-line no-console
+    console.info("End Time: " + new Date(Date.now()).toLocaleString());
+    await closeAsyncObjects(objsToClose);
+});
+
+// ---------------------------------------------------------------------------
+// Helper: check that subscription credentials are configured
+// ---------------------------------------------------------------------------
+
+function requireCredentials(): void {
+    if (!Settings.SpeechSubscriptionKey
+        || Settings.SpeechSubscriptionKey === "<<YOUR_SUBSCRIPTION_KEY>>"
+        || !Settings.SpeechRegion
+        || Settings.SpeechRegion === "<<YOUR_REGION>>") {
+        throw new Error(
+            "Speech subscription key and region must be configured to run E2E tests. " +
+            "See tests/CONFIGURATION.md for setup instructions."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a SpeechConfig (subscription-based)
+// ---------------------------------------------------------------------------
+
+function buildSpeechConfig(): sdk.SpeechConfig {
+    requireCredentials();
+    let s: sdk.SpeechConfig;
+    if (undefined === Settings.SpeechEndpoint) {
+        s = sdk.SpeechConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
+    } else {
+        s = sdk.SpeechConfig.fromEndpoint(new URL(Settings.SpeechEndpoint), Settings.SpeechSubscriptionKey);
+        s.setProperty(sdk.PropertyId.SpeechServiceConnection_Region, Settings.SpeechRegion);
+    }
+    if (undefined !== Settings.proxyServer) {
+        s.setProxy(Settings.proxyServer, Settings.proxyPort);
+    }
+    expect(s).not.toBeUndefined();
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a recognizer from a WAV file
+// ---------------------------------------------------------------------------
+
+function buildRecognizerFromWaveFile(speechConfig: sdk.SpeechConfig, fileName?: string): sdk.SpeechRecognizer {
+    const audioConfig: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(
+        fileName === undefined ? Settings.WaveFile : fileName
+    );
+    if (speechConfig.speechRecognitionLanguage === undefined) {
+        speechConfig.speechRecognitionLanguage = Settings.WaveFileLanguage;
+    }
+    const r: sdk.SpeechRecognizer = new sdk.SpeechRecognizer(speechConfig, audioConfig);
+    expect(r).not.toBeUndefined();
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: capture the speech.context JSON from the wire
+//
+// Returns a Promise that resolves with the parsed speech.context object.
+// The recognizer runs recognizeOnceAsync and we intercept the message.
+// ---------------------------------------------------------------------------
+
+interface SpeechContextJson {
+    phraseDetection?: {
+        language?: string;
+        initialSilenceTimeout?: number;
+        trailingSilenceTimeout?: number;
+        enrichment?: {
+            profanity?: string;
+            interactive?: Record<string, unknown>;
+            conversation?: Record<string, unknown>;
+            dictation?: Record<string, unknown>;
+        };
+        [key: string]: unknown;
+    };
+    phraseOutput?: {
+        interimResults?: {
+            stableThreshold?: number;
+            [key: string]: unknown;
+        };
+        [key: string]: unknown;
+    };
+    [key: string]: unknown;
+}
+
+function captureSpeechContext(recognizer: sdk.SpeechRecognizer): Promise<SpeechContextJson> {
+    return new Promise<SpeechContextJson>((resolve, reject) => {
+        const con: sdk.Connection = sdk.Connection.fromRecognizer(recognizer);
+        let captured = false;
+
+        con.messageSent = (args: sdk.ConnectionMessageEventArgs): void => {
+            if (!captured && args.message.path === "speech.context" && args.message.isTextMessage) {
+                captured = true;
+                try {
+                    const ctx = JSON.parse(args.message.TextMessage) as SpeechContextJson;
+                    resolve(ctx);
+                } catch (error) {
+                    reject(error);
+                }
+            }
+        };
+
+        recognizer.canceled = (_: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
+            if (!captured) {
+                // If canceled before we got speech.context, still let it try
+                // But if it's an error, report it
+                if (e.reason === sdk.CancellationReason.Error) {
+                    reject(new Error("Recognition canceled with error: " + e.errorDetails));
+                }
+            }
+        };
+
+        recognizer.recognizeOnceAsync(
+            (_result: sdk.SpeechRecognitionResult): void => {
+                // Recognition complete — if we haven't captured speech.context by now, fail
+                if (!captured) {
+                    reject(new Error("Recognition completed but speech.context message was never intercepted"));
+                }
+            },
+            (error: string): void => {
+                reject(new Error("recognizeOnceAsync error: " + error));
+            }
+        );
+    });
+}
+
+// ===================================================================
+//  TEST: Language appears in speech.context
+// ===================================================================
+//
+//  INPUT:  speechRecognitionLanguage = "en-US"
+//  OUTPUT: speech.context JSON → phraseDetection.language === "en-US"
+//
+
+describe("speech.context wire inspection", () => {
+
+    test("Language property appears as phraseDetection.language in speech.context", async () => {
+        const s = buildSpeechConfig();
+        objsToClose.push(s);
+        s.speechRecognitionLanguage = "en-US";
+
+        const r = buildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        const ctx = await captureSpeechContext(r);
+
+        // VERIFY: phraseDetection.language is "en-US"
+        expect(ctx.phraseDetection).toBeDefined();
+        expect(ctx.phraseDetection.language).toEqual("en-US");
+    }, 15000);
+
+    // ===================================================================
+    //  TEST: InitialSilenceTimeout appears in speech.context
+    // ===================================================================
+    //
+    //  INPUT:  SpeechServiceConnection_InitialSilenceTimeoutMs = "5000"
+    //  OUTPUT: speech.context JSON → phraseDetection.initialSilenceTimeout === 5000 (number)
+    //
+
+    test("InitialSilenceTimeoutMs property appears as phraseDetection.initialSilenceTimeout", async () => {
+        const s = buildSpeechConfig();
+        objsToClose.push(s);
+        s.setProperty(sdk.PropertyId.SpeechServiceConnection_InitialSilenceTimeoutMs, "5000");
+
+        const r = buildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        const ctx = await captureSpeechContext(r);
+
+        // VERIFY: initialSilenceTimeout is the number 5000 (not the string "5000")
+        expect(ctx.phraseDetection).toBeDefined();
+        expect(ctx.phraseDetection.initialSilenceTimeout).toEqual(5000);
+        expect(typeof ctx.phraseDetection.initialSilenceTimeout).toEqual("number");
+    }, 15000);
+
+    // ===================================================================
+    //  TEST: EndSilenceTimeout appears in speech.context
+    // ===================================================================
+    //
+    //  INPUT:  SpeechServiceConnection_EndSilenceTimeoutMs = "2000"
+    //  OUTPUT: speech.context JSON → phraseDetection.trailingSilenceTimeout === 2000 (number)
+    //
+
+    test("EndSilenceTimeoutMs property appears as phraseDetection.trailingSilenceTimeout", async () => {
+        const s = buildSpeechConfig();
+        objsToClose.push(s);
+        s.setProperty(sdk.PropertyId.SpeechServiceConnection_EndSilenceTimeoutMs, "2000");
+
+        const r = buildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        const ctx = await captureSpeechContext(r);
+
+        // VERIFY: trailingSilenceTimeout is the number 2000
+        expect(ctx.phraseDetection).toBeDefined();
+        expect(ctx.phraseDetection.trailingSilenceTimeout).toEqual(2000);
+        expect(typeof ctx.phraseDetection.trailingSilenceTimeout).toEqual("number");
+    }, 15000);
+
+    // ===================================================================
+    //  TEST: ProfanityOption appears in speech.context
+    // ===================================================================
+    //
+    //  INPUT:  SpeechServiceResponse_ProfanityOption = "Raw"
+    //  OUTPUT: speech.context JSON → phraseDetection.enrichment.profanity === "Raw"
+    //
+
+    test("ProfanityOption property appears as phraseDetection.enrichment.profanity", async () => {
+        const s = buildSpeechConfig();
+        objsToClose.push(s);
+        s.setProperty(sdk.PropertyId.SpeechServiceResponse_ProfanityOption, "Raw");
+
+        const r = buildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        const ctx = await captureSpeechContext(r);
+
+        // VERIFY: profanity is "Raw"
+        expect(ctx.phraseDetection).toBeDefined();
+        expect(ctx.phraseDetection.enrichment).toBeDefined();
+        expect(ctx.phraseDetection.enrichment.profanity).toEqual("Raw");
+    }, 15000);
+
+    // ===================================================================
+    //  TEST: PostProcessingOption (non-truetext) appears in speech.context
+    // ===================================================================
+    //
+    //  INPUT:  SpeechServiceResponse_PostProcessingOption = "myCustomOption"
+    //  OUTPUT: speech.context JSON → phraseDetection.enrichment.interactive
+    //            .postprocessingoption === "myCustomOption"
+    //
+
+    test("PostProcessingOption (non-truetext) appears as enrichment.interactive.postprocessingoption", async () => {
+        const s = buildSpeechConfig();
+        objsToClose.push(s);
+        s.setProperty(sdk.PropertyId.SpeechServiceResponse_PostProcessingOption, "myCustomOption");
+
+        const r = buildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        const ctx = await captureSpeechContext(r);
+
+        // VERIFY: postprocessingoption is set on the interactive enrichment
+        expect(ctx.phraseDetection).toBeDefined();
+        expect(ctx.phraseDetection.enrichment).toBeDefined();
+        expect(ctx.phraseDetection.enrichment.interactive).toBeDefined();
+        expect(ctx.phraseDetection.enrichment.interactive.postprocessingoption).toEqual("myCustomOption");
+    }, 15000);
+
+    // ===================================================================
+    //  TEST: PostProcessingOption "truetext" expands to specific fields
+    // ===================================================================
+    //
+    //  INPUT:  SpeechServiceResponse_PostProcessingOption = "truetext"
+    //  OUTPUT: speech.context JSON → phraseDetection.enrichment.interactive contains:
+    //            .punctuationMode = "Implicit"
+    //            .disfluencyMode = "Removed"
+    //            .intermediatePunctuationMode = "Implicit"
+    //            .intermediatedisfluencymode = "Removed"
+    //          AND postprocessingoption must NOT be set (client-side expansion)
+    //
+
+    test("PostProcessingOption 'truetext' expands to punctuationMode/disfluencyMode (NOT postprocessingoption)", async () => {
+        const s = buildSpeechConfig();
+        objsToClose.push(s);
+        s.setProperty(sdk.PropertyId.SpeechServiceResponse_PostProcessingOption, "truetext");
+
+        const r = buildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        const ctx = await captureSpeechContext(r);
+
+        // VERIFY: truetext is expanded into specific fields
+        const interactive = ctx.phraseDetection?.enrichment?.interactive;
+        expect(interactive).toBeDefined();
+        expect(interactive.punctuationMode).toEqual("Implicit");
+        expect(interactive.disfluencyMode).toEqual("Removed");
+        expect(interactive.intermediatePunctuationMode).toEqual("Implicit");
+        expect(interactive.intermediatedisfluencymode).toEqual("Removed");
+
+        // VERIFY: postprocessingoption must NOT be set (truetext is expanded client-side)
+        expect(interactive.postprocessingoption).toBeUndefined();
+    }, 15000);
+
+    // ===================================================================
+    //  TEST: StablePartialResultThreshold appears in speech.context
+    // ===================================================================
+    //
+    //  INPUT:  SpeechServiceResponse_StablePartialResultThreshold = "3"
+    //  OUTPUT: speech.context JSON → phraseOutput.interimResults.stableThreshold === 3 (number)
+    //
+
+    test("StablePartialResultThreshold property appears as phraseOutput.interimResults.stableThreshold", async () => {
+        const s = buildSpeechConfig();
+        objsToClose.push(s);
+        s.setProperty(sdk.PropertyId.SpeechServiceResponse_StablePartialResultThreshold, "3");
+
+        const r = buildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        const ctx = await captureSpeechContext(r);
+
+        // VERIFY: stableThreshold is the number 3 (not the string "3")
+        expect(ctx.phraseOutput).toBeDefined();
+        expect(ctx.phraseOutput.interimResults).toBeDefined();
+        expect(ctx.phraseOutput.interimResults.stableThreshold).toEqual(3);
+        expect(typeof ctx.phraseOutput.interimResults.stableThreshold).toEqual("number");
+    }, 15000);
+
+    // ===================================================================
+    //  TEST: All 6 properties compose in a single speech.context message
+    // ===================================================================
+    //
+    //  INPUT:  Set all 6 properties at once:
+    //            language = "en-US"
+    //            initialSilenceTimeout = "8000"
+    //            endSilenceTimeout = "3000"
+    //            profanity = "Masked"
+    //            postProcessingOption = "truetext"
+    //            stableThreshold = "5"
+    //
+    //  OUTPUT: All fields appear in ONE speech.context JSON without
+    //          overwriting each other (deep-merge correctness)
+    //
+
+    test("All 6 properties compose correctly in a single speech.context message", async () => {
+        const s = buildSpeechConfig();
+        objsToClose.push(s);
+        s.speechRecognitionLanguage = "en-US";
+        s.setProperty(sdk.PropertyId.SpeechServiceConnection_InitialSilenceTimeoutMs, "8000");
+        s.setProperty(sdk.PropertyId.SpeechServiceConnection_EndSilenceTimeoutMs, "3000");
+        s.setProperty(sdk.PropertyId.SpeechServiceResponse_ProfanityOption, "Masked");
+        s.setProperty(sdk.PropertyId.SpeechServiceResponse_PostProcessingOption, "truetext");
+        s.setProperty(sdk.PropertyId.SpeechServiceResponse_StablePartialResultThreshold, "5");
+
+        const r = buildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        const ctx = await captureSpeechContext(r);
+
+        // VERIFY: phraseDetection fields
+        expect(ctx.phraseDetection.language).toEqual("en-US");
+        expect(ctx.phraseDetection.initialSilenceTimeout).toEqual(8000);
+        expect(ctx.phraseDetection.trailingSilenceTimeout).toEqual(3000);
+
+        // VERIFY: profanity
+        expect(ctx.phraseDetection.enrichment.profanity).toEqual("Masked");
+
+        // VERIFY: truetext expansion
+        expect(ctx.phraseDetection.enrichment.interactive.punctuationMode).toEqual("Implicit");
+        expect(ctx.phraseDetection.enrichment.interactive.disfluencyMode).toEqual("Removed");
+
+        // VERIFY: phraseOutput
+        expect(ctx.phraseOutput.interimResults.stableThreshold).toEqual(5);
+    }, 20000);
+
+    // ===================================================================
+    //  TEST: Properties NOT set → fields NOT present in speech.context
+    // ===================================================================
+    //
+    //  INPUT:  No extra properties set (only default language from test setup)
+    //  OUTPUT: speech.context JSON should NOT contain:
+    //            - phraseDetection.initialSilenceTimeout
+    //            - phraseDetection.trailingSilenceTimeout
+    //            - phraseDetection.enrichment.profanity
+    //            - phraseOutput.interimResults.stableThreshold
+    //
+
+    test("When no extra properties are set, optional fields are absent from speech.context", async () => {
+        const s = buildSpeechConfig();
+        objsToClose.push(s);
+        // Only set language (which BuildRecognizerFromWaveFile does by default)
+
+        const r = buildRecognizerFromWaveFile(s);
+        objsToClose.push(r);
+
+        const ctx = await captureSpeechContext(r);
+
+        // VERIFY: optional fields are not present
+        expect(ctx.phraseDetection?.initialSilenceTimeout).toBeUndefined();
+        expect(ctx.phraseDetection?.trailingSilenceTimeout).toBeUndefined();
+        expect(ctx.phraseDetection?.enrichment?.profanity).toBeUndefined();
+        // stableThreshold should not be set either
+        if (ctx.phraseOutput?.interimResults) {
+            expect(ctx.phraseOutput.interimResults.stableThreshold).toBeUndefined();
+        }
+    }, 15000);
+});

--- a/tests/SpeechContextSetterTests.ts
+++ b/tests/SpeechContextSetterTests.ts
@@ -1,0 +1,518 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Unit tests for the 6 speech.context setter methods added to ServiceRecognizerBase:
+ *   setLanguageJson, setInitialSilenceTimeoutJson, setEndSilenceTimeoutJson,
+ *   setProfanityOptionJson, setPostProcessingOptionJson, setStableIntermediateThresholdJson
+ *
+ * Strategy: We bypass the ServiceRecognizerBase constructor (which requires many complex deps)
+ * by using Object.create() and manually wiring only the fields the setters depend on:
+ *   - privSpeechContext  (SpeechContext)
+ *   - privRecognizerConfig (RecognizerConfig — specifically .parameters and .autoDetectSourceLanguages)
+ *   - recognitionMode (via privRecognizerConfig.recognitionMode)
+ *
+ * We mock modules that trigger circular dependency chains (AudioConfig → common.browser → sdk)
+ * so that importing ServiceRecognizerBase doesn't break the test suite.
+ */
+
+// Break the barrel-export circular dependency chains before any imports
+// The chain is: sdk/Exports → AudioInputStream → common.speech/Exports → Transcription/Exports
+//             → ConversationTranslatorRecognizer → SessionEventArgs (not yet resolved)
+jest.mock("../src/sdk/Audio/AudioConfig", () => ({}));
+jest.mock("../src/sdk/Audio/AudioInputStream", () => ({}));
+jest.mock("../src/sdk/Audio/AudioOutputStream", () => ({}));
+jest.mock("../src/common.browser/Exports", () => ({}));
+jest.mock("../src/common.speech/Transcription/Exports", () => ({}));
+
+import { PropertyCollection } from "../src/sdk/PropertyCollection";
+import { PropertyId } from "../src/sdk/PropertyId";
+import { DynamicGrammarBuilder } from "../src/common.speech/DynamicGrammarBuilder";
+import { SpeechContext } from "../src/common.speech/SpeechContext";
+import { RecognizerConfig } from "../src/common.speech/RecognizerConfig";
+import { Context, SpeechServiceConfig } from "../src/common.speech/SpeechServiceConfig";
+import { RecognitionMode } from "../src/common.speech/ServiceMessages/PhraseDetection/PhraseDetectionContext";
+import { ProfanityHandlingMode } from "../src/common.speech/ServiceMessages/PhraseDetection/Enrichment";
+import { InteractivePunctuationMode } from "../src/common.speech/ServiceMessages/PhraseDetection/InteractiveEnrichmentOptions";
+import { ConversationPunctuationMode } from "../src/common.speech/ServiceMessages/PhraseDetection/ConversationEnrichmentOptions";
+import { DictationPunctuationMode } from "../src/common.speech/ServiceMessages/PhraseDetection/DictationEnrichmentOptions";
+import { DisfluencyMode } from "../src/common.speech/ServiceMessages/PhraseDetection/DisfluencyMode";
+import { ServiceRecognizerBase } from "../src/common.speech/ServiceRecognizerBase";
+import { SpeechContext as SpeechServiceContext } from "../src/common.speech/ServiceMessages/SpeechContext";
+import { Settings } from "./Settings";
+
+beforeAll((): void => {
+    Settings.LoadSettings();
+});
+
+// eslint-disable-next-line no-console
+beforeEach((): void => console.info("------------------Starting test case: " + expect.getState().currentTestName + "-------------------------"));
+
+// ---------------------------------------------------------------------------
+// Test harness: create a "bare" ServiceRecognizerBase that only has the fields
+// the setters touch, without invoking the real constructor.
+// ---------------------------------------------------------------------------
+
+interface TestableRecognizer {
+    privSpeechContext: SpeechContext;
+    privRecognizerConfig: RecognizerConfig;
+    setLanguageJson(): void;
+    setInitialSilenceTimeoutJson(): void;
+    setEndSilenceTimeoutJson(): void;
+    setProfanityOptionJson(): void;
+    setPostProcessingOptionJson(): void;
+    setStableIntermediateThresholdJson(): void;
+    recognitionMode: RecognitionMode;
+}
+
+function createTestRecognizer(mode: RecognitionMode = RecognitionMode.Interactive): TestableRecognizer {
+    const params = new PropertyCollection();
+    const config = new RecognizerConfig(
+        new SpeechServiceConfig(new Context(null)),
+        params,
+    );
+    config.recognitionMode = mode;
+
+    const dgBuilder = new DynamicGrammarBuilder();
+    const speechContext = new SpeechContext(dgBuilder);
+
+    // Build a bare instance from the prototype — avoids complex constructor deps
+    const instance = Object.create(ServiceRecognizerBase.prototype) as TestableRecognizer;
+    instance.privSpeechContext = speechContext;
+    instance.privRecognizerConfig = config;
+
+    return instance;
+}
+
+function getContext(rec: TestableRecognizer): SpeechServiceContext {
+    return rec.privSpeechContext.getContext();
+}
+
+// ===================================================================
+// setLanguageJson
+// ===================================================================
+
+describe("setLanguageJson", () => {
+    test("sets phraseDetection.language when property is present", () => {
+        const rec = createTestRecognizer();
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_RecoLanguage, "en-US");
+
+        rec.setLanguageJson();
+
+        const ctx = getContext(rec);
+        expect(ctx.phraseDetection).toBeDefined();
+        expect(ctx.phraseDetection.language).toEqual("en-US");
+    });
+
+    test("clears phraseDetection.language when property is absent", () => {
+        const rec = createTestRecognizer();
+        // Pre-seed a language to verify it gets removed
+        getContext(rec).phraseDetection = { language: "de-DE" };
+
+        rec.setLanguageJson();
+
+        expect(getContext(rec).phraseDetection.language).toBeUndefined();
+    });
+
+    test("clears language when autoDetectSourceLanguages is configured", () => {
+        const rec = createTestRecognizer();
+        // Set both language AND auto-detect — auto-detect should win
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_RecoLanguage, "en-US");
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_AutoDetectSourceLanguages, "en-US,fr-FR");
+
+        rec.setLanguageJson();
+
+        expect(getContext(rec).phraseDetection).toBeDefined();
+        expect(getContext(rec).phraseDetection.language).toBeUndefined();
+    });
+
+    test("does not overwrite sibling phraseDetection fields", () => {
+        const rec = createTestRecognizer();
+        getContext(rec).phraseDetection = { mode: RecognitionMode.Interactive, initialSilenceTimeout: 5000 };
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_RecoLanguage, "ja-JP");
+
+        rec.setLanguageJson();
+
+        const pd = getContext(rec).phraseDetection;
+        expect(pd.language).toEqual("ja-JP");
+        expect(pd.mode).toEqual(RecognitionMode.Interactive);
+        expect(pd.initialSilenceTimeout).toEqual(5000);
+    });
+});
+
+// ===================================================================
+// setInitialSilenceTimeoutJson
+// ===================================================================
+
+describe("setInitialSilenceTimeoutJson", () => {
+    test("sets phraseDetection.initialSilenceTimeout as integer", () => {
+        const rec = createTestRecognizer();
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_InitialSilenceTimeoutMs, "5000");
+
+        rec.setInitialSilenceTimeoutJson();
+
+        expect(getContext(rec).phraseDetection.initialSilenceTimeout).toEqual(5000);
+        // Verify it's a number, not a string
+        expect(typeof getContext(rec).phraseDetection.initialSilenceTimeout).toEqual("number");
+    });
+
+    test("clears initialSilenceTimeout when property is absent", () => {
+        const rec = createTestRecognizer();
+        getContext(rec).phraseDetection = { initialSilenceTimeout: 3000 };
+
+        rec.setInitialSilenceTimeoutJson();
+
+        expect(getContext(rec).phraseDetection.initialSilenceTimeout).toBeUndefined();
+    });
+
+    test("does not overwrite sibling phraseDetection fields", () => {
+        const rec = createTestRecognizer();
+        getContext(rec).phraseDetection = { language: "en-US", trailingSilenceTimeout: 2000 };
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_InitialSilenceTimeoutMs, "10000");
+
+        rec.setInitialSilenceTimeoutJson();
+
+        const pd = getContext(rec).phraseDetection;
+        expect(pd.initialSilenceTimeout).toEqual(10000);
+        expect(pd.language).toEqual("en-US");
+        expect(pd.trailingSilenceTimeout).toEqual(2000);
+    });
+});
+
+// ===================================================================
+// setEndSilenceTimeoutJson
+// ===================================================================
+
+describe("setEndSilenceTimeoutJson", () => {
+    test("sets phraseDetection.trailingSilenceTimeout as integer", () => {
+        const rec = createTestRecognizer();
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_EndSilenceTimeoutMs, "2000");
+
+        rec.setEndSilenceTimeoutJson();
+
+        expect(getContext(rec).phraseDetection.trailingSilenceTimeout).toEqual(2000);
+        expect(typeof getContext(rec).phraseDetection.trailingSilenceTimeout).toEqual("number");
+    });
+
+    test("clears trailingSilenceTimeout when property is absent", () => {
+        const rec = createTestRecognizer();
+        getContext(rec).phraseDetection = { trailingSilenceTimeout: 1500 };
+
+        rec.setEndSilenceTimeoutJson();
+
+        expect(getContext(rec).phraseDetection.trailingSilenceTimeout).toBeUndefined();
+    });
+
+    test("does not overwrite sibling phraseDetection fields", () => {
+        const rec = createTestRecognizer();
+        getContext(rec).phraseDetection = { initialSilenceTimeout: 5000 };
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_EndSilenceTimeoutMs, "3000");
+
+        rec.setEndSilenceTimeoutJson();
+
+        const pd = getContext(rec).phraseDetection;
+        expect(pd.trailingSilenceTimeout).toEqual(3000);
+        expect(pd.initialSilenceTimeout).toEqual(5000);
+    });
+});
+
+// ===================================================================
+// setProfanityOptionJson
+// ===================================================================
+
+describe("setProfanityOptionJson", () => {
+    test("sets phraseDetection.enrichment.profanity when property is present", () => {
+        const rec = createTestRecognizer();
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_ProfanityOption, "Raw");
+
+        rec.setProfanityOptionJson();
+
+        const enrichment = getContext(rec).phraseDetection.enrichment;
+        expect(enrichment).toBeDefined();
+        expect(enrichment.profanity).toEqual("Raw");
+    });
+
+    test("clears profanity when property is absent", () => {
+        const rec = createTestRecognizer();
+        getContext(rec).phraseDetection = { enrichment: { profanity: ProfanityHandlingMode.Masked } };
+
+        rec.setProfanityOptionJson();
+
+        expect(getContext(rec).phraseDetection.enrichment.profanity).toBeUndefined();
+    });
+
+    test("does not overwrite sibling enrichment fields", () => {
+        const rec = createTestRecognizer();
+        getContext(rec).phraseDetection = {
+            enrichment: {
+                interactive: { postprocessingoption: "someOption" }
+            }
+        };
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_ProfanityOption, "Removed");
+
+        rec.setProfanityOptionJson();
+
+        const enrichment = getContext(rec).phraseDetection.enrichment;
+        expect(enrichment.profanity).toEqual("Removed");
+        expect(enrichment.interactive.postprocessingoption).toEqual("someOption");
+    });
+
+    test("handles absent enrichment gracefully when clearing", () => {
+        const rec = createTestRecognizer();
+        // phraseDetection exists but enrichment does not
+        getContext(rec).phraseDetection = {};
+
+        rec.setProfanityOptionJson();
+
+        // Should not throw; profanity just stays undefined
+        expect(getContext(rec).phraseDetection.enrichment).toBeUndefined();
+    });
+});
+
+// ===================================================================
+// setPostProcessingOptionJson
+// ===================================================================
+
+describe("setPostProcessingOptionJson", () => {
+    test("sets postprocessingoption for Interactive mode with non-truetext value", () => {
+        const rec = createTestRecognizer(RecognitionMode.Interactive);
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_PostProcessingOption, "someOption");
+
+        rec.setPostProcessingOptionJson();
+
+        const enrichment = getContext(rec).phraseDetection.enrichment;
+        expect(enrichment.interactive).toBeDefined();
+        expect(enrichment.interactive.postprocessingoption).toEqual("someOption");
+    });
+
+    test("sets postprocessingoption for Conversation mode", () => {
+        const rec = createTestRecognizer(RecognitionMode.Conversation);
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_PostProcessingOption, "custom");
+
+        rec.setPostProcessingOptionJson();
+
+        const enrichment = getContext(rec).phraseDetection.enrichment;
+        expect(enrichment.conversation).toBeDefined();
+        expect(enrichment.conversation.postprocessingoption).toEqual("custom");
+    });
+
+    test("sets postprocessingoption for Dictation mode", () => {
+        const rec = createTestRecognizer(RecognitionMode.Dictation);
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_PostProcessingOption, "dict_opt");
+
+        rec.setPostProcessingOptionJson();
+
+        const enrichment = getContext(rec).phraseDetection.enrichment;
+        expect(enrichment.dictation).toBeDefined();
+        expect(enrichment.dictation.postprocessingoption).toEqual("dict_opt");
+    });
+
+    test("expands truetext to punctuationMode and disfluencyMode for Interactive", () => {
+        const rec = createTestRecognizer(RecognitionMode.Interactive);
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_PostProcessingOption, "truetext");
+
+        rec.setPostProcessingOptionJson();
+
+        const interactive = getContext(rec).phraseDetection.enrichment.interactive;
+        expect(interactive.punctuationMode).toEqual(InteractivePunctuationMode.Implicit);
+        expect(interactive.disfluencyMode).toEqual(DisfluencyMode.Removed);
+        expect(interactive.intermediatePunctuationMode).toEqual(InteractivePunctuationMode.Implicit);
+        expect((interactive as Record<string, unknown>).intermediatedisfluencymode).toEqual(DisfluencyMode.Removed);
+        // postprocessingoption should NOT be set for truetext (client-side expansion)
+        expect(interactive.postprocessingoption).toBeUndefined();
+    });
+
+    test("expands TrueText (case-insensitive) for Conversation mode", () => {
+        const rec = createTestRecognizer(RecognitionMode.Conversation);
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_PostProcessingOption, "TrueText");
+
+        rec.setPostProcessingOptionJson();
+
+        const conversation = getContext(rec).phraseDetection.enrichment.conversation;
+        expect(conversation.punctuationMode).toEqual(ConversationPunctuationMode.Implicit);
+        expect(conversation.disfluencyMode).toEqual(DisfluencyMode.Removed);
+        expect(conversation.postprocessingoption).toBeUndefined();
+    });
+
+    test("expands truetext for Dictation mode", () => {
+        const rec = createTestRecognizer(RecognitionMode.Dictation);
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_PostProcessingOption, "TRUETEXT");
+
+        rec.setPostProcessingOptionJson();
+
+        const dictation = getContext(rec).phraseDetection.enrichment.dictation;
+        expect(dictation.punctuationMode).toEqual(DictationPunctuationMode.Implicit);
+        expect(dictation.disfluencyMode).toEqual(DisfluencyMode.Removed);
+        expect(dictation.postprocessingoption).toBeUndefined();
+    });
+
+    test("clears stale fields when property is absent", () => {
+        const rec = createTestRecognizer(RecognitionMode.Interactive);
+        // Pre-seed postprocessing fields
+        getContext(rec).phraseDetection = {
+            enrichment: {
+                interactive: {
+                    postprocessingoption: "old",
+                    punctuationMode: InteractivePunctuationMode.Implicit,
+                    disfluencyMode: DisfluencyMode.Removed,
+                }
+            }
+        };
+
+        // Now call with property absent (undefined)
+        rec.setPostProcessingOptionJson();
+
+        const interactive = getContext(rec).phraseDetection.enrichment.interactive;
+        expect(interactive.postprocessingoption).toBeUndefined();
+        expect(interactive.punctuationMode).toBeUndefined();
+        expect(interactive.disfluencyMode).toBeUndefined();
+    });
+
+    test("clears stale truetext fields when switching to non-truetext value", () => {
+        const rec = createTestRecognizer(RecognitionMode.Interactive);
+        // Pre-seed truetext expansion
+        getContext(rec).phraseDetection = {
+            enrichment: {
+                interactive: {
+                    punctuationMode: InteractivePunctuationMode.Implicit,
+                    disfluencyMode: DisfluencyMode.Removed,
+                    intermediatePunctuationMode: InteractivePunctuationMode.Implicit,
+                }
+            }
+        };
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_PostProcessingOption, "newOption");
+
+        rec.setPostProcessingOptionJson();
+
+        const interactive = getContext(rec).phraseDetection.enrichment.interactive;
+        expect(interactive.postprocessingoption).toEqual("newOption");
+        // truetext expansion fields should be cleared
+        expect(interactive.punctuationMode).toBeUndefined();
+        expect(interactive.disfluencyMode).toBeUndefined();
+        expect(interactive.intermediatePunctuationMode).toBeUndefined();
+    });
+
+    test("does not overwrite sibling enrichment fields like profanity", () => {
+        const rec = createTestRecognizer(RecognitionMode.Interactive);
+        getContext(rec).phraseDetection = {
+            enrichment: {
+                profanity: ProfanityHandlingMode.Raw
+            }
+        };
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_PostProcessingOption, "opt1");
+
+        rec.setPostProcessingOptionJson();
+
+        const enrichment = getContext(rec).phraseDetection.enrichment;
+        expect(enrichment.profanity).toEqual(ProfanityHandlingMode.Raw);
+        expect(enrichment.interactive.postprocessingoption).toEqual("opt1");
+    });
+});
+
+// ===================================================================
+// setStableIntermediateThresholdJson
+// ===================================================================
+
+describe("setStableIntermediateThresholdJson", () => {
+    test("sets phraseOutput.interimResults.stableThreshold as integer", () => {
+        const rec = createTestRecognizer();
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_StablePartialResultThreshold, "3");
+
+        rec.setStableIntermediateThresholdJson();
+
+        const phraseOutput = getContext(rec).phraseOutput;
+        expect(phraseOutput).toBeDefined();
+        expect(phraseOutput.interimResults).toBeDefined();
+        expect(phraseOutput.interimResults.stableThreshold).toEqual(3);
+        expect(typeof phraseOutput.interimResults.stableThreshold).toEqual("number");
+    });
+
+    test("clears stableThreshold when property is absent", () => {
+        const rec = createTestRecognizer();
+        getContext(rec).phraseOutput = { interimResults: { stableThreshold: 5 } };
+
+        rec.setStableIntermediateThresholdJson();
+
+        expect(getContext(rec).phraseOutput.interimResults.stableThreshold).toBeUndefined();
+    });
+
+    test("handles absent interimResults gracefully when clearing", () => {
+        const rec = createTestRecognizer();
+        getContext(rec).phraseOutput = {};
+
+        rec.setStableIntermediateThresholdJson();
+
+        // Should not throw; phraseOutput should still be defined
+        expect(getContext(rec).phraseOutput).toBeDefined();
+    });
+
+    test("deep-merges — does not replace existing phraseOutput.detailed", () => {
+        const rec = createTestRecognizer();
+        // Pre-seed phraseOutput with detailed options (as setLanguageIdJson might do)
+        getContext(rec).phraseOutput = {
+            format: "Detailed" as any,
+            detailed: { options: ["WordTimings" as any] },
+        };
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_StablePartialResultThreshold, "7");
+
+        rec.setStableIntermediateThresholdJson();
+
+        const phraseOutput = getContext(rec).phraseOutput;
+        expect(phraseOutput.interimResults.stableThreshold).toEqual(7);
+        // Existing fields preserved
+        expect(phraseOutput.format).toEqual("Detailed");
+        expect(phraseOutput.detailed.options).toContain("WordTimings");
+    });
+
+    test("works correctly when called after setLanguageIdJson populates phraseOutput", () => {
+        const rec = createTestRecognizer();
+        // Simulate what setLanguageIdJson does — creates phraseOutput with interimResults
+        getContext(rec).phraseOutput = {
+            interimResults: { resultType: "Auto" as any },
+        };
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_StablePartialResultThreshold, "4");
+
+        rec.setStableIntermediateThresholdJson();
+
+        const interimResults = getContext(rec).phraseOutput.interimResults;
+        expect(interimResults.stableThreshold).toEqual(4);
+        // resultType from setLanguageIdJson should be preserved
+        expect(interimResults.resultType).toEqual("Auto");
+    });
+});
+
+// ===================================================================
+// Cross-setter deep-merge: multiple setters applied sequentially
+// ===================================================================
+
+describe("Deep-merge across multiple setters", () => {
+    test("all setters compose without replacing each other's fields", () => {
+        const rec = createTestRecognizer(RecognitionMode.Interactive);
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_RecoLanguage, "fr-FR");
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_InitialSilenceTimeoutMs, "8000");
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceConnection_EndSilenceTimeoutMs, "3000");
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_ProfanityOption, "Masked");
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_PostProcessingOption, "truetext");
+        rec.privRecognizerConfig.parameters.setProperty(PropertyId.SpeechServiceResponse_StablePartialResultThreshold, "5");
+
+        // Call in the order the recognize() method calls them
+        rec.setLanguageJson();
+        rec.setInitialSilenceTimeoutJson();
+        rec.setEndSilenceTimeoutJson();
+        rec.setProfanityOptionJson();
+        rec.setPostProcessingOptionJson();
+        rec.setStableIntermediateThresholdJson();
+
+        const ctx = getContext(rec);
+        // phraseDetection fields
+        expect(ctx.phraseDetection.language).toEqual("fr-FR");
+        expect(ctx.phraseDetection.initialSilenceTimeout).toEqual(8000);
+        expect(ctx.phraseDetection.trailingSilenceTimeout).toEqual(3000);
+        expect(ctx.phraseDetection.enrichment.profanity).toEqual("Masked");
+        // truetext expansion
+        expect(ctx.phraseDetection.enrichment.interactive.punctuationMode).toEqual(InteractivePunctuationMode.Implicit);
+        expect(ctx.phraseDetection.enrichment.interactive.disfluencyMode).toEqual(DisfluencyMode.Removed);
+        // phraseOutput
+        expect(ctx.phraseOutput.interimResults.stableThreshold).toEqual(5);
+    });
+});


### PR DESCRIPTION
## Context

The JavaScript Speech SDK does not populate several `speech.context` message. These fields are currently only sent as URL query parameters in the JS SDK, but the native SDK sends them in the `speech.context` JSON body.

The missing fields include:

- phraseDetection.language
- phraseDetection.initialSilenceTimeout
- phraseDetection.trailingSilenceTimeout
- phraseDetection.enrichment.profanity
- phraseOutput.interimResults.stableThreshold
- phraseDetection.enrichment.[mode].postprocessingoption

## Problem

How to populate the `speech.context` message fields with the values that are configured in the speech config properties?

## Solution

Implement the corresponding setters in `ServiceRecognizerBase`