### PR TITLE
[JS] Fix TTS REST requests when using a custom domain

### DIFF
--- a/src/common.speech/ConnectionFactoryBase.ts
+++ b/src/common.speech/ConnectionFactoryBase.ts
@@ -71,7 +71,7 @@ export abstract class ConnectionFactoryBase implements IConnectionFactory {
         }
     }
 
-    public static async getRedirectUrlFromEndpoint(endpoint: string): Promise<string> {
+    public static async getRedirectUrlFromEndpoint(endpoint: string, useWebSocketProtocol: boolean = true): Promise<string> {
         // make a rest call to the endpoint to get the redirect url
         const redirectUrl: URL = new URL(endpoint);
         redirectUrl.protocol = "https:";
@@ -96,10 +96,13 @@ export abstract class ConnectionFactoryBase implements IConnectionFactory {
         try {
             // Validate the URL before returning
             const redirectUrl = new URL(redirectUrlString.trim());
-            if (redirectUrl.protocol === "https:") {
-                redirectUrl.protocol = "wss:";
-            } else if (redirectUrl.protocol === "http:") {
-                redirectUrl.protocol = "ws:";
+            // WebSocket callers need the ws(s) scheme; REST callers (e.g. voices/list) must keep http(s).
+            if (useWebSocketProtocol) {
+                if (redirectUrl.protocol === "https:") {
+                    redirectUrl.protocol = "wss:";
+                } else if (redirectUrl.protocol === "http:") {
+                    redirectUrl.protocol = "ws:";
+                }
             }
 
             return redirectUrl.toString();

--- a/src/common.speech/SynthesisRestAdapter.ts
+++ b/src/common.speech/SynthesisRestAdapter.ts
@@ -19,18 +19,21 @@ import { HeaderNames } from "./HeaderNames.js";
  */
 export class SynthesisRestAdapter {
     private privRestAdapter: RestMessageAdapter;
-    private privUri: string;
+    private privUri: string | undefined;
+    private privEndpoint: string;
+    private privIsCustomEndpoint: boolean;
     private privAuthentication: IAuthentication;
 
     public constructor(config: SynthesizerConfig, authentication: IAuthentication) {
 
         let endpoint = config.parameters.getProperty(PropertyId.SpeechServiceConnection_Endpoint, undefined);
+        this.privIsCustomEndpoint = !!endpoint;
         if (!endpoint) {
             const region: string = config.parameters.getProperty(PropertyId.SpeechServiceConnection_Region, "westus");
             const hostSuffix: string = ConnectionFactoryBase.getHostSuffix(region);
             endpoint = config.parameters.getProperty(PropertyId.SpeechServiceConnection_Host, `https://${region}.tts.speech${hostSuffix}`);
         }
-        this.privUri = `${endpoint}/cognitiveservices/voices/list`;
+        this.privEndpoint = endpoint;
 
         const options: IRequestOptions = RestConfigBase.requestOptions;
         this.privRestAdapter = new RestMessageAdapter(options);
@@ -44,12 +47,51 @@ export class SynthesisRestAdapter {
      * @param connectionId - guid for connectionId
      * @returns {Promise<IRestResponse>} rest response to status request
      */
-    public getVoicesList(connectionId: string): Promise<IRestResponse> {
+    public async getVoicesList(connectionId: string): Promise<IRestResponse> {
+        const uri: string = await this.getVoicesListUri();
         this.privRestAdapter.setHeaders(HeaderNames.ConnectionId, connectionId);
-        return this.privAuthentication.fetch(connectionId).then((authInfo: AuthInfo): Promise<IRestResponse> => {
-            this.privRestAdapter.setHeaders(authInfo.headerName, authInfo.token);
-            return this.privRestAdapter.request(RestRequestType.Get, this.privUri);
-        });
+        const authInfo: AuthInfo = await this.privAuthentication.fetch(connectionId);
+        this.privRestAdapter.setHeaders(authInfo.headerName, authInfo.token);
+        return this.privRestAdapter.request(RestRequestType.Get, uri);
+    }
+
+    /**
+     * Builds (and caches) the voices/list URI. When the caller supplied a custom endpoint with no path
+     * (e.g. a custom-domain or private-link host via fromEndpoint), the host may not serve the voices/list
+     * route directly and AAD token auth requires the regional host with the ocp-apim-custom-domain-name
+     * query parameter. In that case we resolve the service redirect (which is exposed on the synthesis
+     * route) to discover the regional host and custom-domain parameter, then retarget it to the
+     * voices/list path, keeping the http(s) scheme for this REST call.
+     */
+    private async getVoicesListUri(): Promise<string> {
+        if (this.privUri !== undefined) {
+            return this.privUri;
+        }
+
+        const voicesPath = "/cognitiveservices/voices/list";
+        const endpointUrl: URL = new URL(this.privEndpoint);
+        const pathName: string = endpointUrl.pathname;
+        const hasNoPath: boolean = pathName === "" || pathName === "/";
+
+        if (this.privIsCustomEndpoint && hasNoPath) {
+            // The redirect handler is exposed on the synthesis route. Resolving it returns the regional
+            // host together with the Ocp-Apim-Custom-Domain-Name parameter (or, when no redirect applies,
+            // falls back to the original host). We then point the resolved URL at the voices/list path.
+            endpointUrl.pathname = "/tts/cognitiveservices/websocket/v1";
+            const resolved: string = await ConnectionFactoryBase.getRedirectUrlFromEndpoint(endpointUrl.toString(), false);
+            const resolvedUrl: URL = new URL(resolved);
+            resolvedUrl.pathname = voicesPath;
+            resolvedUrl.searchParams.delete("GenerateRedirectResponse");
+            this.privUri = resolvedUrl.toString();
+        } else if (hasNoPath) {
+            endpointUrl.pathname = voicesPath;
+            this.privUri = endpointUrl.toString();
+        } else {
+            // The endpoint already carries a path; preserve the legacy behavior of appending the voices route.
+            this.privUri = `${this.privEndpoint}${voicesPath}`;
+        }
+
+        return this.privUri;
     }
 
 }

--- a/tests/SpeechConfigConnectionFactories.ts
+++ b/tests/SpeechConfigConnectionFactories.ts
@@ -110,7 +110,7 @@ export class SpeechConfigConnectionFactory {
 
             case SpeechConnectionType.CloudFromEndpointWithKeyAuth:
                 return this.buildCloudEndpointKeyConfig<T>(isTranslationConfig);
-            
+
             case SpeechConnectionType.CloudFromEndpointWithKeyCredentialAuth:
                 return this.buildCloudEndpointKeyCredentialConfig<T>(isTranslationConfig);
 
@@ -118,7 +118,7 @@ export class SpeechConfigConnectionFactory {
                 return this.buildCloudEndpointConfigWithCogSvcsToken<T>(isTranslationConfig);
 
             case SpeechConnectionType.CloudFromEndpointWithEntraIdTokenAuth:
-                return this.buildCloudEndpointConfigWithEntraId<T>(isTranslationConfig);
+                return this.buildCloudEndpointConfigWithEntraId<T>(isTranslationConfig, serviceType);
 
             case SpeechConnectionType.ContainerFromHost:
                 return this.buildContainerSpeechConfig<T>(serviceType, isTranslationConfig);
@@ -203,7 +203,7 @@ export class SpeechConfigConnectionFactory {
     /**
      * Gets an Azure AD token for the specified subscription key from the SubscriptionsRegionsMap.
      * Uses the DefaultAzureCredential from @azure/identity to acquire tokens.
-     * 
+     *
      * @param subscriptionKey The key in the SubscriptionsRegionsMap that contains AAD configuration
      * @returns A promise that resolves to the access token
      */
@@ -357,7 +357,10 @@ export class SpeechConfigConnectionFactory {
     /**
      * Builds a cloud endpoint config with Entra ID token authentication.
      */
-    private static buildCloudEndpointConfigWithEntraId<T extends ConfigType>(isTranslationConfig: boolean): T {
+    private static buildCloudEndpointConfigWithEntraId<T extends ConfigType>(
+        isTranslationConfig: boolean,
+        serviceType: SpeechServiceType = SpeechServiceType.SpeechRecognition
+    ): T {
         const subscriptionRegion = this.getSubscriptionRegion(SubscriptionsRegionsKeys.AAD_SPEECH_CLIENT_SECRET);
         const endpoint = subscriptionRegion.Endpoint;
 
@@ -365,8 +368,26 @@ export class SpeechConfigConnectionFactory {
             throw new Error("Endpoint is not defined for the AAD subscription");
         }
 
+        // The AAD resource endpoint points at the STT universal route/host, which cannot serve TTS. For
+        // synthesis we reduce it to the resource's custom-domain host (no path) so the SDK can append the
+        // correct TTS route while still validating the Entra ID token against the right resource.
+        const resolvedEndpoint = serviceType === SpeechServiceType.TextToSpeech
+            ? this.deriveTextToSpeechEntraIdEndpoint(endpoint)
+            : endpoint;
+
         const credential = new DefaultAzureCredential();
-        return this.buildEndpointWithTokenCredential<T>(credential, endpoint, isTranslationConfig);
+        return this.buildEndpointWithTokenCredential<T>(credential, resolvedEndpoint, isTranslationConfig);
+    }
+
+    /**
+     * Derives a token-credential friendly TTS endpoint from the configured Entra ID speech endpoint by
+     * reducing it to the resource's custom-domain host with no path.
+     */
+    private static deriveTextToSpeechEntraIdEndpoint(endpoint: string): string {
+        const url = new URL(endpoint);
+        const customDomain = url.searchParams.get("ocp-apim-custom-domain-name");
+        const host = customDomain || url.hostname;
+        return `https://${host}`;
     }
 
     /**

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -45,6 +45,13 @@ beforeEach((): void => {
 
 jest.retryTimes(Settings.RetryCount);
 
+// Entra ID (AAD) token-credential tests require an AAD-enabled Speech resource and an environment where a
+// managed identity / service principal can be resolved (e.g. the connection-test pipeline that also sets up
+// the right managed identity). They are gated through the exact same runConnectionTest helper the STT
+// connection tests use, so they are skipped on normal CI runs (where DefaultAzureCredential cannot resolve a
+// single identity) and only execute in the dedicated connection-test pipeline.
+const EntraIdTokenCredentialTest: jest.It = SpeechConfigConnectionFactory.runConnectionTest(SpeechConnectionType.CloudFromEndpointWithEntraIdTokenAuth);
+
 afterEach(async (): Promise<void> => {
     // eslint-disable-next-line no-console
     console.info("End Time: " + new Date(Date.now()).toLocaleString());
@@ -499,7 +506,7 @@ describe("Service based tests", (): void => {
         SpeechConnectionType.Subscription,
         SpeechConnectionType.CloudFromEndpointWithKeyAuth,
         SpeechConnectionType.CloudFromEndpointWithCogSvcsTokenAuth,
-        // SpeechConnectionType.CloudFromEndpointWithEntraIdTokenAuth,
+        SpeechConnectionType.CloudFromEndpointWithEntraIdTokenAuth,
         SpeechConnectionType.LegacyCogSvcsTokenAuth,
         SpeechConnectionType.LegacyEntraIdTokenAuth,
         SpeechConnectionType.CloudFromHost,
@@ -1401,9 +1408,11 @@ describe("Service based tests", (): void => {
         });
     });
 
+    describe("Speech Synthesis Token Credential Connection Tests", (): void => {
+
     // Requires an Entra ID (AAD) enabled Speech resource and ambient Azure credentials
     // (e.g. AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET).
-    test("testSpeechSynthesizerWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
+    EntraIdTokenCredentialTest("testSpeechSynthesizerWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizerWithEntraIdTokenCredential");
 
@@ -1430,7 +1439,7 @@ describe("Service based tests", (): void => {
     // The getVoicesAsync REST call resolves the service redirect for custom-domain / private-link hosts
     // (matching the websocket synthesis path), so the regional voices/list route is reached with the
     // ocp-apim-custom-domain-name parameter required for AAD token auth.
-    test("testGetVoicesAsyncWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
+    EntraIdTokenCredentialTest("testGetVoicesAsyncWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testGetVoicesAsyncWithEntraIdTokenCredential");
 
@@ -1456,7 +1465,7 @@ describe("Service based tests", (): void => {
 
     // Streams synthesized audio to a PullAudioOutputStream while authenticating with an Entra ID token credential.
     // Requires an Entra ID (AAD) enabled Speech resource and ambient Azure credentials.
-    test("testSpeechSynthesizerPullStreamWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
+    EntraIdTokenCredentialTest("testSpeechSynthesizerPullStreamWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizerPullStreamWithEntraIdTokenCredential");
 
@@ -1488,7 +1497,7 @@ describe("Service based tests", (): void => {
     // Text streaming requires the universal v2 synthesis route. The synthesis connection factory only rewrites
     // the path to /tts/cognitiveservices/websocket/v1 when no path is supplied, so we provide a fully-formed v2
     // endpoint (regional TTS host + v2 route + custom-domain name) which the factory uses as-is.
-    test("testSpeechSynthesizerTextStreamingWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
+    EntraIdTokenCredentialTest("testSpeechSynthesizerTextStreamingWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console
         console.info("Name: testSpeechSynthesizerTextStreamingWithEntraIdTokenCredential");
 
@@ -1526,6 +1535,8 @@ describe("Service based tests", (): void => {
             stream.close();
         }, 300);
     }, 30000);
+
+    });
 
     test("test Speech Synthesizer: Language Auto Detection", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -109,11 +109,9 @@ const BuildEntraIdTokenCredentialEndpoint: () => URL = (): URL => {
 };
 
 // Derives a fully-formed v2 TTS websocket endpoint for Entra ID (AAD) token authentication.
-// Text input streaming requires the universal v2 synthesis route. The synthesis connection factory only
-// rewrites the path to /tts/cognitiveservices/websocket/v1 (and resolves a redirect) when the supplied
-// endpoint has no path; when a full v2 path is provided it is used as-is. We therefore build the regional
-// TTS host with the v2 route and carry the resource's custom-domain name so the service can validate the
-// AAD token against the correct resource.
+// Text input streaming requires the universal v2 synthesis route. Like BuildEntraIdTokenCredentialEndpoint,
+// we reduce the configured endpoint to its custom-domain host (which AAD validates the token against) and
+// then point it at the v2 websocket route, which text input streaming requires.
 const BuildEntraIdTokenCredentialV2Endpoint: () => URL = (): URL => {
     const sub = ResolveEntraIdSubscriptionRegion();
     const configured: string = (sub && sub.Endpoint) || Settings.SpeechEndpoint;
@@ -123,13 +121,8 @@ const BuildEntraIdTokenCredentialV2Endpoint: () => URL = (): URL => {
 
     const url: URL = new URL(configured);
     const customDomain: string = url.searchParams.get("ocp-apim-custom-domain-name");
-    const region: string = (sub && sub.Region) || url.hostname.split(".")[0];
-    const ttsHost: string = `${region}.tts.speech.microsoft.com`;
-    const v2: URL = new URL(`wss://${ttsHost}/cognitiveservices/websocket/v2`);
-    if (customDomain) {
-        v2.searchParams.set("Ocp-Apim-Custom-Domain-Name", customDomain);
-    }
-    return v2;
+    const host: string = customDomain || url.hostname;
+    return new URL(`wss://${host}/cognitiveservices/websocket/v2`);
 };
 
 const CheckSynthesisResult: (result: sdk.SpeechSynthesisResult, reason: sdk.ResultReason) =>

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -108,23 +108,6 @@ const BuildEntraIdTokenCredentialEndpoint: () => URL = (): URL => {
     return new URL(`https://${host}`);
 };
 
-// Derives a fully-formed v2 TTS websocket endpoint for Entra ID (AAD) token authentication.
-// Text input streaming requires the universal v2 synthesis route. Like BuildEntraIdTokenCredentialEndpoint,
-// we reduce the configured endpoint to its custom-domain host (which AAD validates the token against) and
-// then point it at the v2 websocket route, which text input streaming requires.
-const BuildEntraIdTokenCredentialV2Endpoint: () => URL = (): URL => {
-    const sub = ResolveEntraIdSubscriptionRegion();
-    const configured: string = (sub && sub.Endpoint) || Settings.SpeechEndpoint;
-    if (!configured) {
-        throw new Error("No endpoint configured for the Entra ID speech subscription.");
-    }
-
-    const url: URL = new URL(configured);
-    const customDomain: string = url.searchParams.get("ocp-apim-custom-domain-name");
-    const host: string = customDomain || url.hostname;
-    return new URL(`wss://${host}/cognitiveservices/websocket/v2`);
-};
-
 const CheckSynthesisResult: (result: sdk.SpeechSynthesisResult, reason: sdk.ResultReason) =>
     void = (result: sdk.SpeechSynthesisResult, reason: sdk.ResultReason): void => {
         expect(result).not.toBeUndefined();
@@ -1485,49 +1468,6 @@ describe("Service based tests", (): void => {
             done(e);
         });
     });
-
-    // Text input streaming (bidirectional) authenticated with an Entra ID token credential.
-    // Text streaming requires the universal v2 synthesis route. The synthesis connection factory only rewrites
-    // the path to /tts/cognitiveservices/websocket/v1 when no path is supplied, so we provide a fully-formed v2
-    // endpoint (regional TTS host + v2 route + custom-domain name) which the factory uses as-is.
-    EntraIdTokenCredentialTest("testSpeechSynthesizerTextStreamingWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
-        // eslint-disable-next-line no-console
-        console.info("Name: testSpeechSynthesizerTextStreamingWithEntraIdTokenCredential");
-
-        const credential: DefaultAzureCredential = new DefaultAzureCredential();
-        const speechConfig: sdk.SpeechConfig = sdk.SpeechConfig.fromEndpoint(BuildEntraIdTokenCredentialV2Endpoint(), credential);
-        objsToClose.push(speechConfig);
-        expect(speechConfig).not.toBeUndefined();
-        speechConfig.speechSynthesisLanguage = "en-US";
-        speechConfig.speechSynthesisVoiceName = "en-US-AvaMultilingualNeural";
-
-        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
-        objsToClose.push(s);
-        expect(s).not.toBeUndefined();
-
-        const request = new sdk.SpeechSynthesisRequest(sdk.SpeechSynthesisRequestInputType.TextStream);
-        const stream = request.inputStream;
-
-        s.speakAsync(request, (result: sdk.SpeechSynthesisResult): void => {
-            // eslint-disable-next-line no-console
-            console.info("Streaming synthesis completed.");
-            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-            done();
-        }, (e: string): void => {
-            done(e);
-        });
-
-        // Send text pieces with a small delay to simulate streaming
-        setTimeout((): void => {
-            stream.write("hello ");
-        }, 100);
-        setTimeout((): void => {
-            stream.write("world.");
-        }, 200);
-        setTimeout((): void => {
-            stream.close();
-        }, 300);
-    }, 30000);
 
     });
 

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -3,6 +3,7 @@
 /* eslint-disable no-console */
 import * as fs from "fs";
 import bent, { BentResponse } from "bent";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
 import { ConsoleLoggingListener } from "../src/common.browser/Exports";
 import { HeaderNames } from "../src/common.speech/HeaderNames";
@@ -18,6 +19,8 @@ import {
     closeAsyncObjects,
     WaitForCondition
 } from "./Utilities";
+import { ConfigLoader } from "./ConfigLoader";
+import { SubscriptionsRegionsKeys } from "./SubscriptionRegion";
 import { SpeechConfigConnectionFactory } from "./SpeechConfigConnectionFactories";
 import { SpeechConnectionType } from "./SpeechConnectionTypes";
 import { SpeechServiceType } from "./SpeechServiceTypes";
@@ -64,6 +67,52 @@ const BuildSpeechConfig: (connectionType?: SpeechConnectionType) => Promise<sdk.
     }
 
     return s;
+};
+
+// Derives a token-credential friendly TTS endpoint from the configured unified speech subscription.
+// The configured endpoint points at the STT universal route (and host), which cannot serve TTS, so we
+// reduce it to the resource's custom-domain host with no path. The synthesis connection factory then
+// appends the TTS websocket route and the REST adapter appends the voices route, both of which work with
+// Entra ID (AAD) token authentication.
+const BuildEntraIdTokenCredentialEndpoint: () => URL = (): URL => {
+    const configLoader: ConfigLoader = ConfigLoader.instance;
+    configLoader.initialize();
+    const sub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+    const configured: string = (sub && sub.Endpoint) || Settings.SpeechEndpoint;
+    if (!configured) {
+        throw new Error("No endpoint configured for the unified speech subscription.");
+    }
+
+    const url: URL = new URL(configured);
+    const customDomain: string = url.searchParams.get("ocp-apim-custom-domain-name");
+    const host: string = customDomain || url.hostname;
+    return new URL(`https://${host}`);
+};
+
+// Derives a fully-formed v2 TTS websocket endpoint for Entra ID (AAD) token authentication.
+// Text input streaming requires the universal v2 synthesis route. The synthesis connection factory only
+// rewrites the path to /tts/cognitiveservices/websocket/v1 (and resolves a redirect) when the supplied
+// endpoint has no path; when a full v2 path is provided it is used as-is. We therefore build the regional
+// TTS host with the v2 route and carry the resource's custom-domain name so the service can validate the
+// AAD token against the correct resource.
+const BuildEntraIdTokenCredentialV2Endpoint: () => URL = (): URL => {
+    const configLoader: ConfigLoader = ConfigLoader.instance;
+    configLoader.initialize();
+    const sub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+    const configured: string = (sub && sub.Endpoint) || Settings.SpeechEndpoint;
+    if (!configured) {
+        throw new Error("No endpoint configured for the unified speech subscription.");
+    }
+
+    const url: URL = new URL(configured);
+    const customDomain: string = url.searchParams.get("ocp-apim-custom-domain-name");
+    const region: string = (sub && sub.Region) || url.hostname.split(".")[0];
+    const ttsHost: string = `${region}.tts.speech.microsoft.com`;
+    const v2: URL = new URL(`wss://${ttsHost}/cognitiveservices/websocket/v2`);
+    if (customDomain) {
+        v2.searchParams.set("Ocp-Apim-Custom-Domain-Name", customDomain);
+    }
+    return v2;
 };
 
 const CheckSynthesisResult: (result: sdk.SpeechSynthesisResult, reason: sdk.ResultReason) =>
@@ -1341,6 +1390,132 @@ describe("Service based tests", (): void => {
             });
         });
     });
+
+    // Requires an Entra ID (AAD) enabled Speech resource and ambient Azure credentials
+    // (e.g. AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET).
+    test("testSpeechSynthesizerWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
+        // eslint-disable-next-line no-console
+        console.info("Name: testSpeechSynthesizerWithEntraIdTokenCredential");
+
+        const credential: DefaultAzureCredential = new DefaultAzureCredential();
+        const speechConfig: sdk.SpeechConfig = sdk.SpeechConfig.fromEndpoint(BuildEntraIdTokenCredentialEndpoint(), credential);
+        objsToClose.push(speechConfig);
+        expect(speechConfig).not.toBeUndefined();
+
+        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+        objsToClose.push(s);
+        expect(s).not.toBeUndefined();
+
+        s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
+            // eslint-disable-next-line no-console
+            console.info("speaking text finished.");
+            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+            done();
+        }, (e: string): void => {
+            done(e);
+        });
+    });
+
+    // Requires an Entra ID (AAD) enabled Speech resource and ambient Azure credentials.
+    // The getVoicesAsync REST call resolves the service redirect for custom-domain / private-link hosts
+    // (matching the websocket synthesis path), so the regional voices/list route is reached with the
+    // ocp-apim-custom-domain-name parameter required for AAD token auth.
+    test("testGetVoicesAsyncWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
+        // eslint-disable-next-line no-console
+        console.info("Name: testGetVoicesAsyncWithEntraIdTokenCredential");
+
+        const credential: DefaultAzureCredential = new DefaultAzureCredential();
+        const speechConfig: sdk.SpeechConfig = sdk.SpeechConfig.fromEndpoint(BuildEntraIdTokenCredentialEndpoint(), credential);
+        objsToClose.push(speechConfig);
+        expect(speechConfig).not.toBeUndefined();
+
+        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+        objsToClose.push(s);
+        expect(s).not.toBeUndefined();
+
+        s.getVoicesAsync().then((voicesResult: sdk.SynthesisVoicesResult): void => {
+            expect(voicesResult).not.toBeUndefined();
+            expect(voicesResult.resultId).not.toBeUndefined();
+            expect(voicesResult.voices.length).toBeGreaterThan(0);
+            expect(voicesResult.reason).toEqual(sdk.ResultReason.VoicesListRetrieved);
+            done();
+        }).catch((error: any): void => {
+            done(error);
+        });
+    });
+
+    // Streams synthesized audio to a PullAudioOutputStream while authenticating with an Entra ID token credential.
+    // Requires an Entra ID (AAD) enabled Speech resource and ambient Azure credentials.
+    test("testSpeechSynthesizerPullStreamWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
+        // eslint-disable-next-line no-console
+        console.info("Name: testSpeechSynthesizerPullStreamWithEntraIdTokenCredential");
+
+        const credential: DefaultAzureCredential = new DefaultAzureCredential();
+        const speechConfig: sdk.SpeechConfig = sdk.SpeechConfig.fromEndpoint(BuildEntraIdTokenCredentialEndpoint(), credential);
+        objsToClose.push(speechConfig);
+        expect(speechConfig).not.toBeUndefined();
+        speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
+
+        const stream = sdk.AudioOutputStream.createPullStream();
+        const audioConfig: sdk.AudioConfig = sdk.AudioConfig.fromStreamOutput(stream);
+        expect(audioConfig).not.toBeUndefined();
+
+        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
+        expect(s).not.toBeUndefined();
+
+        s.speakTextAsync("hello world.", (result: sdk.SpeechSynthesisResult): void => {
+            // eslint-disable-next-line no-console
+            console.info("speaking text finished.");
+            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+            s.close();
+            ReadPullAudioOutputStream(stream, result.audioData.byteLength - 44, done);
+        }, (e: string): void => {
+            done(e);
+        });
+    });
+
+    // Text input streaming (bidirectional) authenticated with an Entra ID token credential.
+    // Text streaming requires the universal v2 synthesis route. The synthesis connection factory only rewrites
+    // the path to /tts/cognitiveservices/websocket/v1 when no path is supplied, so we provide a fully-formed v2
+    // endpoint (regional TTS host + v2 route + custom-domain name) which the factory uses as-is.
+    test("testSpeechSynthesizerTextStreamingWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
+        // eslint-disable-next-line no-console
+        console.info("Name: testSpeechSynthesizerTextStreamingWithEntraIdTokenCredential");
+
+        const credential: DefaultAzureCredential = new DefaultAzureCredential();
+        const speechConfig: sdk.SpeechConfig = sdk.SpeechConfig.fromEndpoint(BuildEntraIdTokenCredentialV2Endpoint(), credential);
+        objsToClose.push(speechConfig);
+        expect(speechConfig).not.toBeUndefined();
+        speechConfig.speechSynthesisLanguage = "en-US";
+        speechConfig.speechSynthesisVoiceName = "en-US-AvaMultilingualNeural";
+
+        const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+        objsToClose.push(s);
+        expect(s).not.toBeUndefined();
+
+        const request = new sdk.SpeechSynthesisRequest(sdk.SpeechSynthesisRequestInputType.TextStream);
+        const stream = request.inputStream;
+
+        s.speakAsync(request, (result: sdk.SpeechSynthesisResult): void => {
+            // eslint-disable-next-line no-console
+            console.info("Streaming synthesis completed.");
+            CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
+            done();
+        }, (e: string): void => {
+            done(e);
+        });
+
+        // Send text pieces with a small delay to simulate streaming
+        setTimeout((): void => {
+            stream.write("hello ");
+        }, 100);
+        setTimeout((): void => {
+            stream.write("world.");
+        }, 200);
+        setTimeout((): void => {
+            stream.close();
+        }, 300);
+    }, 30000);
 
     test("test Speech Synthesizer: Language Auto Detection", (done: jest.DoneCallback): void => {
         // eslint-disable-next-line no-console

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -69,18 +69,30 @@ const BuildSpeechConfig: (connectionType?: SpeechConnectionType) => Promise<sdk.
     return s;
 };
 
-// Derives a token-credential friendly TTS endpoint from the configured unified speech subscription.
+// Resolves the subscription entry used for Entra ID (AAD) token-credential tests. On CI the
+// AADSpeechClientSecret resource is provisioned with the RBAC role the test service principal needs
+// (this is the same entry the STT Entra ID tests use), so we prefer it and fall back to the unified
+// speech subscription for local runs that only have the unified entry configured.
+const ResolveEntraIdSubscriptionRegion = () => {
+    const configLoader: ConfigLoader = ConfigLoader.instance;
+    configLoader.initialize();
+    const aad = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.AAD_SPEECH_CLIENT_SECRET);
+    if (aad && aad.Endpoint) {
+        return aad;
+    }
+    return configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+};
+
+// Derives a token-credential friendly TTS endpoint from the configured Entra ID speech subscription.
 // The configured endpoint points at the STT universal route (and host), which cannot serve TTS, so we
 // reduce it to the resource's custom-domain host with no path. The synthesis connection factory then
 // appends the TTS websocket route and the REST adapter appends the voices route, both of which work with
 // Entra ID (AAD) token authentication.
 const BuildEntraIdTokenCredentialEndpoint: () => URL = (): URL => {
-    const configLoader: ConfigLoader = ConfigLoader.instance;
-    configLoader.initialize();
-    const sub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+    const sub = ResolveEntraIdSubscriptionRegion();
     const configured: string = (sub && sub.Endpoint) || Settings.SpeechEndpoint;
     if (!configured) {
-        throw new Error("No endpoint configured for the unified speech subscription.");
+        throw new Error("No endpoint configured for the Entra ID speech subscription.");
     }
 
     const url: URL = new URL(configured);
@@ -96,12 +108,10 @@ const BuildEntraIdTokenCredentialEndpoint: () => URL = (): URL => {
 // TTS host with the v2 route and carry the resource's custom-domain name so the service can validate the
 // AAD token against the correct resource.
 const BuildEntraIdTokenCredentialV2Endpoint: () => URL = (): URL => {
-    const configLoader: ConfigLoader = ConfigLoader.instance;
-    configLoader.initialize();
-    const sub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+    const sub = ResolveEntraIdSubscriptionRegion();
     const configured: string = (sub && sub.Endpoint) || Settings.SpeechEndpoint;
     if (!configured) {
-        throw new Error("No endpoint configured for the unified speech subscription.");
+        throw new Error("No endpoint configured for the Entra ID speech subscription.");
     }
 
     const url: URL = new URL(configured);

--- a/tests/SynthesisRestAdapterTests.ts
+++ b/tests/SynthesisRestAdapterTests.ts
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { RestMessageAdapter } from "../src/common.browser/Exports";
+import { ConnectionFactoryBase } from "../src/common.speech/ConnectionFactoryBase";
+import {
+    AuthInfo,
+    IAuthentication,
+    SynthesisRestAdapter,
+    SynthesizerConfig,
+} from "../src/common.speech/Exports";
+import { HeaderNames } from "../src/common.speech/HeaderNames";
+import { PropertyCollection, PropertyId } from "../src/sdk/Exports";
+
+// Minimal IAuthentication stub so the adapter can attach an auth header without contacting any service.
+class StubAuthentication implements IAuthentication {
+    public fetch(_authFetchEventId: string): Promise<AuthInfo> {
+        return Promise.resolve(new AuthInfo(HeaderNames.Authorization, "Bearer test-token"));
+    }
+    public fetchOnExpiry(_authFetchEventId: string): Promise<AuthInfo> {
+        return Promise.resolve(new AuthInfo(HeaderNames.Authorization, "Bearer test-token"));
+    }
+}
+
+const buildAdapter = (configure: (params: PropertyCollection) => void): { adapter: SynthesisRestAdapter; requestMock: jest.Mock } => {
+    const params: PropertyCollection = new PropertyCollection();
+    configure(params);
+    const config: SynthesizerConfig = new SynthesizerConfig(null, params);
+    const adapter: SynthesisRestAdapter = new SynthesisRestAdapter(config, new StubAuthentication());
+
+    // Capture the URI handed to the REST layer and short-circuit the actual network call.
+    const requestMock: jest.Mock = jest.fn().mockResolvedValue({ ok: true, status: 200, data: "{}", json: {} });
+    jest.spyOn(RestMessageAdapter.prototype, "request").mockImplementation(requestMock as never);
+    jest.spyOn(RestMessageAdapter.prototype, "setHeaders").mockImplementation((): void => { /* no-op */ });
+
+    return { adapter, requestMock };
+};
+
+describe("SynthesisRestAdapter voices/list URI resolution", (): void => {
+
+    afterEach((): void => {
+        jest.restoreAllMocks();
+    });
+
+    test("uses the region-derived host when no endpoint is supplied (no redirect resolution)", async (): Promise<void> => {
+        const redirectSpy = jest.spyOn(ConnectionFactoryBase, "getRedirectUrlFromEndpoint");
+        const { adapter, requestMock } = buildAdapter((params: PropertyCollection): void => {
+            params.setProperty(PropertyId.SpeechServiceConnection_Region, "westus2");
+        });
+
+        await adapter.getVoicesList("conn-id");
+
+        expect(redirectSpy).not.toHaveBeenCalled();
+        const calledUri: string = requestMock.mock.calls[0][1] as string;
+        expect(calledUri).toEqual("https://westus2.tts.speech.microsoft.com/cognitiveservices/voices/list");
+    });
+
+    test("resolves a custom-domain endpoint via the synthesis redirect and retargets to voices/list", async (): Promise<void> => {
+        // The redirect handler is exposed on the synthesis route and returns the regional host plus the
+        // custom-domain parameter required for AAD token auth.
+        const redirectSpy = jest.spyOn(ConnectionFactoryBase, "getRedirectUrlFromEndpoint").mockResolvedValue(
+            "https://eastus.tts.speech.microsoft.com/cognitiveservices/websocket/v1?GenerateRedirectResponse=true&Ocp-Apim-Custom-Domain-Name=mycustom.cognitiveservices.azure.com");
+
+        const { adapter, requestMock } = buildAdapter((params: PropertyCollection): void => {
+            params.setProperty(PropertyId.SpeechServiceConnection_Endpoint, "https://mycustom.cognitiveservices.azure.com/");
+        });
+
+        await adapter.getVoicesList("conn-id");
+
+        // Redirect must be resolved on the synthesis path, keeping the http(s) scheme for this REST call.
+        expect(redirectSpy).toHaveBeenCalledTimes(1);
+        const redirectArg: string = redirectSpy.mock.calls[0][0] as string;
+        const useWebSocketProtocol: boolean = redirectSpy.mock.calls[0][1] as boolean;
+        expect(new URL(redirectArg).pathname).toEqual("/tts/cognitiveservices/websocket/v1");
+        expect(useWebSocketProtocol).toBe(false);
+
+        // Final voices URI is on the resolved regional host, carries the custom-domain param, and drops
+        // the GenerateRedirectResponse marker.
+        const calledUri: URL = new URL(requestMock.mock.calls[0][1] as string);
+        expect(calledUri.protocol).toEqual("https:");
+        expect(calledUri.host).toEqual("eastus.tts.speech.microsoft.com");
+        expect(calledUri.pathname).toEqual("/cognitiveservices/voices/list");
+        expect(calledUri.searchParams.get("Ocp-Apim-Custom-Domain-Name")).toEqual("mycustom.cognitiveservices.azure.com");
+        expect(calledUri.searchParams.has("GenerateRedirectResponse")).toBe(false);
+    });
+
+    test("falls back to the original host when no redirect applies to a custom endpoint", async (): Promise<void> => {
+        // getRedirectUrlFromEndpoint returns its input unchanged on a non-200 response.
+        jest.spyOn(ConnectionFactoryBase, "getRedirectUrlFromEndpoint").mockImplementation(
+            (endpoint: string): Promise<string> => Promise.resolve(endpoint));
+
+        const { adapter, requestMock } = buildAdapter((params: PropertyCollection): void => {
+            params.setProperty(PropertyId.SpeechServiceConnection_Endpoint, "https://eastus.tts.speech.microsoft.com/");
+        });
+
+        await adapter.getVoicesList("conn-id");
+
+        const calledUri: URL = new URL(requestMock.mock.calls[0][1] as string);
+        expect(calledUri.host).toEqual("eastus.tts.speech.microsoft.com");
+        expect(calledUri.pathname).toEqual("/cognitiveservices/voices/list");
+    });
+
+    test("preserves legacy behavior when the endpoint already carries a path", async (): Promise<void> => {
+        const redirectSpy = jest.spyOn(ConnectionFactoryBase, "getRedirectUrlFromEndpoint");
+        const { adapter, requestMock } = buildAdapter((params: PropertyCollection): void => {
+            params.setProperty(PropertyId.SpeechServiceConnection_Endpoint, "https://myhost.example.com/custom/path");
+        });
+
+        await adapter.getVoicesList("conn-id");
+
+        expect(redirectSpy).not.toHaveBeenCalled();
+        const calledUri: string = requestMock.mock.calls[0][1] as string;
+        expect(calledUri).toEqual("https://myhost.example.com/custom/path/cognitiveservices/voices/list");
+    });
+
+    test("resolves the URI only once across multiple calls", async (): Promise<void> => {
+        const redirectSpy = jest.spyOn(ConnectionFactoryBase, "getRedirectUrlFromEndpoint").mockResolvedValue(
+            "https://eastus.tts.speech.microsoft.com/cognitiveservices/websocket/v1?Ocp-Apim-Custom-Domain-Name=mycustom.cognitiveservices.azure.com");
+
+        const { adapter } = buildAdapter((params: PropertyCollection): void => {
+            params.setProperty(PropertyId.SpeechServiceConnection_Endpoint, "https://mycustom.cognitiveservices.azure.com/");
+        });
+
+        await adapter.getVoicesList("conn-id");
+        await adapter.getVoicesList("conn-id");
+
+        expect(redirectSpy).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("ConnectionFactoryBase.getRedirectUrlFromEndpoint protocol handling", (): void => {
+    const regionalHttpsUrl = "https://eastus.tts.speech.microsoft.com/cognitiveservices/websocket/v1";
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach((): void => {
+        originalFetch = globalThis.fetch;
+    });
+
+    afterEach((): void => {
+        globalThis.fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    test("converts to wss by default (WebSocket callers)", async (): Promise<void> => {
+        globalThis.fetch = jest.fn().mockResolvedValue({
+            status: 200,
+            text: (): Promise<string> => Promise.resolve(regionalHttpsUrl),
+        }) as never;
+
+        const result: string = await ConnectionFactoryBase.getRedirectUrlFromEndpoint("https://mycustom.cognitiveservices.azure.com/tts/cognitiveservices/websocket/v1");
+        expect(new URL(result).protocol).toEqual("wss:");
+    });
+
+    test("keeps https when useWebSocketProtocol is false (REST callers)", async (): Promise<void> => {
+        globalThis.fetch = jest.fn().mockResolvedValue({
+            status: 200,
+            text: (): Promise<string> => Promise.resolve(regionalHttpsUrl),
+        }) as never;
+
+        const result: string = await ConnectionFactoryBase.getRedirectUrlFromEndpoint("https://mycustom.cognitiveservices.azure.com/tts/cognitiveservices/websocket/v1", false);
+        expect(new URL(result).protocol).toEqual("https:");
+    });
+
+    test("returns the original endpoint on a non-200 response", async (): Promise<void> => {
+        globalThis.fetch = jest.fn().mockResolvedValue({ status: 404 }) as never;
+
+        const endpoint = "https://mycustom.cognitiveservices.azure.com/tts/cognitiveservices/websocket/v1";
+        const result: string = await ConnectionFactoryBase.getRedirectUrlFromEndpoint(endpoint, false);
+        expect(result).toEqual(endpoint);
+    });
+});

--- a/tests/TranslationSynthTests.ts
+++ b/tests/TranslationSynthTests.ts
@@ -14,6 +14,8 @@ import {
 import { ByteBufferAudioFile } from "./ByteBufferAudioFile";
 import { ConfigLoader } from "./ConfigLoader";
 import { Settings } from "./Settings";
+import { SpeechConfigConnectionFactory } from "./SpeechConfigConnectionFactories";
+import { SpeechConnectionType } from "./SpeechConnectionTypes";
 import { SubscriptionsRegionsKeys } from "./SubscriptionRegion";
 import {
     closeAsyncObjects,
@@ -39,6 +41,13 @@ beforeEach((): void => {
 });
 
 jest.retryTimes(Settings.RetryCount);
+
+// Entra ID (AAD) token-credential tests require an AAD-enabled Speech resource and an environment where a
+// managed identity / service principal can be resolved (e.g. the connection-test pipeline that also sets up
+// the right managed identity). They are gated through the exact same runConnectionTest helper the STT
+// connection tests use, so they are skipped on normal CI runs (where DefaultAzureCredential cannot resolve a
+// single identity) and only execute in the dedicated connection-test pipeline.
+const EntraIdTokenCredentialTest: jest.It = SpeechConfigConnectionFactory.runConnectionTest(SpeechConnectionType.CloudFromEndpointWithEntraIdTokenAuth);
 
 afterEach(async (): Promise<void> => {
     // eslint-disable-next-line no-console
@@ -230,7 +239,9 @@ test("TranslateVoiceRoundTrip", (done: jest.DoneCallback): void => {
 
 // Requires an Entra ID (AAD) enabled Speech resource and ambient Azure credentials
 // (e.g. Azure CLI login, or AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET).
-test("TranslateVoiceWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
+describe("Translation Synthesis Token Credential Connection Tests", (): void => {
+
+EntraIdTokenCredentialTest("TranslateVoiceWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
     // eslint-disable-next-line no-console
     console.info("Name: TranslateVoiceWithEntraIdTokenCredential");
     const s: sdk.SpeechTranslationConfig = BuildSpeechConfigWithTokenCredential();
@@ -297,6 +308,8 @@ test("TranslateVoiceWithEntraIdTokenCredential", (done: jest.DoneCallback): void
             }, (error: string) => done(error));
         });
 }, 10000);
+
+});
 
 test("TranslateVoiceInvalidVoice", (done: jest.DoneCallback): void => {
     // eslint-disable-next-line no-console

--- a/tests/TranslationSynthTests.ts
+++ b/tests/TranslationSynthTests.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { DefaultAzureCredential } from "@azure/identity";
 import * as sdk from "../microsoft.cognitiveservices.speech.sdk";
 import {
     ConsoleLoggingListener,
@@ -11,7 +12,9 @@ import {
 } from "../src/common/Exports";
 
 import { ByteBufferAudioFile } from "./ByteBufferAudioFile";
+import { ConfigLoader } from "./ConfigLoader";
 import { Settings } from "./Settings";
+import { SubscriptionsRegionsKeys } from "./SubscriptionRegion";
 import {
     closeAsyncObjects,
     WaitForCondition
@@ -68,6 +71,30 @@ const BuildRecognizerFromWaveFile: (speechConfig?: sdk.SpeechTranslationConfig) 
 
 const BuildSpeechConfig: () => sdk.SpeechTranslationConfig = (): sdk.SpeechTranslationConfig => {
     const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromSubscription(Settings.SpeechSubscriptionKey, Settings.SpeechRegion);
+    expect(s).not.toBeUndefined();
+    return s;
+};
+
+// Derives the translation endpoint from the configured unified speech subscription. The translation
+// recognizer connects over the universal v2 STT route, which is exactly what the unified subscription
+// endpoint points at (carrying the resource's custom-domain name so the service can validate the AAD
+// token against the correct resource), so we can use it as-is for Entra ID token authentication.
+const BuildEntraIdTokenCredentialEndpoint: () => URL = (): URL => {
+    const configLoader: ConfigLoader = ConfigLoader.instance;
+    configLoader.initialize();
+    const sub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+    const configured: string = (sub && sub.Endpoint) || Settings.SpeechEndpoint;
+    if (!configured) {
+        throw new Error("No endpoint configured for the unified speech subscription.");
+    }
+    return new URL(configured);
+};
+
+// Builds a SpeechTranslationConfig that authenticates with an Entra ID (AAD) TokenCredential
+// instead of a subscription key. Requires an Entra ID enabled Speech resource.
+const BuildSpeechConfigWithTokenCredential: () => sdk.SpeechTranslationConfig = (): sdk.SpeechTranslationConfig => {
+    const credential: DefaultAzureCredential = new DefaultAzureCredential();
+    const s: sdk.SpeechTranslationConfig = sdk.SpeechTranslationConfig.fromEndpoint(BuildEntraIdTokenCredentialEndpoint(), credential);
     expect(s).not.toBeUndefined();
     return s;
 };
@@ -193,6 +220,76 @@ test("TranslateVoiceRoundTrip", (done: jest.DoneCallback): void => {
                     expect(speech.text).toEqual("Wie ist das Wetter?");
                     done();
                 }, (error: string) => done(error));
+            }, (error: string) => done(error));
+        });
+}, 10000);
+
+// Requires an Entra ID (AAD) enabled Speech resource and ambient Azure credentials
+// (e.g. Azure CLI login, or AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET).
+test("TranslateVoiceWithEntraIdTokenCredential", (done: jest.DoneCallback): void => {
+    // eslint-disable-next-line no-console
+    console.info("Name: TranslateVoiceWithEntraIdTokenCredential");
+    const s: sdk.SpeechTranslationConfig = BuildSpeechConfigWithTokenCredential();
+    objsToClose.push(s);
+
+    s.voiceName = "de-DE-KatjaNeural";
+
+    const r: sdk.TranslationRecognizer = BuildRecognizerFromWaveFile(s);
+    objsToClose.push(r);
+
+    let synthCount: number = 0;
+    let synthFragmentCount: number = 0;
+
+    r.synthesizing = ((o: sdk.Recognizer, e: sdk.TranslationSynthesisEventArgs): void => {
+        switch (e.result.reason) {
+            case sdk.ResultReason.Canceled:
+                done(sdk.ResultReason[e.result.reason]);
+                break;
+            case sdk.ResultReason.SynthesizingAudio:
+                expect(e.result.audio).not.toBeUndefined();
+                expect(e.result.audio.byteLength).toBeGreaterThan(0);
+                synthFragmentCount++;
+                break;
+            case sdk.ResultReason.SynthesizingAudioCompleted:
+                synthCount++;
+                break;
+        }
+    });
+
+    let canceled: boolean = false;
+    let inTurn: boolean = false;
+
+    r.canceled = ((o: sdk.Recognizer, e: sdk.TranslationRecognitionCanceledEventArgs): void => {
+        try {
+            switch (e.reason) {
+                case sdk.CancellationReason.Error:
+                    done(e.errorDetails);
+                    break;
+                case sdk.CancellationReason.EndOfStream:
+                    expect(synthCount).toEqual(1);
+                    expect(synthFragmentCount).toBeGreaterThan(0);
+                    canceled = true;
+                    break;
+            }
+        } catch (error) {
+            done(error);
+        }
+    });
+
+    r.sessionStarted = ((o: sdk.Recognizer, e: sdk.SessionEventArgs): void => {
+        inTurn = true;
+    });
+
+    r.sessionStopped = ((o: sdk.Recognizer, e: sdk.SessionEventArgs): void => {
+        inTurn = false;
+    });
+
+    r.startContinuousRecognitionAsync();
+
+    WaitForCondition((): boolean => (canceled && !inTurn),
+        (): void => {
+            r.stopContinuousRecognitionAsync((): void => {
+                done();
             }, (error: string) => done(error));
         });
 }, 10000);

--- a/tests/TranslationSynthTests.ts
+++ b/tests/TranslationSynthTests.ts
@@ -75,17 +75,21 @@ const BuildSpeechConfig: () => sdk.SpeechTranslationConfig = (): sdk.SpeechTrans
     return s;
 };
 
-// Derives the translation endpoint from the configured unified speech subscription. The translation
-// recognizer connects over the universal v2 STT route, which is exactly what the unified subscription
-// endpoint points at (carrying the resource's custom-domain name so the service can validate the AAD
-// token against the correct resource), so we can use it as-is for Entra ID token authentication.
+// Derives the translation endpoint from the configured Entra ID speech subscription. The translation
+// recognizer connects over the universal v2 STT route, which is exactly what the subscription endpoint
+// points at (carrying the resource's custom-domain name so the service can validate the AAD token against
+// the correct resource), so we can use it as-is for Entra ID token authentication. On CI the
+// AADSpeechClientSecret resource is provisioned with the RBAC role the test service principal needs (the
+// same entry the STT Entra ID tests use), so we prefer it and fall back to the unified speech subscription
+// for local runs that only have the unified entry configured.
 const BuildEntraIdTokenCredentialEndpoint: () => URL = (): URL => {
     const configLoader: ConfigLoader = ConfigLoader.instance;
     configLoader.initialize();
-    const sub = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
+    const aad = configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.AAD_SPEECH_CLIENT_SECRET);
+    const sub = (aad && aad.Endpoint) ? aad : configLoader.getSubscriptionRegion(SubscriptionsRegionsKeys.UNIFIED_SPEECH_SUBSCRIPTION);
     const configured: string = (sub && sub.Endpoint) || Settings.SpeechEndpoint;
     if (!configured) {
-        throw new Error("No endpoint configured for the unified speech subscription.");
+        throw new Error("No endpoint configured for the Entra ID speech subscription.");
     }
     return new URL(configured);
 };


### PR DESCRIPTION
Fix: [getVoicesAsync()](vscode-file://vscode-app/c:/Users/xitzhang/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) failed for custom-domain endpoints (used with Entra ID/token-credential auth) because the REST adapter built the voices URL by naive string concat and skipped the custom-domain redirect resolution. Now [SynthesisRestAdapter.ts](vscode-file://vscode-app/c:/Users/xitzhang/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) resolves the redirect via the synthesis route, then retargets to /cognitiveservices/voices/list. Added an optional useWebSocketProtocol flag to [getRedirectUrlFromEndpoint](vscode-file://vscode-app/c:/Users/xitzhang/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so the REST call keeps https instead of upgrading to wss. Added unit tests plus enabled the Entra ID TTS and translation synthesis tests.

No public API change — all edits are internal [common.speech](vscode-file://vscode-app/c:/Users/xitzhang/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) types (not in the published [.d.ts](vscode-file://vscode-app/c:/Users/xitzhang/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)); the new param is optional and [SpeechSynthesizer.getVoicesAsync()](vscode-file://vscode-app/c:/Users/xitzhang/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) keeps its exact signature.