### PR TITLE
Add channel property to recognition results

### DIFF
--- a/src/common.speech/ServiceMessages/DetailedSpeechPhrase.ts
+++ b/src/common.speech/ServiceMessages/DetailedSpeechPhrase.ts
@@ -12,6 +12,7 @@ export interface IDetailedSpeechPhrase {
     PrimaryLanguage?: IPrimaryLanguage;
     DisplayText?: string;
     SpeakerId?: string;
+    Channel?: number;
     [key: string]: any;
 }
 
@@ -99,6 +100,9 @@ export class DetailedSpeechPhrase implements IDetailedSpeechPhrase {
     }
     public get SpeakerId(): string {
         return this.privDetailedSpeechPhrase.SpeakerId;
+    }
+    public get Channel(): number {
+        return this.privDetailedSpeechPhrase.Channel === undefined ? 0 : this.privDetailedSpeechPhrase.Channel;
     }
     private mapRecognitionStatus(status: any): RecognitionStatus {
         if (typeof status === "string") {

--- a/src/common.speech/ServiceMessages/SimpleSpeechPhrase.ts
+++ b/src/common.speech/ServiceMessages/SimpleSpeechPhrase.ts
@@ -11,6 +11,7 @@ export interface ISimpleSpeechPhrase {
     Duration?: number;
     PrimaryLanguage?: IPrimaryLanguage;
     SpeakerId?: string;
+    Channel?: number;
     [key: string]: any;
 }
 
@@ -71,6 +72,10 @@ export class SimpleSpeechPhrase implements ISimpleSpeechPhrase {
 
     public get SpeakerId(): string {
         return this.privSimpleSpeechPhrase.SpeakerId;
+    }
+
+    public get Channel(): number {
+        return this.privSimpleSpeechPhrase.Channel === undefined ? 0 : this.privSimpleSpeechPhrase.Channel;
     }
 
     private mapRecognitionStatus(status: any): RecognitionStatus {

--- a/src/common.speech/SpeechServiceRecognizer.ts
+++ b/src/common.speech/SpeechServiceRecognizer.ts
@@ -128,7 +128,8 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                             undefined, // Speaker Id
                             undefined,
                             simple.asJson(),
-                            resultProps);
+                            resultProps,
+                            simple.Channel);
                     } else {
                         const detailed: DetailedSpeechPhrase = DetailedSpeechPhrase.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
                         resultProps.setProperty(PropertyId.SpeechServiceResponse_JsonResult, detailed.asJson());
@@ -144,7 +145,8 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                             undefined, // Speaker Id
                             undefined,
                             detailed.asJson(),
-                            resultProps);
+                            resultProps,
+                            detailed.Channel);
                     }
 
                     const event: SpeechRecognitionEventArgs = new SpeechRecognitionEventArgs(result, result.offset, this.privRequestSession.sessionId);

--- a/src/sdk/RecognitionResult.ts
+++ b/src/sdk/RecognitionResult.ts
@@ -18,6 +18,7 @@ export class RecognitionResult {
     private privErrorDetails: string;
     private privJson: string;
     private privProperties: PropertyCollection;
+    private privChannel: number;
 
     /**
      * Creates and initializes an instance of this class.
@@ -32,9 +33,10 @@ export class RecognitionResult {
      * @param {string} errorDetails - Error details, if provided.
      * @param {string} json - Additional Json, if provided.
      * @param {PropertyCollection} properties - Additional properties, if provided.
+     * @param {number} channel - The audio channel the result was recognized on. Defaults to 0 in non-multichannel scenarios.
      */
     public constructor(resultId?: string, reason?: ResultReason, text?: string, duration?: number,
-                offset?: number, language?: string, languageDetectionConfidence?: string, errorDetails?: string, json?: string, properties?: PropertyCollection) {
+                offset?: number, language?: string, languageDetectionConfidence?: string, errorDetails?: string, json?: string, properties?: PropertyCollection, channel?: number) {
         this.privResultId = resultId;
         this.privReason = reason;
         this.privText = text;
@@ -45,6 +47,7 @@ export class RecognitionResult {
         this.privErrorDetails = errorDetails;
         this.privJson = json;
         this.privProperties = properties;
+        this.privChannel = channel === undefined ? 0 : channel;
     }
 
     /**
@@ -155,5 +158,17 @@ export class RecognitionResult {
      */
     public get properties(): PropertyCollection {
         return this.privProperties;
+    }
+
+    /**
+     * The audio channel the result was recognized on. In non-multichannel
+     * scenarios this defaults to 0.
+     * @member RecognitionResult.prototype.channel
+     * @function
+     * @public
+     * @returns {number} The zero-based audio channel index of the result.
+     */
+    public get channel(): number {
+        return this.privChannel;
     }
 }

--- a/src/sdk/SpeechRecognitionResult.ts
+++ b/src/sdk/SpeechRecognitionResult.ts
@@ -24,12 +24,13 @@ export class SpeechRecognitionResult extends RecognitionResult {
      * @param {string} errorDetails - Error details, if provided.
      * @param {string} json - Additional Json, if provided.
      * @param {PropertyCollection} properties - Additional properties, if provided.
+     * @param {number} channel - The audio channel the result was recognized on. Defaults to 0 in non-multichannel scenarios.
      */
     public constructor(resultId?: string, reason?: ResultReason, text?: string,
                        duration?: number, offset?: number, language?: string,
                        languageDetectionConfidence?: string, speakerId?: string, errorDetails?: string,
-                       json?: string, properties?: PropertyCollection) {
-        super(resultId, reason, text, duration, offset, language, languageDetectionConfidence, errorDetails, json, properties);
+                       json?: string, properties?: PropertyCollection, channel?: number) {
+        super(resultId, reason, text, duration, offset, language, languageDetectionConfidence, errorDetails, json, properties, channel);
         this.privSpeakerId = speakerId;
     }
 

--- a/tests/SpeechRecoReconnectTests.ts
+++ b/tests/SpeechRecoReconnectTests.ts
@@ -306,7 +306,7 @@ test("Reliable reconnect - multichannel audio receives continuation token", (don
     let serviceReturnedServiceTag: boolean = false;
     let lastServiceToken: string = "";
     let lastServiceTag: string = "";
-    // Per-channel results the service returns ("Channel":0 / "Channel":1). Both channels of
+    // Per-channel results the service returns (result.channel 0 / 1). Both channels of
     // the multichannel audio must be seen for the test to pass.
     const channelsSeen: Set<number> = new Set<number>();
     let disconnects: number = 0;
@@ -382,16 +382,11 @@ test("Reliable reconnect - multichannel audio receives continuation token", (don
             bucket.push(e.result.text);
         }
         // Record which channel this result came from so we can assert both channels of the
-        // multichannel audio produced output.
-        try {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const phrase: any = JSON.parse(e.result.json);
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            if (phrase && typeof phrase.Channel === "number") {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                channelsSeen.add(phrase.Channel as number);
-            }
-        } catch { /* ignore non-JSON results */ }
+        // multichannel audio produced output. Read the strongly-typed SpeechRecognitionResult.channel
+        // property rather than hand-parsing the raw phrase JSON.
+        if (typeof e.result.channel === "number") {
+            channelsSeen.add(e.result.channel);
+        }
     };
 
     r.canceled = (o: sdk.Recognizer, e: sdk.SpeechRecognitionCanceledEventArgs): void => {
@@ -439,9 +434,10 @@ test("Reliable reconnect - multichannel audio receives continuation token", (don
                     expect(lastServiceToken).not.toEqual("");
                     expect(lastServiceTag).not.toEqual("");
 
-                    // Both channels of the multichannel audio must have produced results.
-                    expect(channelsSeen.has(0)).toEqual(true);
-                    expect(channelsSeen.has(1)).toEqual(true);
+                    // Both channels of the multichannel audio must have produced results:
+                    // the exact set of channel values seen must be {0, 1} - no more, no fewer,
+                    // and specifically those two values.
+                    expect(Array.from(channelsSeen).sort()).toEqual([0, 1]);
 
                     // Prove the SDK ingested the continuation info through its PRODUCTION
                     // path (ReconnectContinuationState.updateFromHeaders), not just the
@@ -572,20 +568,9 @@ test("Reliable reconnect - resends rebased absolute continuation offset and trim
     r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
         if (e.result.text) {
             (disconnects > 0 ? resultsAfterReconnect : resultsBeforeReconnect).push(e.result.text);
-            // The channel lives only in the raw service JSON; default to 0 if absent.
-            let channel: number = 0;
-            try {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const resultJson: any = JSON.parse(
-                    e.result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_JsonResult, "{}"));
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                if (typeof resultJson.Channel === "number") {
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                    channel = resultJson.Channel as number;
-                }
-            } catch {
-                // Leave channel at 0 if the JSON is missing or unparseable.
-            }
+            // Read the strongly-typed SpeechRecognitionResult.channel property (defaults to 0
+            // in non-multichannel scenarios) rather than hand-parsing the raw service JSON.
+            const channel: number = typeof e.result.channel === "number" ? e.result.channel : 0;
             recognizedSpans.push({
                 afterReconnect: disconnects > 0,
                 channel,

--- a/tests/SpeechRecognizerTests.ts
+++ b/tests/SpeechRecognizerTests.ts
@@ -460,6 +460,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean): void
                 expect(result).not.toBeUndefined();
                 expect(result.errorDetails).toBeUndefined();
                 expect(result.reason).toEqual(sdk.ResultReason.RecognizedSpeech);
+                expect(result.channel).toEqual(0);
 
                 // Check that latency property is set on final result
                 const latency = result.properties.getProperty(sdk.PropertyId.SpeechServiceResponse_RecognitionLatencyMs);
@@ -1261,7 +1262,7 @@ describe.each([true])("Service based tests", (forceNodeWebSocket: boolean): void
         s.speechRecognitionLanguage = "en-US";
         s.outputFormat = sdk.OutputFormat.Detailed;
         s.setProperty(sdk.PropertyId.Recognizer_StopTimeoutMs, "100");
-        s.setProperty("SPEECH-TransmitLengthBeforThrottleMs", "60000"); // large value to avoid throttling 
+        s.setProperty("SPEECH-TransmitLengthBeforThrottleMs", "60000"); // large value to avoid throttling
 
         const config: sdk.AudioConfig = WaveFileAudioInput.getAudioConfigFromFile(Settings.InputDir + "aboutSpeechSdk.wav");
 


### PR DESCRIPTION
Expose the audio channel index on RecognitionResult/SpeechRecognitionResult (defaults to 0 in non-multichannel scenarios), plumbed from the SimpleSpeechPhrase/DetailedSpeechPhrase Channel field. Update tests to assert result.channel: single-channel yields 0, multichannel yields exactly {0,1}.