### PR TITLE
Fix offset calculation in reliable reconnect; improve reliable reconnect test robustness.

### DIFF
--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -870,7 +870,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                         break;
 
                     case "speech.startdetected":
-                        const speechStartDetected: SpeechDetected = SpeechDetected.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
+                        const speechStartDetected: SpeechDetected = SpeechDetected.fromJSON(connectionMessage.textBody, this.serviceOffsetBase);
                         const speechStartEventArgs = new RecognitionEventArgs(speechStartDetected.Offset, this.privRequestSession.sessionId);
                         if (!!this.privRecognizer.speechStartDetected) {
                             this.privRecognizer.speechStartDetected(this.privRecognizer, speechStartEventArgs);
@@ -885,8 +885,8 @@ export abstract class ServiceRecognizerBase implements IDisposable {
                             // If the request was empty, the JSON returned is empty.
                             json = "{ Offset: 0 }";
                         }
-                        const speechStopDetected: SpeechDetected = SpeechDetected.fromJSON(json, this.privRequestSession.currentTurnAudioOffset);
-                        const speechStopEventArgs = new RecognitionEventArgs(speechStopDetected.Offset + this.privRequestSession.currentTurnAudioOffset, this.privRequestSession.sessionId);
+                        const speechStopDetected: SpeechDetected = SpeechDetected.fromJSON(json, this.serviceOffsetBase);
+                        const speechStopEventArgs = new RecognitionEventArgs(speechStopDetected.Offset, this.privRequestSession.sessionId);
                         if (!!this.privRecognizer.speechEndDetected) {
                             this.privRecognizer.speechEndDetected(this.privRecognizer, speechStopEventArgs);
                         }
@@ -938,6 +938,10 @@ export abstract class ServiceRecognizerBase implements IDisposable {
     // Undefined disables the X-StreamId header, preserving legacy behavior.
     private get audioStreamId(): string | undefined {
         return this.privEnableReliableReconnect ? this.privContinuationState.defaultStreamId : undefined;
+    }
+
+    protected get serviceOffsetBase(): number {
+        return this.privEnableReliableReconnect ? 0 : this.privRequestSession.currentTurnAudioOffset;
     }
 
     // Injects the reliable-reconnect sections into speech.context: the audio.streams marker

--- a/src/common.speech/SpeechServiceRecognizer.ts
+++ b/src/common.speech/SpeechServiceRecognizer.ts
@@ -56,7 +56,7 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
         switch (connectionMessage.path.toLowerCase()) {
             case "speech.hypothesis":
             case "speech.fragment":
-                const hypothesis: SpeechHypothesis = SpeechHypothesis.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
+                const hypothesis: SpeechHypothesis = SpeechHypothesis.fromJSON(connectionMessage.textBody, this.serviceOffsetBase);
                 resultProps.setProperty(PropertyId.SpeechServiceResponse_JsonResult, hypothesis.asJson());
 
                 const hypothesisLatencyMs = this.privRequestSession.onHypothesis(hypothesis.Offset);
@@ -91,7 +91,7 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                 processed = true;
                 break;
             case "speech.phrase":
-                const simple: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
+                const simple: SimpleSpeechPhrase = SimpleSpeechPhrase.fromJSON(connectionMessage.textBody, this.serviceOffsetBase);
                 resultProps.setProperty(PropertyId.SpeechServiceResponse_JsonResult, simple.asJson());
 
                 const resultReason: ResultReason = EnumTranslation.implTranslateRecognitionResult(simple.RecognitionStatus, this.privExpectContentAssessmentResponse);
@@ -131,7 +131,7 @@ export class SpeechServiceRecognizer extends ServiceRecognizerBase {
                             resultProps,
                             simple.Channel);
                     } else {
-                        const detailed: DetailedSpeechPhrase = DetailedSpeechPhrase.fromJSON(connectionMessage.textBody, this.privRequestSession.currentTurnAudioOffset);
+                        const detailed: DetailedSpeechPhrase = DetailedSpeechPhrase.fromJSON(connectionMessage.textBody, this.serviceOffsetBase);
                         resultProps.setProperty(PropertyId.SpeechServiceResponse_JsonResult, detailed.asJson());
 
                         result = new SpeechRecognitionResult(

--- a/tests/ReliableReconnectTests.ts
+++ b/tests/ReliableReconnectTests.ts
@@ -214,14 +214,19 @@ interface TestableRecognizer {
     privSpeechContext: SpeechContext;
     privContinuationState: ReconnectContinuationState;
     privEnableReliableReconnect: boolean;
+    privRequestSession: {
+        currentTurnAudioOffset: number;
+    };
+    readonly serviceOffsetBase: number;
     applyReconnectContinuation(): void;
 }
 
-function createTestRecognizer(): TestableRecognizer {
+function createTestRecognizer(enableReliableReconnect: boolean = true, currentTurnAudioOffset: number = 0): TestableRecognizer {
     const instance = Object.create(ServiceRecognizerBase.prototype) as TestableRecognizer;
     instance.privSpeechContext = new SpeechContext(new DynamicGrammarBuilder());
     instance.privContinuationState = new ReconnectContinuationState();
-    instance.privEnableReliableReconnect = true;
+    instance.privEnableReliableReconnect = enableReliableReconnect;
+    instance.privRequestSession = { currentTurnAudioOffset };
     return instance;
 }
 
@@ -230,6 +235,18 @@ function getContext(rec: TestableRecognizer): SpeechServiceContext {
 }
 
 describe("ServiceRecognizerBase reliable reconnect wiring", (): void => {
+
+    it("uses session-absolute service offsets when reliable reconnect is enabled", (): void => {
+        const rec = createTestRecognizer(true, 5000);
+
+        expect(rec.serviceOffsetBase).toEqual(0);
+    });
+
+    it("preserves turn-relative service offsets when reliable reconnect is disabled", (): void => {
+        const rec = createTestRecognizer(false, 5000);
+
+        expect(rec.serviceOffsetBase).toEqual(5000);
+    });
 
     it("injects audio.streams but no continuation on a fresh turn", (): void => {
         const rec = createTestRecognizer();

--- a/tests/SpeechRecoReconnectTests.ts
+++ b/tests/SpeechRecoReconnectTests.ts
@@ -311,11 +311,15 @@ test("Reliable reconnect - multichannel audio receives continuation token", (don
     const channelsSeen: Set<number> = new Set<number>();
     let disconnects: number = 0;
     let connections: number = 0;
-    // Final recognition results split by the forced mid-stream drop: everything the service
-    // returns BEFORE the reconnect vs everything it returns AFTER it. Both buckets must contain
-    // the expected text to prove recognition resumed across the reconnect.
-    const resultsBeforeReconnect: string[] = [];
-    const resultsAfterReconnect: string[] = [];
+    type RecognitionPhase = "beforeDisconnect" | "reconnecting" | "afterReconnect";
+    interface RecognitionSpan {
+        channel: number;
+        offset: number;
+        duration: number;
+        phase: RecognitionPhase;
+    }
+    const recognitionSpans: RecognitionSpan[] = [];
+    const requiredChannels: number[] = [0, 1];
 
     const connection: sdk.Connection = sdk.Connection.fromRecognizer(r);
 
@@ -376,16 +380,18 @@ test("Reliable reconnect - multichannel audio receives continuation token", (don
     };
 
     r.recognized = (o: sdk.Recognizer, e: sdk.SpeechRecognitionEventArgs): void => {
-        // Bucket the final text by whether the drop/reconnect has happened yet.
-        if (e.result.text) {
-            const bucket: string[] = disconnects > 0 ? resultsAfterReconnect : resultsBeforeReconnect;
-            bucket.push(e.result.text);
-        }
-        // Record which channel this result came from so we can assert both channels of the
-        // multichannel audio produced output. Read the strongly-typed SpeechRecognitionResult.channel
-        // property rather than hand-parsing the raw phrase JSON.
-        if (typeof e.result.channel === "number") {
-            channelsSeen.add(e.result.channel);
+        const channel: number = e.result.channel;
+        if (e.result.text.trim().length > 0 && (channel === 0 || channel === 1)) {
+            const phase: RecognitionPhase = disconnects === 0
+                ? "beforeDisconnect"
+                : connections >= 2 ? "afterReconnect" : "reconnecting";
+            recognitionSpans.push({
+                channel,
+                offset: e.result.offset,
+                duration: e.result.duration,
+                phase,
+            });
+            channelsSeen.add(channel);
         }
     };
 
@@ -398,9 +404,11 @@ test("Reliable reconnect - multichannel audio receives continuation token", (don
     };
 
     r.startContinuousRecognitionAsync((): void => {
-        // Stop once we have results on BOTH sides of the forced reconnect.
-        WaitForCondition((): boolean =>
-            (resultsBeforeReconnect.length > 0 && disconnects > 0 && resultsAfterReconnect.length > 0),
+        const hasSpan = (channel: number, phase: RecognitionPhase): boolean =>
+            recognitionSpans.some((span: RecognitionSpan): boolean =>
+                span.channel === channel && span.phase === phase);
+        WaitForCondition((): boolean => requiredChannels.every((channel: number): boolean =>
+            hasSpan(channel, "beforeDisconnect") && hasSpan(channel, "afterReconnect")),
         (): void => {
             r.stopContinuousRecognitionAsync((): void => {
                 try {
@@ -411,18 +419,35 @@ test("Reliable reconnect - multichannel audio receives continuation token", (don
                     expect(disconnects).toBeGreaterThanOrEqual(1);
                     expect(connections).toBeGreaterThanOrEqual(2);
 
-                    // Recognition results - with the expected text - must exist both BEFORE the
-                    // drop and AFTER the reconnect, proving recognition resumed seamlessly.
-                    expect(resultsBeforeReconnect.length).toBeGreaterThan(0);
-                    expect(resultsAfterReconnect.length).toBeGreaterThan(0);
+                    const reconnectingSpans: RecognitionSpan[] = recognitionSpans.filter(
+                        (span: RecognitionSpan): boolean => span.phase === "reconnecting");
+                    // eslint-disable-next-line no-console
+                    console.info(`Finalized spans delivered while reconnecting: ${JSON.stringify(reconnectingSpans)}`);
 
-                    // The actual recognized TEXT must be correct on both sides of the reconnect:
-                    // channel 1's "What's the weather like?" is recognized early (before the drop),
-                    // and channel 0's long Batman passage finalizes after the reconnect.
-                    expect(resultsBeforeReconnect.some((t: string): boolean =>
-                        t.includes("What's the weather like"))).toEqual(true);
-                    expect(resultsAfterReconnect.some((t: string): boolean =>
-                        t.includes("Batman"))).toEqual(true);
+                    const calculateGap = (channel: number): number => {
+                        const beforeSpans: RecognitionSpan[] = recognitionSpans.filter(
+                            (span: RecognitionSpan): boolean =>
+                                span.channel === channel && span.phase === "beforeDisconnect");
+                        const afterSpans: RecognitionSpan[] = recognitionSpans.filter(
+                            (span: RecognitionSpan): boolean =>
+                                span.channel === channel && span.phase === "afterReconnect");
+                        expect(beforeSpans.length).toBeGreaterThan(0);
+                        expect(afterSpans.length).toBeGreaterThan(0);
+
+                        const preEnd: number = Math.max(...beforeSpans.map(
+                            (span: RecognitionSpan): number => span.offset + span.duration));
+                        const postStart: number = Math.min(...afterSpans.map(
+                            (span: RecognitionSpan): number => span.offset));
+                        const gap: number = postStart - preEnd;
+                        // eslint-disable-next-line no-console
+                        console.info(`Channel ${channel} reconnect boundary: ${JSON.stringify({ beforeSpans, afterSpans, preEnd, postStart })}`);
+                        // eslint-disable-next-line no-console
+                        console.info(`Channel ${channel} reconnect gap: ${gap / 10_000_000} seconds`);
+                        expect(gap).toBeGreaterThanOrEqual(0);
+                        return gap;
+                    };
+                    expect(calculateGap(0)).toBeLessThan(20_000_000);
+                    expect(calculateGap(1)).toBeLessThan(60_000_000);
 
                     // All continuation info must have been received from the service: the
                     // X-Continuation-Token header, the per-stream


### PR DESCRIPTION
## CONTEXT

Two issues are observed in the current code base:

1. reliable reconnect test robustness.
2. audio offset calculation for reliable reconnect 

### Reliable reconnect test robustness.

The test "Reliable reconnect - multichannel audio receives continuation token" in `SpeechRecoReconnectTests.ts` is not guaranteed to pass because of the following uncertainties:

- Audio buffer submission rate is not regulated, and there is no guarantee how many seconds of audio will be submitted to service before the disconnection.
- Speech recognition service itself has some uncertainty in latency.

### Offset calculation

When reliable reconnect is enabled, service returns the audio offset that is session-based (offset = 0 for the first byte in the current session), while the SDK still treats the service-returned offset as turn-based (offset=0 for the first byte in the current "turn"), resulting in SDK double adjusting the offset value. 

## PROBLEM

- How to eliminate the uncertainty in the test outcome while still verifying that the reconnection occurs as expected?
- How to make SDK correctly calculate the offset when reliable reconnect is enabled?

## SOLUTION

Modify the test to verify the gap of the audio offset in the recognition results before and after disconnection, making sure the gap is reasonably small.

Modify the offset calculation in SDK so that when reliable connect is enabled, the offset is not adjusted by `currentTurnAudioOffset`
