### PR TITLE
Update https-proxy-agent dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,8 @@
       "dependencies": {
         "@azure/core-auth": "^1.9.0",
         "@types/webrtc": "^0.0.37",
-        "agent-base": "^6.0.1",
         "bent": "^7.3.12",
-        "https-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^7.0.6",
         "uuid": "^11.1.1",
         "ws": "^8.21.0"
       },
@@ -147,19 +146,6 @@
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
       },
       "engines": {
         "node": ">= 14"
@@ -2440,6 +2426,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -5208,21 +5195,25 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "4.0.0",
+      "version": "7.0.6",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "5",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent/node_modules/agent-base": {
-      "version": "5.1.1",
+      "version": "7.1.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "license": "MIT",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ws": false,
     "fs": false,
     "agent-base": false,
+    "http": false,
     "tls": false,
     "net": false
   },
@@ -108,9 +109,8 @@
   "dependencies": {
     "@azure/core-auth": "^1.9.0",
     "@types/webrtc": "^0.0.37",
-    "agent-base": "^6.0.1",
     "bent": "^7.3.12",
-    "https-proxy-agent": "^4.0.0",
+    "https-proxy-agent": "^7.0.6",
     "uuid": "^11.1.1",
     "ws": "^8.21.0"
   },

--- a/src/common.browser/WebsocketMessageAdapter.ts
+++ b/src/common.browser/WebsocketMessageAdapter.ts
@@ -6,8 +6,7 @@
 import * as http from "http";
 import * as net from "net";
 import * as tls from "tls";
-import Agent from "agent-base";
-import HttpsProxyAgent from "https-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
 
 import ws from "ws";
 import { HeaderNames } from "../common.speech/HeaderNames.js";
@@ -40,6 +39,25 @@ interface ISendItem {
     RawWebsocketMessage: RawWebsocketMessage;
     sendStatusDeferral: Deferred<void>;
 }
+
+type WebsocketAgentConnectParameters = Parameters<HttpsProxyAgent<string>["connect"]>;
+type WebsocketAgentConnectOptions = WebsocketAgentConnectParameters[1] & tls.ConnectionOptions & net.TcpNetConnectOpts & {
+    requestOCSP?: boolean;
+    secureEndpoint?: boolean;
+};
+type DirectWebsocketAgent = http.Agent & {
+    createConnection: (options: WebsocketAgentConnectParameters[1]) => net.Socket;
+};
+
+type WebsocketAgent = ws.ClientOptions["agent"] & {
+    protocol?: string;
+};
+
+const addOcspOptions = (options: WebsocketAgentConnectParameters[1]): WebsocketAgentConnectOptions => ({
+    ...options,
+    requestOCSP: true,
+    servername: options.host,
+} as WebsocketAgentConnectOptions);
 
 export class WebsocketMessageAdapter {
     private privConnectionState: ConnectionState;
@@ -136,10 +154,9 @@ export class WebsocketMessageAdapter {
                 // The ocsp library will handle validation for us and fail the connection if needed.
                 this.privCertificateValidatedDeferral.resolve();
 
-                options.agent = this.getAgent();
-
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                (options.agent as any).protocol = protocol;
+                const agent: WebsocketAgent = this.getAgent(protocol);
+                agent.protocol = protocol;
+                options.agent = agent;
                 this.privWebsocketClient = new ws(this.privUri, options);
                 this.privWebsocketClient.on("redirect", (redirectUrl: string): void => {
                     const event: ConnectionRedirectEvent = new ConnectionRedirectEvent(this.privConnectionId, redirectUrl, this.privUri, `Getting redirect URL from endpoint ${this.privUri} with redirect URL '${redirectUrl}'`);
@@ -336,73 +353,45 @@ export class WebsocketMessageAdapter {
         Events.instance.onEvent(event);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    private getAgent(): http.Agent {
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        const agent: { proxyInfo: ProxyInfo } = new Agent.Agent(this.createConnection) as unknown as { proxyInfo: ProxyInfo };
-
+    private getAgent(protocol: string): WebsocketAgent {
         if (this.proxyInfo !== undefined &&
             this.proxyInfo.HostName !== undefined &&
             this.proxyInfo.Port > 0) {
-            agent.proxyInfo = this.proxyInfo;
+            return WebsocketMessageAdapter.GetProxyAgent(this.proxyInfo);
         }
 
-        return agent as unknown as http.Agent;
-    }
-
-    private static GetProxyAgent(proxyInfo: ProxyInfo): HttpsProxyAgent {
-        const httpProxyOptions: HttpsProxyAgent.HttpsProxyAgentOptions = {
-            host: proxyInfo.HostName,
-            port: proxyInfo.Port,
-        };
-
-        if (!!proxyInfo.UserName) {
-            httpProxyOptions.headers = {
-                "Proxy-Authentication": "Basic " + Buffer.from(`${proxyInfo.UserName}:${(proxyInfo.Password === undefined) ? "" : proxyInfo.Password}`).toString("base64"),
-            };
-        } else {
-            httpProxyOptions.headers = {};
-        }
-
-        httpProxyOptions.headers.requestOCSP = "true";
-
-        const httpProxyAgent: HttpsProxyAgent = new HttpsProxyAgent(httpProxyOptions);
-        return httpProxyAgent;
-    }
-
-    private createConnection(request: Agent.ClientRequest, options: Agent.RequestOptions): Promise<net.Socket> {
-        let socketPromise: Promise<net.Socket>;
-
-        options = {
-            ...options,
-            ...{
-                requestOCSP: true,
-                servername: options.host
-            }
-        };
-
-        if (!!this.proxyInfo) {
-            const httpProxyAgent: HttpsProxyAgent = WebsocketMessageAdapter.GetProxyAgent(this.proxyInfo);
-            const baseAgent: Agent.Agent = httpProxyAgent as unknown as Agent.Agent;
-
-            socketPromise = new Promise<net.Socket>((resolve: (value: net.Socket) => void, reject: (error: string | Error) => void): void => {
-                baseAgent.callback(request, options, (error: Error, socket: net.Socket): void => {
-                    if (!!error) {
-                        reject(error);
-                    } else {
-                        resolve(socket);
-                    }
-                });
+        const agent: DirectWebsocketAgent = new http.Agent() as DirectWebsocketAgent;
+        agent.createConnection = (options: WebsocketAgentConnectParameters[1]): net.Socket => {
+            const secureEndpoint = (options as WebsocketAgentConnectOptions).secureEndpoint ?? protocol.toLocaleLowerCase() === "https:";
+            const socketOptions: WebsocketAgentConnectOptions = addOcspOptions({
+                ...options,
+                secureEndpoint,
             });
-        } else {
-            if (!!options.secureEndpoint) {
-                socketPromise = Promise.resolve(tls.connect(options));
-            } else {
-                socketPromise = Promise.resolve(net.connect(options));
-            }
+            return socketOptions.secureEndpoint ? tls.connect(socketOptions) : net.connect(socketOptions);
+        };
+
+        return agent;
+    }
+
+    private static GetProxyAgent(proxyInfo: ProxyInfo): WebsocketAgent {
+        const proxyHost: string = proxyInfo.HostName.includes(":") && !proxyInfo.HostName.startsWith("[")
+            ? `[${proxyInfo.HostName}]`
+            : proxyInfo.HostName;
+        const proxyUrl: URL = new URL(`http://${proxyHost}:${proxyInfo.Port}`);
+        if (!!proxyInfo.UserName) {
+            const proxyPassword: string = proxyInfo.Password === undefined ? "" : proxyInfo.Password;
+            proxyUrl.username = encodeURIComponent(proxyInfo.UserName);
+            proxyUrl.password = encodeURIComponent(proxyPassword);
         }
 
-        return socketPromise;
+        // https-proxy-agent handles Proxy-Authorization natively from URL credentials.
+        // OCSP stapling is configured via addOcspOptions on the socket options below.
+        const proxyAgent: HttpsProxyAgent<string> = new HttpsProxyAgent(proxyUrl.toString());
+        const connect = proxyAgent.connect.bind(proxyAgent) as (request: WebsocketAgentConnectParameters[0], options: WebsocketAgentConnectOptions) => Promise<net.Socket>;
+        proxyAgent.connect = (request: WebsocketAgentConnectParameters[0], options: WebsocketAgentConnectParameters[1]): Promise<net.Socket> =>
+            connect(request, addOcspOptions(options));
+
+        return proxyAgent as unknown as WebsocketAgent;
     }
 
     private get isWebsocketOpen(): boolean {

--- a/tests/SpeechSynthesisTests.ts
+++ b/tests/SpeechSynthesisTests.ts
@@ -124,16 +124,41 @@ const CheckSynthesisResult: (result: sdk.SpeechSynthesisResult, reason: sdk.Resu
         }
     };
 
-const CheckBinaryEqual: (arr1: ArrayBuffer, arr2: ArrayBuffer) => void =
-    (arr1: ArrayBuffer, arr2: ArrayBuffer): void => {
-        expect(arr1).not.toBeUndefined();
-        expect(arr2).not.toBeUndefined();
-        expect(arr1.byteLength).toEqual(arr2.byteLength);
-        const view1: Uint8Array = new Uint8Array(arr1);
-        const view2: Uint8Array = new Uint8Array(arr2);
-        for (let i: number = 0; i < arr1.byteLength; i++) {
-            expect(view1[i]).toEqual(view2[i]);
+const CheckRiffPcmComplete: (result: sdk.SpeechSynthesisResult) => number =
+    (result: sdk.SpeechSynthesisResult): number => {
+        if (!result.audioData || result.audioData.byteLength < 44) {
+            throw new Error("Expected a RIFF PCM buffer with a complete 44-byte header.");
         }
+
+        const view: DataView = new DataView(result.audioData);
+        expect(String.fromCharCode(...new Uint8Array(result.audioData, 0, 4))).toEqual("RIFF");
+        expect(String.fromCharCode(...new Uint8Array(result.audioData, 8, 4))).toEqual("WAVE");
+        expect(String.fromCharCode(...new Uint8Array(result.audioData, 12, 4))).toEqual("fmt ");
+        expect(view.getUint16(20, true)).toEqual(1);
+        expect(String.fromCharCode(...new Uint8Array(result.audioData, 36, 4))).toEqual("data");
+
+        const byteRate: number = view.getUint32(28, true);
+        const dataLength: number = view.getUint32(40, true);
+        if (byteRate === 0 || dataLength === 0) {
+            throw new Error("Expected RIFF PCM audio with a positive byte rate and data length.");
+        }
+
+        expect(result.audioData.byteLength).toEqual(dataLength + 44);
+        return dataLength * 1e7 / byteRate;
+    };
+
+const CheckRiffPcmFormatsEqual: (arr1: ArrayBuffer, arr2: ArrayBuffer) => void =
+    (arr1: ArrayBuffer, arr2: ArrayBuffer): void => {
+        const format1: Uint8Array = new Uint8Array(arr1, 8, 28);
+        const format2: Uint8Array = new Uint8Array(arr2, 8, 28);
+        expect(Array.from(format1)).toEqual(Array.from(format2));
+    };
+
+const CheckSynthesisDurationsSimilar: (duration1: number, duration2: number) => void =
+    (duration1: number, duration2: number): void => {
+        const longerDuration: number = Math.max(duration1, duration2);
+        expect(longerDuration).toBeGreaterThan(0);
+        expect(Math.abs(duration1 - duration2) / longerDuration).toBeLessThan(0.1);
     };
 
 const ReadPullAudioOutputStream: (stream: sdk.PullAudioOutputStream, length?: number, done?: jest.DoneCallback) => void =
@@ -1124,6 +1149,7 @@ describe("Service based tests", (): void => {
         BuildSpeechConfig().then((speechConfig: sdk.SpeechConfig): void => {
             objsToClose.push(speechConfig);
             speechConfig.speechSynthesisVoiceName = "en-US-AvaNeural";
+            speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
 
             const s: sdk.SpeechSynthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
             expect(s).not.toBeUndefined();
@@ -1146,7 +1172,10 @@ describe("Service based tests", (): void => {
                 // eslint-disable-next-line no-console
                 console.info("speaking ssml finished.");
                 CheckSynthesisResult(result, sdk.ResultReason.SynthesizingAudioCompleted);
-                CheckBinaryEqual(r.audioData, result.audioData);
+                const textDuration: number = CheckRiffPcmComplete(r);
+                const ssmlDuration: number = CheckRiffPcmComplete(result);
+                CheckRiffPcmFormatsEqual(r.audioData, result.audioData);
+                CheckSynthesisDurationsSimilar(textDuration, ssmlDuration);
                 done();
             }, (e: string): void => {
                 done(e);

--- a/tests/WebsocketMessageAdapterProxySelectionTests.ts
+++ b/tests/WebsocketMessageAdapterProxySelectionTests.ts
@@ -6,7 +6,20 @@ jest.mock("ws", () => ({
     default: jest.fn(),
 }));
 
+jest.mock("net", () => ({
+    ...jest.requireActual("net"),
+    connect: jest.fn(),
+}));
+
+jest.mock("tls", () => ({
+    ...jest.requireActual("tls"),
+    connect: jest.fn(),
+}));
+
 import ws from "ws";
+import * as net from "net";
+import * as tls from "tls";
+import { HttpsProxyAgent } from "https-proxy-agent";
 
 import { WebsocketMessageAdapter } from "../src/common.browser/WebsocketMessageAdapter";
 
@@ -33,14 +46,21 @@ const formatter: any = {
 describe("WebsocketMessageAdapter transport selection", (): void => {
     const wsMock = ws as unknown as jest.Mock;
     const originalWebSocket = (globalThis as any).WebSocket;
+    const originalWindow = (globalThis as any).window;
 
     afterEach((): void => {
+        jest.clearAllMocks();
         WebsocketMessageAdapter.forceNpmWebSocket = false;
         wsMock.mockReset();
         if (originalWebSocket === undefined) {
             delete (globalThis as any).WebSocket;
         } else {
             (globalThis as any).WebSocket = originalWebSocket;
+        }
+        if (originalWindow === undefined) {
+            delete (globalThis as any).window;
+        } else {
+            (globalThis as any).window = originalWindow;
         }
     });
 
@@ -90,6 +110,170 @@ describe("WebsocketMessageAdapter transport selection", (): void => {
         expect(wsMock.mock.calls[0][1]).toEqual(expect.objectContaining({ agent: expect.anything() }));
 
         nodeSocket.onclose({ wasClean: false, code: 1000, reason: "closed", target: nodeSocket });
+        await openPromise;
+    });
+
+    testIfNode("translates proxy settings and credentials into the proxy agent", async (): Promise<void> => {
+        const nodeSocket = createFakeSocket();
+        wsMock.mockImplementation(() => nodeSocket);
+
+        const adapter = new WebsocketMessageAdapter(
+            "wss://example.test/speech",
+            "connection-id",
+            formatter,
+            { HostName: "proxy.example", Port: 8080, UserName: "user", Password: "pass" } as any,
+            {},
+            false,
+        );
+
+        const openPromise = adapter.open();
+        const options = wsMock.mock.calls[0][1] as ws.ClientOptions;
+        const agent = options.agent as HttpsProxyAgent<string>;
+
+        expect(agent).toBeInstanceOf(HttpsProxyAgent);
+        expect(agent.proxy.protocol).toBe("http:");
+        expect(agent.proxy.hostname).toBe("proxy.example");
+        expect(agent.proxy.port).toBe("8080");
+        expect(agent.proxy.username).toBe("user");
+        expect(agent.proxy.password).toBe("pass");
+
+        nodeSocket.onclose({ wasClean: false, code: 1000, reason: "closed", target: nodeSocket });
+        await openPromise;
+    });
+
+    testIfNode("supports IPv6 proxy hosts", async (): Promise<void> => {
+        const nodeSocket = createFakeSocket();
+        wsMock.mockImplementation(() => nodeSocket);
+
+        const adapter = new WebsocketMessageAdapter(
+            "wss://example.test/speech",
+            "connection-id",
+            formatter,
+            { HostName: "::1", Port: 8080 } as any,
+            {},
+            false,
+        );
+
+        const openPromise = adapter.open();
+        const options = wsMock.mock.calls[0][1] as ws.ClientOptions;
+        const agent = options.agent as HttpsProxyAgent<string>;
+
+        expect(agent.proxy.hostname).toBe("[::1]");
+        expect(agent.proxy.port).toBe("8080");
+
+        nodeSocket.onclose({ wasClean: false, code: 1000, reason: "closed", target: nodeSocket });
+        await openPromise;
+    });
+
+    testIfNode("preserves percent sequences in proxy credentials", async (): Promise<void> => {
+        const nodeSocket = createFakeSocket();
+        wsMock.mockImplementation(() => nodeSocket);
+
+        const adapter = new WebsocketMessageAdapter(
+            "wss://example.test/speech",
+            "connection-id",
+            formatter,
+            { HostName: "proxy.example", Port: 8080, UserName: "user%41", Password: "pass%word" } as any,
+            {},
+            false,
+        );
+
+        const openPromise = adapter.open();
+        const options = wsMock.mock.calls[0][1] as ws.ClientOptions;
+        const agent = options.agent as HttpsProxyAgent<string>;
+
+        expect(decodeURIComponent(agent.proxy.username)).toBe("user%41");
+        expect(decodeURIComponent(agent.proxy.password)).toBe("pass%word");
+
+        nodeSocket.onclose({ wasClean: false, code: 1000, reason: "closed", target: nodeSocket });
+        await openPromise;
+    });
+
+    testIfNode("uses a direct TLS socket with OCSP options for wss without relying on secureEndpoint", async (): Promise<void> => {
+        const nodeSocket = createFakeSocket();
+        const tlsSocket = createFakeSocket();
+        const tlsConnectMock = tls.connect as unknown as jest.Mock;
+        tlsConnectMock.mockReturnValue(tlsSocket);
+        wsMock.mockImplementation(() => nodeSocket);
+        delete (globalThis as any).WebSocket;
+
+        const adapter = new WebsocketMessageAdapter(
+            "wss://example.test/speech",
+            "connection-id",
+            formatter,
+            undefined as any,
+            {},
+            false,
+        );
+
+        const openPromise = adapter.open();
+        const options = wsMock.mock.calls[0][1] as ws.ClientOptions;
+        const agent = options.agent as any;
+
+        expect(agent.createConnection({ host: "example.test", port: 443 })).toBe(tlsSocket);
+        expect(tlsConnectMock).toHaveBeenCalledWith(expect.objectContaining({
+            requestOCSP: true,
+            servername: "example.test",
+            secureEndpoint: true,
+        }));
+
+        nodeSocket.onclose({ wasClean: false, code: 1000, reason: "closed", target: nodeSocket });
+        await openPromise;
+    });
+
+    testIfNode("uses a direct TCP socket with OCSP options for ws without relying on secureEndpoint", async (): Promise<void> => {
+        const nodeSocket = createFakeSocket();
+        const netSocket = createFakeSocket();
+        const netConnectMock = net.connect as unknown as jest.Mock;
+        netConnectMock.mockReturnValue(netSocket);
+        wsMock.mockImplementation(() => nodeSocket);
+        delete (globalThis as any).WebSocket;
+
+        const adapter = new WebsocketMessageAdapter(
+            "ws://example.test/speech",
+            "connection-id",
+            formatter,
+            undefined as any,
+            {},
+            false,
+        );
+
+        const openPromise = adapter.open();
+        const options = wsMock.mock.calls[0][1] as ws.ClientOptions;
+        const agent = options.agent as any;
+
+        expect(agent.createConnection({ host: "example.test", port: 80 })).toBe(netSocket);
+        expect(netConnectMock).toHaveBeenCalledWith(expect.objectContaining({
+            requestOCSP: true,
+            servername: "example.test",
+            secureEndpoint: false,
+        }));
+
+        nodeSocket.onclose({ wasClean: false, code: 1000, reason: "closed", target: nodeSocket });
+        await openPromise;
+    });
+
+    testIfNode("uses the browser WebSocket path when a browser global is present even if proxy is configured", async (): Promise<void> => {
+        const browserSocket = createFakeSocket();
+        const browserWebSocketMock = jest.fn(() => browserSocket);
+        (globalThis as any).window = {};
+        (globalThis as any).WebSocket = browserWebSocketMock;
+
+        const adapter = new WebsocketMessageAdapter(
+            "wss://example.test/speech",
+            "connection-id",
+            formatter,
+            { HostName: "proxy.example", Port: 8080, UserName: "user", Password: "pass" } as any,
+            {},
+            false,
+        );
+
+        const openPromise = adapter.open();
+
+        expect(browserWebSocketMock).toHaveBeenCalledWith("wss://example.test/speech");
+        expect(wsMock).not.toHaveBeenCalled();
+
+        browserSocket.onclose({ wasClean: false, code: 1000, reason: "closed", target: browserSocket });
         await openPromise;
     });
 });


### PR DESCRIPTION
Upgrade the runtime `https-proxy-agent` dependency from v4 to v7 and remove the SDK's direct dependency on `agent-base`.

Refactor `WebsocketMessageAdapter` to use the v7 proxy-agent API while preserving direct and proxied WebSocket transport behavior.
